### PR TITLE
fix: failing installation on Windows + MSYS

### DIFF
--- a/.npm/bin/lefthook
+++ b/.npm/bin/lefthook
@@ -14,7 +14,7 @@ case $OS in
     Darwin)
         GOOS=darwin
         ;;
-    Windows*|CYGWIN*)
+    Windows*|CYGWIN*|MSYS_NT*)
         GOOS=windows
         EXT=.exe
         ;;


### PR DESCRIPTION
Hi!

Since version 0.7.3, the installation on Windows + [Git Bash](https://gitforwindows.org/) for NodeJS projects fails.
Git Bash uses the bash MSYS and the `lefthook` script doesn't support it, failure output example:

```
# echo "${OS} ${ARCH}"
MSYS_NT-10.0-19043 x86_64

Unsupported OS: MSYS_NT-10.0-19043
```

This patch fixes this issue.
Thank you