### PR TITLE
Fix unreachable conditional in hook template

### DIFF
--- a/cmd/templates/hook.tmpl
+++ b/cmd/templates/hook.tmpl
@@ -21,12 +21,12 @@ call_lefthook()
   elif bundle exec lefthook -h >/dev/null 2>&1
   then
     bundle exec lefthook $@
-  elif npx @arkweid/lefthook -h >/dev/null 2>&1
-  then
-    npx @arkweid/lefthook $@
   elif yarn lefthook -h >/dev/null 2>&1
   then
     yarn lefthook $@
+  elif npx @arkweid/lefthook -h >/dev/null 2>&1
+  then
+    npx @arkweid/lefthook $@
   else
     echo "Can't find lefthook in PATH"
   fi


### PR DESCRIPTION
Resolves https://github.com/evilmartians/lefthook/issues/241

For devs who are using yarn as their package manager, the git hook
templates are conditioned so that it will never attempt to run `yarn
lefthook` from the local package it is installed in. Instead, the
conditional will always end with `npx @arkweid/lefthook` which ends up
fetching the package via network.

In the worst case, the dev will fetch this package twice, once in the
`elif` conditional and again within the `then` block, causing a
significiant delay before the lefthook binary is executed. This degrades
performance to an almost unusable state.

To fix, give `yarn` a chance to find the lefthook binary within its
local cache before moving on to `npx`.