### PR TITLE
Create .git/hooks directory when it does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+-[PR](https://github.com/evilmartians/lefthook/pull/169) Create .git/hooks directory when it does not exist @DmitryTsepelev
+
 # 0.7.3 (2021-04-23)
 
 -[PR](https://github.com/evilmartians/lefthook/pull/168) Package versions for all architectures (x86_64, ARM64, x86) into Ruby gem and NPM package @Envek

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -73,9 +73,14 @@ func DeleteGitHooks(fs afero.Fs) {
 	hooksPath := filepath.Join(getRootPath(), ".git", "hooks")
 
 	hooks, err := afero.ReadDir(fs, hooksPath)
+	log.Println("hooksPath", hooksPath)
 	if (err != nil) {
-		log.Println(".git/hooks directory does not exist, creating")
-		os.Mkdir(hooksPath, os.ModePerm)
+		log.Println("⚠️ ", au.Bold(".git/hooks"), "directory does not exist, creating")
+
+		if err := os.MkdirAll(hooksPath, os.ModePerm); err != nil {
+			log.Println(au.Brown("🚨 Failed to create"), au.Bold(".git/hooks"), au.Brown("directory"))
+			log.Fatal(err)
+		}
 	}
 
 	for _, file := range hooks {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"log"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/afero"
@@ -70,7 +71,13 @@ func deleteSourceDirs(fs afero.Fs) {
 // DeleteGitHooks read the config and remove all git hooks except
 func DeleteGitHooks(fs afero.Fs) {
 	hooksPath := filepath.Join(getRootPath(), ".git", "hooks")
-	hooks, _ := afero.ReadDir(fs, hooksPath)
+
+	hooks, err := afero.ReadDir(fs, hooksPath)
+	if (err != nil) {
+		log.Println(".git/hooks directory does not exist, creating")
+		os.Mkdir(hooksPath, os.ModePerm)
+	}
+
 	for _, file := range hooks {
 		hookFile := filepath.Join(hooksPath, file.Name())
 		if isLefthookFile(hookFile) || aggressive {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -73,7 +73,6 @@ func DeleteGitHooks(fs afero.Fs) {
 	hooksPath := filepath.Join(getRootPath(), ".git", "hooks")
 
 	hooks, err := afero.ReadDir(fs, hooksPath)
-	log.Println("hooksPath", hooksPath)
 	if (err != nil) {
 		log.Println("⚠️ ", au.Bold(".git/hooks"), "directory does not exist, creating")
 


### PR DESCRIPTION
[Sometimes](https://github.com/evilmartians/lefthook/issues/158) `.git/hooks` directory does not exist and lefthook fails to init hooks. The solution is to create the directory when it does not exist.

Closes #158.