### PR TITLE
node: fix docs to actually refer to the correct package

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -33,7 +33,7 @@ pre-commit:
 
 ## Test it
 ```bash
-npx lefthook install && npx lefthook run pre-commit
+npx @arkweid/lefthook install && npx @arkweid/lefthook run pre-commit
 ```
 
 ### More info


### PR DESCRIPTION
It turns out that the lefthook package is actually a fake, and shouldn't be run, instead you'd want this change.