### PR TITLE
Bring auto install back

### DIFF
--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -44,6 +44,10 @@ func (l *Lefthook) Run(hookName string, gitArgs []string) error {
 		return nil
 	}
 
+	if hookName == config.ChecksumHookName {
+		return nil
+	}
+
 	// Load config
 	cfg, err := config.Load(l.Fs, l.repo.RootPath)
 	if err != nil {

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -45,7 +45,7 @@ func (l *Lefthook) Run(hookName string, gitArgs []string) error {
 	}
 
 	if hookName == config.ChecksumHookName {
-		return nil
+		log.SetLevel(log.WarnLevel)
 	}
 
 	// Load config

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-{{.AutoInstall}}
-
 if [ "$LEFTHOOK" = "0" ]; then
   exit 0
 fi
@@ -10,12 +8,12 @@ if [ -t 1 ] ; then
   exec < /dev/tty ; # <- enables interactive shell
 fi
 
-dir="$(git rev-parse --show-toplevel)"
-osArch=$(echo "$(uname)" | tr '[:upper:]' '[:lower:]')
-cpuArch=$(echo "$(uname -m)" | sed 's/aarch64/arm64/')
-
 call_lefthook()
 {
+  dir="$(git rev-parse --show-toplevel)"
+  osArch=$(echo "$(uname)" | tr '[:upper:]' '[:lower:]')
+  cpuArch=$(echo "$(uname -m)" | sed 's/aarch64/arm64/')
+
   if lefthook{{.Extension}} -h >/dev/null 2>&1
   then
     eval lefthook{{.Extension}} $@
@@ -41,5 +39,7 @@ call_lefthook()
     echo "Can't find lefthook in PATH"
   fi
 }
+
+{{.AutoInstall}}
 
 call_lefthook "run {{.HookName}} $@"

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -10,7 +10,7 @@ import (
 	"github.com/evilmartians/lefthook/internal/config"
 )
 
-const checksumFormat = "# lefthook_version: %s"
+const checksumFormat = "# lefthook_version: %s\n\ncall_lefthook \"install\""
 
 //go:embed *
 var templatesFS embed.FS


### PR DESCRIPTION
An alternative fix for https://github.com/evilmartians/lefthook/pull/280

This PR brings old behavior back + adds silent processing for `prepare-commit-msg` hook.