### PR TITLE
`getGitHooksPath` helper function

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"io/ioutil"
 	"log"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -94,7 +93,7 @@ else
 fi
 `
 
-	pathToFile := filepath.Join(getGitHooksDir(), hookName)
+	pathToFile := filepath.Join(getGitHooksPath(), hookName)
 
 	if yes, _ := afero.Exists(fs, pathToFile); yes {
 		if isLefthookFile(pathToFile) {
@@ -148,18 +147,6 @@ func addProjectHookDir(hookName string, fs afero.Fs) {
 func addLocalHookDir(hookName string, fs afero.Fs) {
 	err := fs.MkdirAll(filepath.Join(getLocalSourceDir(), hookName), defaultFilePermission)
 	check(err)
-}
-
-func getGitHooksDir() string {
-	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
-
-	outputBytes, err := cmd.CombinedOutput()
-	if err != nil {
-		panic(err)
-	}
-
-	gitDir := strings.TrimSpace(string(outputBytes))
-	return filepath.Join(getRootPath(), gitDir, "hooks")
 }
 
 func isLefthookFile(pathFile string) bool {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -35,7 +35,7 @@ func TestInstallCmdExecutor(t *testing.T) {
 		"prepare-commit-msg",
 	}
 
-	files, err := afero.ReadDir(fs, getGitHooksDir())
+	files, err := afero.ReadDir(fs, getGitHooksPath())
 	assert.NoError(t, err)
 
 	actualFiles := []string{}
@@ -60,7 +60,7 @@ func TestAddCmdExecutor(t *testing.T) {
 		"pre-commit",
 	}
 
-	files, _ := afero.ReadDir(fs, getGitHooksDir())
+	files, _ := afero.ReadDir(fs, getGitHooksPath())
 	actualFiles := []string{}
 	for _, f := range files {
 		actualFiles = append(actualFiles, f.Name())
@@ -82,7 +82,7 @@ func TestAddCmdExecutor(t *testing.T) {
 		"pre-push.old",
 	}
 
-	files, _ = afero.ReadDir(fs, getGitHooksDir())
+	files, _ = afero.ReadDir(fs, getGitHooksPath())
 	actualFiles = []string{}
 	for _, f := range files {
 		actualFiles = append(actualFiles, f.Name())
@@ -147,7 +147,8 @@ func presetConfig(fs afero.Fs) {
 	fs.Mkdir(filepath.Join(getRootPath(), ".lefthook/commit-msg"), defaultFilePermission)
 	fs.Mkdir(filepath.Join(getRootPath(), ".lefthook/pre-commit"), defaultFilePermission)
 
-	fs.MkdirAll(filepath.Join(getRootPath(), ".git", "hooks"), defaultFilePermission)
+  setGitHooksPath(".git/hooks")
+	fs.MkdirAll(getGitHooksPath(), defaultFilePermission)
 }
 
 func presetExecutable(hookName string, hookGroup string, exitCode string, fs afero.Fs) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -147,7 +147,7 @@ func presetConfig(fs afero.Fs) {
 	fs.Mkdir(filepath.Join(getRootPath(), ".lefthook/commit-msg"), defaultFilePermission)
 	fs.Mkdir(filepath.Join(getRootPath(), ".lefthook/pre-commit"), defaultFilePermission)
 
-  setGitHooksPath(".git/hooks")
+	setGitHooksPath(".git/hooks")
 	fs.MkdirAll(getGitHooksPath(), defaultFilePermission)
 }
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -205,7 +205,7 @@ func configChecksum(fs afero.Fs) string {
 func recordedChecksum() string {
 	pattern := regexp.MustCompile(`(?:# lefthook_version: )(\w+)`)
 
-	file, err := ioutil.ReadFile(filepath.Join(getGitHooksDir(), checkSumHook))
+	file, err := ioutil.ReadFile(filepath.Join(getGitHooksPath(), checkSumHook))
 	if err != nil {
 		return ""
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/spf13/afero"
 	"github.com/mattn/go-isatty"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -28,12 +28,12 @@ const (
 )
 
 var (
-	Verbose      bool
-	NoColors     bool
-	rootPath     string
-	gitHooksPath string
-	cfgFile      string
-	originConfig *viper.Viper
+	Verbose              bool
+	NoColors             bool
+	rootPath             string
+	gitHooksPath         string
+	cfgFile              string
+	originConfig         *viper.Viper
 	configFileExtensions = []string{".yml", ".yaml"}
 
 	au aurora.Aurora
@@ -58,7 +58,7 @@ lefthook install`,
 		message := `This command must be executed within git repository.
 Change working directory or initialize new repository with 'git init'.`
 
-			log.Fatal(au.Brown(message))
+		log.Fatal(au.Brown(message))
 	},
 }
 
@@ -142,7 +142,7 @@ func getGitHooksPath() string {
 }
 
 func setGitHooksPath(path string) {
-  gitHooksPath = filepath.Join(getRootPath(), path)
+	gitHooksPath = filepath.Join(getRootPath(), path)
 }
 
 func getHooksPathFromGitConfig() string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ var (
 	Verbose      bool
 	NoColors     bool
 	rootPath     string
+	gitHooksPath string
 	cfgFile      string
 	originConfig *viper.Viper
 	configFileExtensions = []string{".yml", ".yaml"}
@@ -92,6 +93,7 @@ func initConfig() {
 	log.SetFlags(0)
 
 	setRootPath(rootExecutionRelPath)
+	setGitHooksPath(getHooksPathFromGitConfig())
 
 	// store original config before merge
 	originConfig = viper.New()
@@ -133,6 +135,25 @@ func setRootPath(path string) {
 
 	outputBytes, _ := cmd.CombinedOutput()
 	rootPath = strings.TrimSpace(string(outputBytes))
+}
+
+func getGitHooksPath() string {
+	return gitHooksPath
+}
+
+func setGitHooksPath(path string) {
+  gitHooksPath = filepath.Join(getRootPath(), path)
+}
+
+func getHooksPathFromGitConfig() string {
+	cmd := exec.Command("git", "rev-parse", "--git-path", "hooks")
+
+	outputBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.TrimSpace(string(outputBytes))
 }
 
 func getSourceDir() string {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -70,13 +70,13 @@ func deleteSourceDirs(fs afero.Fs) {
 
 // DeleteGitHooks read the config and remove all git hooks except
 func DeleteGitHooks(fs afero.Fs) {
-	hooksPath := filepath.Join(getRootPath(), ".git", "hooks")
+	hooksPath := getGitHooksPath()
 
 	hooks, err := afero.ReadDir(fs, hooksPath)
 	if (err != nil) {
-		log.Println("⚠️ ", au.Bold(".git/hooks"), "directory does not exist, creating")
+		log.Println("⚠️ ", au.Bold(hooksPath), "directory does not exist, creating")
 		if err := os.Mkdir(hooksPath, os.ModePerm); err != nil {
-			log.Println(au.Brown("🚨 Failed to create"), au.Bold(".git/hooks"), au.Brown("directory"))
+			log.Println(au.Brown("🚨 Failed to create"), au.Bold(hooksPath), au.Brown("directory"))
 			log.Fatal(err)
 		}
 	}
@@ -99,7 +99,7 @@ func revertOldGitHooks(fs afero.Fs) {
 		return
 	}
 
-	hooksPath := filepath.Join(getRootPath(), ".git", "hooks")
+	hooksPath := getGitHooksPath()
 	for _, file := range hookGroups {
 		hookFilePath := filepath.Join(hooksPath, file.Name()+".old")
 


### PR DESCRIPTION
Resolves #170

This PR adds `getGitHooksPath()` helper as a source of truth about where git hooks are stored

It uses `git rev-parse --git-path hooks` command under the hood (kudos to @stevelacy for the hint!), so it considers possible [overriding](https://git-scm.com/docs/githooks) default `.git/hooks` too 

This is my first PR to the repo, so please, let me know, if I can improve it in any way