### PR TITLE
Include archived binaries in the releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,16 @@ archives:
       linux: Linux
       386: i386
       amd64: x86_64
+  - id: lefthook-gz
+    format: gz
+    files:
+    - none*
+    replacements:
+      windows: Windows
+      darwin: MacOS
+      linux: Linux
+      386: i386
+      amd64: x86_64
 checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
 snapshot:


### PR DESCRIPTION
This brings back the archived binaries. This makes downloading the binaries faster in #188. This also means that we can fulfill the needs of all parties (those who requested raw binaries in the release and us who are writing an automated code to download the binaries for the npm package).

To test this:
```
goreleaser --snapshot --skip-publish --rm-dist
```