### PR TITLE
Add commitlint example in full_guide

### DIFF
--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -224,7 +224,7 @@ When you try to commit `git commit -m "haha bad commit text"` script `template_c
 
 ## Bash script example with Commitlint
 
-Let's create a bash script to check commit templates `.lefthook/commit-msg/commitlint.sh`:
+Let's create a bash script to check conventional commit status `.lefthook/commit-msg/commitlint.sh`:
 
 ```bash
 INPUT_FILE=$1

--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -222,6 +222,34 @@ commit-msg:
 
 When you try to commit `git commit -m "haha bad commit text"` script `template_checker` will be executed. Since commit text doesn't match the described pattern the commit process will be interrupted.
 
+## Bash script example with Commitlint
+
+Let's create a bash script to check commit templates `.lefthook/commit-msg/commitlint.sh`:
+
+```bash
+INPUT_FILE=$1
+START_LINE=`head -n1 $INPUT_FILE`
+ERROR=`echo $START_LINE | npx commitlint --color`
+if ! [[ $? == 0 ]]; then
+  echo "${ERROR}"
+  exit 1
+fi
+```
+
+Now we can ask lefthook to run our bash script by adding this code to
+`lefthook.yml` file:
+
+```yml
+# lefthook.yml
+
+commit-msg:
+  scripts:
+    "commitlint.sh":
+      runner: bash
+```
+
+When you try to commit `git commit -m "haha bad commit text"` script `commitlint.sh` will be executed. Since commit text doesn't match the default config or custom config that you setup for `commitlint`, the process will be interrupted.
+
 ## Local config
 
 We can use `lefthook-local.yml` as local config. Options in this file will overwrite options in `lefthook.yml`. (Don't forget to add this file to `.gitignore`)

--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -227,13 +227,7 @@ When you try to commit `git commit -m "haha bad commit text"` script `template_c
 Let's create a bash script to check conventional commit status `.lefthook/commit-msg/commitlint.sh`:
 
 ```bash
-INPUT_FILE=$1
-START_LINE=`head -n1 $INPUT_FILE`
-ERROR=`echo $START_LINE | npx commitlint --color`
-if ! [[ $? == 0 ]]; then
-  echo "${ERROR}"
-  exit 1
-fi
+echo $(head -n1 $1) | npx commitlint --color
 ```
 
 Now we can ask lefthook to run our bash script by adding this code to


### PR DESCRIPTION
- Relates to this issue: https://github.com/evilmartians/lefthook/issues/122 The solution provided here doesn't stop the process of committing.
- Also mentioned here https://github.com/evilmartians/lefthook/issues/110 but I find that is not the right solution as it doesn't use commitlint.