### PR TITLE
Cleanup hook template

### DIFF
--- a/cmd/templates/hook.tmpl
+++ b/cmd/templates/hook.tmpl
@@ -15,9 +15,6 @@ call_lefthook()
   if lefthook{{.Extension}} -h >/dev/null 2>&1
   then
     eval lefthook{{.Extension}} $@
-  elif test -f "$dir/node_modules/@arkweid/lefthook/bin/lefthook{{.Extension}}"
-  then
-    eval "$dir/node_modules/@arkweid/lefthook/bin/lefthook{{.Extension}} $@"
   elif bundle exec lefthook -h >/dev/null 2>&1
   then
     bundle exec lefthook $@


### PR DESCRIPTION
This was for #232 

But as @aminya point out `npx` already replaced `node_modules/@arkweid/lefthook/bin/lefthook`

There is code left which is useless at the point and can be cleanup

So this PR is updated to clean that code up

