### PR TITLE
Fix: Install hooks based on root path on install

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -80,7 +80,7 @@ func AddConfigYaml(fs afero.Fs) {
 func AddGitHooks(fs afero.Fs) {
 	// add directory hooks
 	var dirsHooks []string
-	dirEntities, err := afero.ReadDir(fs, getSourceDir())
+	dirEntities, err := afero.ReadDir(fs, getRootPath())
 	if err == nil {
 		for _, f := range dirEntities {
 			if f.IsDir() && contains(availableHooks[:], f.Name()) {


### PR DESCRIPTION
the config file on install is set to be on the root folder not in the source folder where package.json is

so on install even though there is a valid lefthook.yml in the root folder the inconsistency on a project where the package.json is in a subfolder does not work.

I was not able to test this out but im pretty sure this is the solution.