### PR TITLE
Fix finding lefthook binary under node_modules

### DIFF
--- a/cmd/templates/hook.tmpl
+++ b/cmd/templates/hook.tmpl
@@ -15,9 +15,9 @@ call_lefthook()
   if lefthook -h >/dev/null 2>&1
   then
     eval $1
-  elif test -f "$dir/node_modules/@arkweid/lefthook/bin/lefthook"
+  elif test -f "$dir/node_modules/.bin/lefthook"
   then
-    eval $dir/node_modules/@arkweid/lefthook/bin/$1
+    eval $dir/node_modules/.bin/$1
   elif bundle exec lefthook -h >/dev/null 2>&1
   then
     bundle exec $1


### PR DESCRIPTION
In #184, the lefthook sh file was removed, but the Node package managers create one automatically under  `node_modules/.bin`. This fixes finding binaries under node_modules no matter what package manager is used.

It also fixes finding binaries for the cases where `$dir` has spaces in it (allowed on Windows)