### PR TITLE
do not init git config on help and version cmds

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,8 @@ const (
 	configExtensionPattern  string      = ".*"
 	defaultFilePermission   os.FileMode = 0755
 	defaultDirPermission    os.FileMode = 0666
+	gitInitMessage          string      = `This command must be executed within git repository.
+Change working directory or initialize new repository with 'git init'.`
 )
 
 var (
@@ -49,14 +51,13 @@ lefthook install`,
 			return
 		}
 
+		initGitConfig()
+
 		if gitInitialized, _ := afero.Exists(appFs, filepath.Join(getRootPath(), ".git")); gitInitialized {
 			return
 		}
 
-		message := `This command must be executed within git repository.
-Change working directory or initialize new repository with 'git init'.`
-
-		log.Fatal(au.Brown(message))
+		log.Fatal(au.Brown(gitInitMessage))
 	},
 }
 
@@ -90,9 +91,6 @@ func initAurora() {
 func initConfig() {
 	log.SetFlags(0)
 
-	setRootPath()
-	setGitHooksPath(getHooksPathFromGitConfig())
-
 	// store original config before merge
 	originConfig = viper.New()
 	originConfig.SetConfigName(configFileName)
@@ -123,6 +121,11 @@ func initConfig() {
 	viper.AutomaticEnv()
 }
 
+func initGitConfig() {
+	setRootPath()
+	setGitHooksPath(getHooksPathFromGitConfig())
+}
+
 func getRootPath() string {
 	return rootPath
 }
@@ -131,7 +134,12 @@ func getRootPath() string {
 func setRootPath() {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 
-	outputBytes, _ := cmd.CombinedOutput()
+	outputBytes, err := cmd.CombinedOutput()
+
+	if err != nil {
+		log.Fatal(au.Brown(gitInitMessage))
+	}
+
 	rootPath = strings.TrimSpace(string(outputBytes))
 }
 


### PR DESCRIPTION
This PR resolves https://github.com/evilmartians/lefthook/issues/206 and https://github.com/evilmartians/lefthook/issues/90.

The root cause is that `git` commands were being run for all subcommands, instead of just the ones that needed them. This PR changes when the git config is resolved so that the problematic commands are not run for `version` and `help`.

Additionally, it slightly improves the error message when you invoke a subcommand that does need to be run from within a git repo. Previously, it would produce a cryptic `exit status 128` response.