### PR TITLE
fix(hook.tmpl): adds cpu arch and os arch to `lefthook`'s filepath

### DIFF
--- a/cmd/templates/hook.tmpl
+++ b/cmd/templates/hook.tmpl
@@ -10,7 +10,7 @@ fi
 
 dir="$(git rev-parse --show-toplevel)"
 osArch=$(echo "$(uname)" | tr '[:upper:]' '[:lower:]')
-cpuArch=$(echo "$(uname -m)" | sed 's/aarch/amd/')
+cpuArch=$(echo "$(uname -m)" | sed 's/aarch64/arm64/')
 
 call_lefthook()
 {

--- a/cmd/templates/hook.tmpl
+++ b/cmd/templates/hook.tmpl
@@ -9,15 +9,17 @@ if [ -t 1 ] ; then
 fi
 
 dir="$(git rev-parse --show-toplevel)"
+osArch=$(echo "$(uname)" | tr '[:upper:]' '[:lower:]')
+cpuArch=$(echo "$(uname -m)" | sed 's/aarch/amd/')
 
 call_lefthook()
 {
   if lefthook{{.Extension}} -h >/dev/null 2>&1
   then
     eval lefthook{{.Extension}} $@
-  elif test -f "$dir/node_modules/@arkweid/lefthook/bin/lefthook{{.Extension}}"
+  elif test -f "$dir/node_modules/@arkweid/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
   then
-    eval "$dir/node_modules/@arkweid/lefthook/bin/lefthook{{.Extension}} $@"
+    eval "$dir/node_modules/@arkweid/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}} $@"
   elif bundle exec lefthook -h >/dev/null 2>&1
   then
     bundle exec lefthook $@


### PR DESCRIPTION
Issue: When installing lefthook via yarn (`yarn add --dev @arkweid/lefthook`) we get the following tree in node_modules:
```
@arkweid
└── lefthook
    ├── README.md
    ├── bin
    │   ├── index.js
    │   ├── lefthook_darwin_amd64
    │   │   └── lefthook
    │   ├── lefthook_darwin_arm64
    │   │   └── lefthook
    │   ├── lefthook_linux_386
    │   │   └── lefthook
    │   ├── lefthook_linux_amd64
    │   │   └── lefthook
    │   ├── lefthook_linux_arm64
    │   │   └── lefthook
    │   ├── lefthook_windows_386
    │   │   └── lefthook.exe
    │   └── lefthook_windows_amd64
    │       └── lefthook.exe
    ├── get-exe.js
    ├── package.json
    └── postinstall.js
```

However the hooks expect the path: `"$dir/node_modules/@arkweid/lefthook/bin/lefthook"`, falling back to npx when not available 😄 

This commit fixes the path.