### PR TITLE
Replace deprecated `File.exists?` with `exist?` for Ruby script

### DIFF
--- a/.rubygems/bin/lefthook
+++ b/.rubygems/bin/lefthook
@@ -26,7 +26,7 @@ binary = "#{binary}.exe" if os == "windows"
 args = $*.map { |x| x.include?(' ') ? "'" + x + "'" : x }
 cmd = File.expand_path "#{File.dirname(__FILE__)}/../libexec/#{binary}"
 
-unless File.exists?(cmd)
+unless File.exist?(cmd)
   raise "Invalid platform. Lefthook wasn't build for #{RUBY_PLATFORM}"
 end
 


### PR DESCRIPTION
This PR replaces `File.exists?` with `exist?` in the Ruby wrapper.


`File.exists?` has been deprecated for many years. And it will be removed since the next release of Ruby (Ruby 3.2).


It displays a warning on Ruby 3.1 with `-w` option.


```bash
$ env RUBYOPT=-w lefthook install
/Users/kuwabara.masataka/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/lefthook-0.7.7/bin/lefthook:30: warning: File.exists? is deprecated; use File.exist? instead
Added config:  /path/to/lefthook.yml
```

It fails on Ruby 3.2-dev.

```bash
$ lefthook install
/Users/kuwabara.masataka/.rbenv/versions/trunk/lib/ruby/gems/3.2.0+0/gems/lefthook-0.7.7/bin/lefthook:30:in `<top (required)>': undefined method `exists?' for File:Class (NoMethodError)

unless File.exists?(cmd)
           ^^^^^^^^
Did you mean?  exist?
	from /Users/kuwabara.masataka/.rbenv/versions/trunk/bin/lefthook:25:in `load'
	from /Users/kuwabara.masataka/.rbenv/versions/trunk/bin/lefthook:25:in `<main>'
```