### PR TITLE
disable the spinner for non-tty output; add option to explicitly disa…

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ Change working directory or initialize new repository with 'git init'.`
 var (
 	Verbose              bool
 	NoColors             bool
+	NoSpinner            bool
 	rootPath             string
 	gitHooksPath         string
 	originConfig         *viper.Viper
@@ -76,6 +77,7 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&NoColors, "no-colors", false, "disable colored output")
+	rootCmd.PersistentFlags().BoolVar(&NoSpinner, "no-spinner", false, "disable spinner")
 
 	initAurora()
 	cobra.OnInitialize(initConfig)
@@ -218,6 +220,19 @@ func EnableColors() bool {
 		return isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 	}
 	return viper.GetBool(colorsConfigKey)
+}
+
+// EnableSpinner shows if the spinner supported for current output or not.
+// If `spinner` explicitly specified in config, will return this value.
+// Otherwise enabled for TTY and disabled for non-terminal output.
+func EnableSpinner() bool {
+	if NoSpinner {
+		return false
+	}
+	if !viper.IsSet(spinnerConfigKey) {
+		return isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+	}
+	return viper.GetBool(spinnerConfigKey)
 }
 
 // VerbosePrint print text if Verbose flag persist

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -115,7 +115,6 @@ func RunCmdExecutor(args []string, fs afero.Fs) error {
 		return errors.New("Piped and Parallel options in conflict")
 	}
 
-
 	spinner = NewSpinner(EnableSpinner())
 	spinner.Start()
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -46,6 +46,7 @@ const (
 	skipEmptyConfigKey   string      = "skip_empty"
 	filesConfigKey       string      = "files"
 	colorsConfigKey      string      = "colors"
+	spinnerConfigKey     string      = "spinner"
 	parallelConfigKey    string      = "parallel"
 	skipOutputConfigKey  string      = "skip_output"
 	outputMeta           string      = "meta"
@@ -114,7 +115,8 @@ func RunCmdExecutor(args []string, fs afero.Fs) error {
 		return errors.New("Piped and Parallel options in conflict")
 	}
 
-	spinner = NewSpinner()
+
+	spinner = NewSpinner(EnableSpinner())
 	spinner.Start()
 
 	sourcePath := filepath.Join(getSourceDir(), hooksGroup)

--- a/cmd/spinner.go
+++ b/cmd/spinner.go
@@ -14,29 +14,46 @@ const (
 
 type Spinner struct {
 	extSpinner *spin.Spinner
+	animate bool
 }
 
-func NewSpinner() *Spinner {
-	return &Spinner{spin.New(spin.CharSets[spinnerCharSet], spinnerRefreshRate)}
+func NewSpinner(animate bool) *Spinner {
+	return &Spinner{
+		spin.New(spin.CharSets[spinnerCharSet], spinnerRefreshRate),
+		animate,
+	}
 }
 
 func (s *Spinner) Start() {
-	s.extSpinner.Suffix = " waiting"
-	s.extSpinner.Start()
+	if s.animate {
+		s.extSpinner.Suffix = " waiting"
+		s.extSpinner.Start()
+	} else {
+		log.Println("waiting")
+	}
 }
 
 func (s *Spinner) Stop() {
-	s.extSpinner.Stop()
+	if s.animate {
+		s.extSpinner.Stop()
+	}
 }
 
 func (s *Spinner) RestartWithMsg(msgs ...interface{}) {
-	s.extSpinner.Stop()
+	hasMsg := !(len(msgs) == 1 && msgs[0] == "")
 
-	if len(msgs) == 1 && msgs[0] == "" {
+	if !s.animate {
+		if hasMsg {
+			log.Println(msgs...)
+		}
+		log.Println("waiting")
+	} else {
+		s.extSpinner.Stop()
+
+		if hasMsg {
+			log.Println(msgs...)
+		}
+
 		s.extSpinner.Start()
-		return
 	}
-
-	log.Println(msgs...)
-	s.extSpinner.Start()
 }

--- a/cmd/spinner.go
+++ b/cmd/spinner.go
@@ -14,7 +14,7 @@ const (
 
 type Spinner struct {
 	extSpinner *spin.Spinner
-	animate bool
+	animate    bool
 }
 
 func NewSpinner(animate bool) *Spinner {

--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -563,6 +563,17 @@ By config `lefthook.yml`, just add the option:
 colors: false
 ```
 
+## Disable spinner
+
+By agrs:
+```bash
+lefthook --no-spinner run pre-commit
+```
+By config `lefthook.yml`, just add the option:
+```yml
+spinner: false
+```
+
 ## Version
 
 ```bash


### PR DESCRIPTION
A possible resolution to https://github.com/evilmartians/lefthook/issues/219

1. The spinner is now disabled by default for non-tty output
2. The spinner can be disabled with the `--no-spinner` flag
3. The spinner can be configured with `spinner` in `lefthook.yml`

Not the prettiest impl, but it should work.