### PR TITLE
Add ability to skip summary output. Also support a LEFT_QUIET env variable

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -475,6 +475,13 @@ func isSkipPrintOutput(outputDetailValue string) bool {
 		}
 	}
 
+	env := os.Getenv("LEFTHOOK_QUIET")
+	for _, elem := range strings.Split(env, ",") {
+		if strings.TrimSpace(elem) == outputDetailValue {
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -58,6 +58,7 @@ const (
 	parallelConfigKey    string      = "parallel"
 	skipOutputConfigKey  string      = "skip_output"
 	outputMeta           string      = "meta"
+	outputSummary        string      = "summary"
 	outputSuccess        string      = "success"
 	subFiles             string      = "{files}"
 	subAllFiles          string      = "{all_files}"
@@ -418,6 +419,10 @@ func printMeta(hooksGroup string) {
 }
 
 func printSummary(execTime time.Duration) {
+	if isSkipPrintOutput(outputSummary) {
+		return
+	}
+
 	if len(okList) == 0 && len(failList) == 0 {
 		log.Println(au.Cyan("\nSUMMARY:"), au.Brown("(SKIP EMPTY)"))
 	} else {

--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -281,7 +281,7 @@ If you need to extend config from some another place, just add top level:
 ```yml
 # lefthook.yml
 
-extends: 
+extends:
   - $HOME/work/lefthook-extend.yml
   - $HOME/work/lefthook-extend-2.yml
 ```
@@ -469,6 +469,22 @@ source_dir: ".lefthook"
 source_dir_local: ".lefthook-local"
 ```
 
+## Manage verbosity
+
+You can manage the verbosity using the `skip_output` config.
+
+Possible values are `meta,success,failure,summary`.
+
+This config quiets all outputs except failures:
+
+```yml
+# lefthook.yml
+
+skip_output:
+  - meta
+  - success
+  - summary
+```
 ## CI integration
 
 Enable `CI` env variable if it doens't exists on your service by default.

--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -485,6 +485,12 @@ skip_output:
   - success
   - summary
 ```
+
+You can also do this with an environment variable:
+```bash
+export LEFTHOOK_QUIET="meta,success,summary"
+```
+
 ## CI integration
 
 Enable `CI` env variable if it doens't exists on your service by default.


### PR DESCRIPTION
Decided to tackle some further issues raised [here](https://github.com/evilmartians/lefthook/issues/78#issuecomment-658333189). There was mention of using a global environment variable so you didn't need to rely on the yaml having it configured. This is personal preference after all.

*My* personal preference is I like it very quiet. So I made it so you could get rid of the summary line as well.