### PR TITLE
Remove MkdirAll from DeleteGitHooks

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -147,7 +147,7 @@ func presetConfig(fs afero.Fs) {
 	fs.Mkdir(filepath.Join(getRootPath(), ".lefthook/commit-msg"), defaultFilePermission)
 	fs.Mkdir(filepath.Join(getRootPath(), ".lefthook/pre-commit"), defaultFilePermission)
 
-	fs.Mkdir(getGitHooksDir(), defaultFilePermission)
+	fs.MkdirAll(filepath.Join(getRootPath(), ".git", "hooks"), defaultFilePermission)
 }
 
 func presetExecutable(hookName string, hookGroup string, exitCode string, fs afero.Fs) {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -75,8 +75,7 @@ func DeleteGitHooks(fs afero.Fs) {
 	hooks, err := afero.ReadDir(fs, hooksPath)
 	if (err != nil) {
 		log.Println("⚠️ ", au.Bold(".git/hooks"), "directory does not exist, creating")
-
-		if err := os.MkdirAll(hooksPath, os.ModePerm); err != nil {
+		if err := os.Mkdir(hooksPath, os.ModePerm); err != nil {
 			log.Println(au.Brown("🚨 Failed to create"), au.Bold(".git/hooks"), au.Brown("directory"))
 			log.Fatal(err)
 		}


### PR DESCRIPTION
We don't need MkdirAll anymore since we check that `.git` directory exists