### PR TITLE
Add .lefthookrc loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+- [PR](https://github.com/evilmartians/lefthook/pull/185) Add `.lefthookrc` to fix incorrect PATH @skryukov
+- [PR](https://github.com/evilmartians/lefthook/pull/182) Support git workspaces and submodules @skryukov
+
+
 # 0.7.4 (2021-04-30)
 
 - [PR](https://github.com/evilmartians/lefthook/pull/171) Improve check for installed git @DmitryTsepelev

--- a/cmd/templates/hook.tmpl
+++ b/cmd/templates/hook.tmpl
@@ -8,6 +8,10 @@ if [ -t 1 ] ; then
   exec < /dev/tty ; # <- enables interactive shell
 fi
 
+if [ -f ~/.lefthookrc ]; then
+  source ~/.lefthookrc
+fi
+
 dir="$(cd "$(dirname "$(dirname "$(dirname "$0")")")" >/dev/null 2>&1 || exit ; pwd -P)"
 
 call_lefthook()

--- a/spec/fixtures/pre-commit
+++ b/spec/fixtures/pre-commit
@@ -8,6 +8,10 @@ if [ -t 1 ] ; then
   exec < /dev/tty ; # <- enables interactive shell
 fi
 
+if [ -f ~/.lefthookrc ]; then
+  source ~/.lefthookrc
+fi
+
 dir="$(cd "$(dirname "$(dirname "$(dirname "$0")")")" >/dev/null 2>&1 || exit ; pwd -P)"
 
 call_lefthook()

--- a/spec/fixtures/pre-push
+++ b/spec/fixtures/pre-push
@@ -8,6 +8,10 @@ if [ -t 1 ] ; then
   exec < /dev/tty ; # <- enables interactive shell
 fi
 
+if [ -f ~/.lefthookrc ]; then
+  source ~/.lefthookrc
+fi
+
 dir="$(cd "$(dirname "$(dirname "$(dirname "$0")")")" >/dev/null 2>&1 || exit ; pwd -P)"
 
 call_lefthook()


### PR DESCRIPTION
Fixes #178 
Probably fixes also #99

The same workaround used in Husky https://typicode.github.io/husky/#/?id=command-not-found