### PR TITLE
Store lefthook checksum in non-hook file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+COMMIT_HASH = $(shell git rev-parse HEAD)
+
 build:
-	go build -o lefthook
+	go build -ldflags "-X github.com/evilmartians/lefthook/internal/version.commit=$(COMMIT_HASH)" -o lefthook
 
 test:
 	go test -cpu 24 -race -count=1 -timeout=30s ./...

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,13 +9,20 @@ import (
 )
 
 func newVersionCmd(opts *lefthook.Options) *cobra.Command {
+	var verbose bool
+
 	versionCmd := cobra.Command{
 		Use:   "version",
 		Short: "Show lefthook version",
 		Run: func(cmd *cobra.Command, args []string) {
-			log.Println(version.Version)
+			log.Println(version.Version(verbose))
 		},
 	}
+
+	versionCmd.Flags().BoolVarP(
+		&verbose, "full", "f", false,
+		"full version with commit hash",
+	)
 
 	return &versionCmd
 }

--- a/internal/config/available_hooks.go
+++ b/internal/config/available_hooks.go
@@ -3,6 +3,9 @@ package config
 // ChecksumFileName - the file, which is used just to store the current config checksum version.
 const ChecksumFileName = "lefthook.checksum"
 
+// GhostHookName - the hook which logs are not shown and which is used for synchronizing hooks.
+const GhostHookName = "prepare-commit-msg"
+
 // AvailableHooks - list of hooks taken from https://git-scm.com/docs/githooks.
 var AvailableHooks = [...]string{
 	"pre-applypatch",

--- a/internal/config/available_hooks.go
+++ b/internal/config/available_hooks.go
@@ -1,7 +1,7 @@
 package config
 
-// ChecksumHookName - git hook, which is used just to store the current config checksum version.
-const ChecksumHookName = "prepare-commit-msg"
+// ChecksumFileName - the file, which is used just to store the current config checksum version.
+const ChecksumFileName = "lefthook.checksum"
 
 // AvailableHooks - list of hooks taken from https://git-scm.com/docs/githooks.
 var AvailableHooks = [...]string{

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -13,6 +13,7 @@ import (
 const (
 	cmdRootPath    = "git rev-parse --show-toplevel"
 	cmdHooksPath   = "git rev-parse --git-path hooks"
+	cmdInfoPath    = "git rev-parse --git-path info"
 	cmdGitPath     = "git rev-parse --git-dir"
 	cmdStagedFiles = "git diff --name-only --cached"
 	cmdAllFiles    = "git ls-files --cached"
@@ -25,6 +26,7 @@ type Repository struct {
 	HooksPath string
 	RootPath  string
 	GitPath   string
+	InfoPath  string
 }
 
 // NewRepository returns a Repository or an error, if git repository it not initialized.
@@ -42,6 +44,11 @@ func NewRepository(fs afero.Fs) (*Repository, error) {
 		hooksPath = filepath.Join(rootPath, hooksPath)
 	}
 
+	infoSubpath, err := execGit(cmdInfoPath)
+	if err != nil {
+		return nil, err
+	}
+
 	gitPath, err := execGit(cmdGitPath)
 	if err != nil {
 		return nil, err
@@ -55,6 +62,7 @@ func NewRepository(fs afero.Fs) (*Repository, error) {
 		HooksPath: hooksPath,
 		RootPath:  rootPath,
 		GitPath:   gitPath,
+		InfoPath:  filepath.Join(rootPath, infoSubpath),
 	}, nil
 }
 

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -44,9 +44,12 @@ func NewRepository(fs afero.Fs) (*Repository, error) {
 		hooksPath = filepath.Join(rootPath, hooksPath)
 	}
 
-	infoSubpath, err := execGit(cmdInfoPath)
+	infoPath, err := execGit(cmdInfoPath)
 	if err != nil {
 		return nil, err
+	}
+	if exists, _ := afero.DirExists(fs, filepath.Join(rootPath, infoPath)); exists {
+		infoPath = filepath.Join(rootPath, infoPath)
 	}
 
 	gitPath, err := execGit(cmdGitPath)
@@ -62,7 +65,7 @@ func NewRepository(fs afero.Fs) (*Repository, error) {
 		HooksPath: hooksPath,
 		RootPath:  rootPath,
 		GitPath:   gitPath,
-		InfoPath:  filepath.Join(rootPath, infoSubpath),
+		InfoPath:  infoPath,
 	}, nil
 }
 

--- a/internal/lefthook/add.go
+++ b/internal/lefthook/add.go
@@ -35,7 +35,7 @@ func (l *Lefthook) Add(args *AddArgs) error {
 		return err
 	}
 
-	err = l.addHook(args.Hook, "")
+	err = l.addHook(args.Hook)
 	if err != nil {
 		return err
 	}

--- a/internal/lefthook/install.go
+++ b/internal/lefthook/install.go
@@ -115,13 +115,12 @@ func (l *Lefthook) createHooksIfNeeded(cfg *config.Config, force bool) error {
 			return err
 		}
 
-		err = l.addHook(hook, checksum)
+		err = l.addHook(hook)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Add an informational hook to use for checksum comparation.
 	err = l.addChecksumFile(checksum)
 	if err != nil {
 		return err

--- a/internal/lefthook/install.go
+++ b/internal/lefthook/install.go
@@ -110,19 +110,20 @@ func (l *Lefthook) createHooksIfNeeded(cfg *config.Config, force bool) error {
 	for hook := range cfg.Hooks {
 		hookNames = append(hookNames, hook)
 
-		err = l.cleanHook(hook, force)
-		if err != nil {
+		if err = l.cleanHook(hook, force); err != nil {
 			return err
 		}
 
-		err = l.addHook(hook)
-		if err != nil {
+		if err = l.addHook(hook); err != nil {
 			return err
 		}
 	}
 
-	err = l.addChecksumFile(checksum)
-	if err != nil {
+	if err = l.addHook(config.GhostHookName); err != nil {
+		return nil
+	}
+
+	if err = l.addChecksumFile(checksum); err != nil {
 		return err
 	}
 

--- a/internal/lefthook/install_test.go
+++ b/internal/lefthook/install_test.go
@@ -62,6 +62,7 @@ post-commit:
 				configPath,
 				hookPath("pre-commit"),
 				hookPath("post-commit"),
+				hookPath(config.GhostHookName),
 				infoPath(config.ChecksumFileName),
 			},
 		},
@@ -86,6 +87,7 @@ post-commit:
 				hookPath("pre-commit"),
 				hookPath("pre-commit.old"),
 				hookPath("post-commit"),
+				hookPath(config.GhostHookName),
 				infoPath(config.ChecksumFileName),
 			},
 		},
@@ -109,6 +111,7 @@ post-commit:
 				configPath,
 				hookPath("pre-commit"),
 				hookPath("post-commit"),
+				hookPath(config.GhostHookName),
 				infoPath(config.ChecksumFileName),
 			},
 			wantNotExist: []string{
@@ -136,6 +139,7 @@ post-commit:
 			wantNotExist: []string{
 				hookPath("pre-commit"),
 				hookPath("post-commit"),
+				hookPath(config.GhostHookName),
 			},
 		},
 		{
@@ -157,6 +161,7 @@ post-commit:
 				configPath,
 				hookPath("pre-commit"),
 				hookPath("post-commit"),
+				hookPath(config.GhostHookName),
 				infoPath(config.ChecksumFileName),
 			},
 		},
@@ -182,6 +187,7 @@ post-commit:
 			wantNotExist: []string{
 				hookPath("pre-commit"),
 				hookPath("post-commit"),
+				hookPath(config.GhostHookName),
 			},
 		},
 		{
@@ -203,6 +209,7 @@ post-commit:
 				configPath,
 				hookPath("pre-commit"),
 				hookPath("post-commit"),
+				hookPath(config.GhostHookName),
 				infoPath(config.ChecksumFileName),
 			},
 		},

--- a/internal/lefthook/lefthook.go
+++ b/internal/lefthook/lefthook.go
@@ -115,12 +115,7 @@ func (l *Lefthook) cleanHook(hook string, force bool) error {
 // Creates a hook file using hook template.
 func (l *Lefthook) addHook(hook, configChecksum string) error {
 	hookPath := filepath.Join(l.repo.HooksPath, hook)
-	err := afero.WriteFile(
+	return afero.WriteFile(
 		l.Fs, hookPath, templates.Hook(hook, configChecksum), hookFileMode,
 	)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/internal/lefthook/lefthook.go
+++ b/internal/lefthook/lefthook.go
@@ -113,9 +113,9 @@ func (l *Lefthook) cleanHook(hook string, force bool) error {
 }
 
 // Creates a hook file using hook template.
-func (l *Lefthook) addHook(hook, configChecksum string) error {
+func (l *Lefthook) addHook(hook string) error {
 	hookPath := filepath.Join(l.repo.HooksPath, hook)
 	return afero.WriteFile(
-		l.Fs, hookPath, templates.Hook(hook, configChecksum), hookFileMode,
+		l.Fs, hookPath, templates.Hook(hook), hookFileMode,
 	)
 }

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -44,6 +44,10 @@ func (l *Lefthook) Run(hookName string, gitArgs []string) error {
 		return nil
 	}
 
+	if hookName == config.GhostHookName {
+		log.SetLevel(log.WarnLevel)
+	}
+
 	// Load config
 	cfg, err := config.Load(l.Fs, l.repo.RootPath)
 	if err != nil {
@@ -76,7 +80,7 @@ func (l *Lefthook) Run(hookName string, gitArgs []string) error {
 	}
 
 	if !outputSettings.doSkip(skipMeta) {
-		log.Info(log.Cyan("Lefthook v" + version.Version))
+		log.Info(log.Cyan("Lefthook v" + version.Version(false)))
 	}
 
 	// This line controls updating the git hook if config has changed

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -44,16 +44,12 @@ func (l *Lefthook) Run(hookName string, gitArgs []string) error {
 		return nil
 	}
 
-	if hookName == config.ChecksumHookName {
-		log.SetLevel(log.WarnLevel)
-	}
-
 	// Load config
 	cfg, err := config.Load(l.Fs, l.repo.RootPath)
 	if err != nil {
 		return err
 	}
-	if err := cfg.Validate(); err != nil {
+	if err = cfg.Validate(); err != nil {
 		return err
 	}
 
@@ -81,6 +77,17 @@ func (l *Lefthook) Run(hookName string, gitArgs []string) error {
 
 	if !outputSettings.doSkip(skipMeta) {
 		log.Info(log.Cyan("Lefthook v" + version.Version))
+	}
+
+	// This line controls updating the git hook if config has changed
+	if err = l.createHooksIfNeeded(cfg, false); err != nil {
+		log.Warn(
+			`⚠️ There was a problem with synchronizing git hooks.
+Run 'lefthook install' manually.`,
+		)
+	}
+
+	if !outputSettings.doSkip(skipMeta) {
 		log.Info(log.Cyan("RUNNING HOOK:"), log.Bold(hookName))
 	}
 

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -19,7 +19,7 @@ type hookTmplData struct {
 	Extension   string
 }
 
-func Hook(hookName, configChecksum string) []byte {
+func Hook(hookName string) []byte {
 	buf := &bytes.Buffer{}
 	t := template.Must(template.ParseFS(templatesFS, "hook.tmpl"))
 	err := t.Execute(buf, hookTmplData{

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -6,11 +6,9 @@ import (
 	"fmt"
 	"runtime"
 	"text/template"
-
-	"github.com/evilmartians/lefthook/internal/config"
 )
 
-const checksumFormat = "# lefthook_version: %s\n\ncall_lefthook \"install\""
+const checksumFormat = "%s %d\n"
 
 //go:embed *
 var templatesFS embed.FS
@@ -25,9 +23,8 @@ func Hook(hookName, configChecksum string) []byte {
 	buf := &bytes.Buffer{}
 	t := template.Must(template.ParseFS(templatesFS, "hook.tmpl"))
 	err := t.Execute(buf, hookTmplData{
-		AutoInstall: autoInstall(hookName, configChecksum),
-		HookName:    hookName,
-		Extension:   getExtension(),
+		HookName:  hookName,
+		Extension: getExtension(),
 	})
 	if err != nil {
 		panic(err)
@@ -45,12 +42,8 @@ func Config() []byte {
 	return tmpl
 }
 
-func autoInstall(hookName, configChecksum string) string {
-	if hookName != config.ChecksumHookName {
-		return ""
-	}
-
-	return fmt.Sprintf(checksumFormat, configChecksum)
+func Checksum(checksum string, timestamp int64) []byte {
+	return []byte(fmt.Sprintf(checksumFormat, checksum, timestamp))
 }
 
 func getExtension() string {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,9 +6,12 @@ import (
 	"strconv"
 )
 
-const Version = "1.0.5"
+const version = "1.0.5"
 
 var (
+	// Is set via -X github.com/evilmartians/lefthook/internal/version.commit={commit}.
+	commit string
+
 	versionRegexp = regexp.MustCompile(
 		`^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?$`,
 	)
@@ -16,6 +19,14 @@ var (
 	errIncorrectVersion = errors.New("format of 'min_version' setting is incorrect")
 	errUncovered        = errors.New("required Lefthook version is higher than current")
 )
+
+func Version(verbose bool) string {
+	if verbose {
+		return version + " " + commit
+	}
+
+	return version
+}
 
 // CheckCovered returns true if given version is less or equal than current
 // and false otherwise.
@@ -28,7 +39,7 @@ func CheckCovered(targetVersion string) error {
 		return errIncorrectVersion
 	}
 
-	major, minor, patch, err := parseVersion(Version)
+	major, minor, patch, err := parseVersion(version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Relates to https://github.com/evilmartians/lefthook/issues/279

- Store lefthook config checksum not in `prepare-commit-msg`, but in `lefthook.checksum` file.
- Make sure config is synchronized when calling `run` command.