### PR TITLE
Add `when "mingw" then "windows"` case

### DIFF
--- a/packaging/rubygems/bin/lefthook
+++ b/packaging/rubygems/bin/lefthook
@@ -18,6 +18,7 @@ os =
   when "darwin"  then "darwin"  # MacOS
   when "windows" then "windows"
   when "mingw32" then "windows" # Windows with MINGW64 reports RUBY_PLATFORM as "x64-mingw32"
+  when "mingw" then "windows"
   else raise "Unknown OS: #{platform.os}"
   end
 


### PR DESCRIPTION
Making this change locally allowed me to run lefthook. I do not *know* if there are any kind of ABI issues, I have no *actual* idea how lefthook works, but I suspect it's fine since it looks like there's no actual interface between go and ruby, only at the process level?

Fixes https://github.com/evilmartians/lefthook/issues/296