### PR TITLE
Fix path for searching npm-installed binary when in worktree

### DIFF
--- a/cmd/templates/hook.tmpl
+++ b/cmd/templates/hook.tmpl
@@ -8,7 +8,7 @@ if [ -t 1 ] ; then
   exec < /dev/tty ; # <- enables interactive shell
 fi
 
-dir="$(cd "$(dirname "$(dirname "$(dirname "$0")")")" >/dev/null 2>&1 || exit ; pwd -P)"
+dir="$(git rev-parse --show-toplevel)"
 
 call_lefthook()
 {

--- a/spec/fixtures/pre-commit
+++ b/spec/fixtures/pre-commit
@@ -8,7 +8,7 @@ if [ -t 1 ] ; then
   exec < /dev/tty ; # <- enables interactive shell
 fi
 
-dir="$(cd "$(dirname "$(dirname "$(dirname "$0")")")" >/dev/null 2>&1 || exit ; pwd -P)"
+dir="$(git rev-parse --show-toplevel)"
 
 call_lefthook()
 {

--- a/spec/fixtures/pre-push
+++ b/spec/fixtures/pre-push
@@ -8,7 +8,7 @@ if [ -t 1 ] ; then
   exec < /dev/tty ; # <- enables interactive shell
 fi
 
-dir="$(cd "$(dirname "$(dirname "$(dirname "$0")")")" >/dev/null 2>&1 || exit ; pwd -P)"
+dir="$(git rev-parse --show-toplevel)"
 
 call_lefthook()
 {


### PR DESCRIPTION
Fixes https://github.com/evilmartians/lefthook/issues/192

The problem arises when:
 1. using worktrees
 2. lefthook is installed via NPM and isn't available in $PATH
 3. lefthook version in main worktree's `package.json` is different from version in the current worktree

Then previously used code always return path to main worktree and founds old Lefthook binary there.

Current code will return path to the root of currently used worktree.

In most cases plain `pwd -P` would be enough but [docs for git hooks](https://git-scm.com/docs/githooks) states that:
> Before Git invokes a hook, it changes its working directory to either $GIT_DIR in a bare repository or the root of the working tree in a non-bare repository. An exception are hooks triggered during a push (pre-receive, update, post-receive, post-update, push-to-checkout) which are always executed in $GIT_DIR.

While Lefthook is always used in non-bare repositories, there is still chance that someone would like to use mentioned hooks that triggered during push, so use `git rev-parse --show-toplevel` helper command instead. Just in case.

Relevant docs:
 - [`git rev-parse --show-toplevel`](https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---show-toplevel)
 - [git hooks](https://git-scm.com/docs/githooks)