### PR TITLE
Allow skipping hooks in certain git states: merge and/or rebase

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -135,6 +135,17 @@ func setRootPath() {
 	rootPath = strings.TrimSpace(string(outputBytes))
 }
 
+func getGitDir() string {
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+
+	outputBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.TrimSpace(string(outputBytes))
+}
+
 func getGitHooksPath() string {
 	return gitHooksPath
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,23 +127,30 @@ func getRootPath() string {
 	return rootPath
 }
 
+// Get absolute path to repository or worktree root
 func setRootPath() {
-	// get absolute path to .git dir (project root)
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 
 	outputBytes, _ := cmd.CombinedOutput()
 	rootPath = strings.TrimSpace(string(outputBytes))
 }
 
+// Get absolute path to .git directory (or current worktree subdirectory in it)
 func getGitDir() string {
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd := exec.Command("git", "rev-parse", "--git-dir") // that may be relative
 
 	outputBytes, err := cmd.CombinedOutput()
 	if err != nil {
 		panic(err)
 	}
 
-	return strings.TrimSpace(string(outputBytes))
+	path := strings.TrimSpace(string(outputBytes))
+
+	if filepath.IsAbs(path) {
+		return path
+	}
+
+	return filepath.Join(getRootPath(), path)
 }
 
 func getGitHooksPath() string {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -409,12 +409,15 @@ func isScriptExist(hooksGroup, executableName string) bool {
 
 func isSkipScript(hooksGroup, executableName string) bool {
 	key := strings.Join([]string{hooksGroup, scriptsConfigKey, executableName, skipConfigKey}, ".")
-	return viper.GetBool(key)
+	return isSkip(key)
 }
 
 func isSkipCommand(hooksGroup, executableName string) bool {
 	key := strings.Join([]string{hooksGroup, commandsConfigKey, executableName, skipConfigKey}, ".")
+	return isSkip(key)
+}
 
+func isSkip(key string) bool {
 	value := viper.Get(key)
 
 	switch typedValue := value.(type) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -458,7 +458,7 @@ func isSkippedGitState(state string) bool {
 }
 
 func isMergeInProgress() bool {
-	if _, err := os.Stat(filepath.Join(getRootPath(), ".git", "MERGE_HEAD")); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(getRootPath(), getGitDir(), "MERGE_HEAD")); os.IsNotExist(err) {
 		return false
 	}
 
@@ -466,8 +466,8 @@ func isMergeInProgress() bool {
 }
 
 func isRebaseInProgress() bool {
-	if _, mergeErr := os.Stat(filepath.Join(getRootPath(), ".git", "rebase-merge")); os.IsNotExist(mergeErr) {
-		if _, applyErr := os.Stat(filepath.Join(getRootPath(), ".git", "rebase-apply")); os.IsNotExist(applyErr) {
+	if _, mergeErr := os.Stat(filepath.Join(getRootPath(), getGitDir(), "rebase-merge")); os.IsNotExist(mergeErr) {
+		if _, applyErr := os.Stat(filepath.Join(getRootPath(), getGitDir(), "rebase-apply")); os.IsNotExist(applyErr) {
 			return false
 		}
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -458,7 +458,7 @@ func isSkippedGitState(state string) bool {
 }
 
 func isMergeInProgress() bool {
-	if _, err := os.Stat(filepath.Join(getRootPath(), getGitDir(), "MERGE_HEAD")); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(getGitDir(), "MERGE_HEAD")); os.IsNotExist(err) {
 		return false
 	}
 
@@ -466,8 +466,8 @@ func isMergeInProgress() bool {
 }
 
 func isRebaseInProgress() bool {
-	if _, mergeErr := os.Stat(filepath.Join(getRootPath(), getGitDir(), "rebase-merge")); os.IsNotExist(mergeErr) {
-		if _, applyErr := os.Stat(filepath.Join(getRootPath(), getGitDir(), "rebase-apply")); os.IsNotExist(applyErr) {
+	if _, mergeErr := os.Stat(filepath.Join(getGitDir(), "rebase-merge")); os.IsNotExist(mergeErr) {
+		if _, applyErr := os.Stat(filepath.Join(getGitDir(), "rebase-apply")); os.IsNotExist(applyErr) {
 			return false
 		}
 	}

--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -239,6 +239,26 @@ pre-push:
       skip: true
 ```
 
+## Skipping commands during rebase or merge
+
+You can skip commands during rebase and/or merge by the same `skip` option:
+
+```yml
+pre-push:
+  commands:
+    packages-audit:
+      skip: merge
+
+# or
+
+pre-push:
+  commands:
+    packages-audit:
+      skip:
+        - merge
+        - rebase
+```
+
 ## Skipping commands by tags
 
 If we have a lot of commands and scripts we can tag them and run skip commands with a specific tag.


### PR DESCRIPTION
`skip` now allows to skip a certain hook during merge or rebase, configuration example:

```
pre-commit:
  commands:
    commit-colors:
      run: commit-colors $(git rev-parse HEAD)
  skip:
    - merge
    - rebase
```

Things to do:

- [x] make it work on Windows
- [x] update docs

Things to discuss:

- should we refactor run and run_windows to avoid duplicating the code?
- ~is there a better name than `skip_git_states`?~ using old `skip` option
- is there a better way to determine that merge or rebase are happening?

Closes #115