### PR TITLE
Add tests on runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.47.3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,8 @@ builds:
   goarch:
     - amd64
     - arm64
+  ldflags:
+    - -s -w -X github.com/evilmartians/lefthook/internal/version.commit={{.Commit}}
 archives:
   - id: lefthook
     format: binary

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ bench:
 
 bin/golangci-lint:
 	@test -x $$(go env GOPATH)/bin/golangci-lint || \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.43.0
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.47.3
 
 lint: bin/golangci-lint
 	$$(go env GOPATH)/bin/golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 COMMIT_HASH = $(shell git rev-parse HEAD)
 
 build:
-	go build -ldflags "-X github.com/evilmartians/lefthook/internal/version.commit=$(COMMIT_HASH)" -o lefthook
+	go build -ldflags "-s -w -X github.com/evilmartians/lefthook/internal/version.commit=$(COMMIT_HASH)" -o lefthook
 
 test:
 	go test -cpu 24 -race -count=1 -timeout=30s ./...

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -114,16 +114,20 @@ func unmarshalScripts(s map[string]interface{}) (map[string]*Script, error) {
 // `scripts` are unmarshalled manually because viper
 // uses "." as a key delimiter. So, this definition:
 //
-//   scripts:
-//     "example.sh":
+// ```yaml
+// scripts:
+//   "example.sh":
 //       runner: bash
+// ```
 //
 // Unmarshals into this:
 //
-//   scripts:
-//     example:
-//       sh:
-//         runner: bash
+// ```yaml
+// scripts:
+//   example:
+//     sh:
+//       runner: bash
+// ```
 //
 // This is not an expected behavior and cannot be controlled yet
 // Working with GetStringMap is the only way to get the structure "as is".

--- a/internal/lefthook/runner/execute_unix.go
+++ b/internal/lefthook/runner/execute_unix.go
@@ -13,7 +13,9 @@ import (
 	"github.com/creack/pty"
 )
 
-func Execute(root string, args []string) (*bytes.Buffer, error) {
+type CommandExecutor struct{}
+
+func (e CommandExecutor) Execute(root string, args []string) (*bytes.Buffer, error) {
 	command := exec.Command("sh", "-c", strings.Join(args, " "))
 	rootDir, _ := filepath.Abs(root)
 	command.Dir = rootDir

--- a/internal/lefthook/runner/execute_windows.go
+++ b/internal/lefthook/runner/execute_windows.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 )
 
-func Execute(root string, args []string) (*bytes.Buffer, error) {
+type CommandExecutor struct{}
+
+func (e CommandExecutor) Execute(root string, args []string) (*bytes.Buffer, error) {
 	command := exec.Command(args[0], args[1:]...)
 	rootDir, _ := filepath.Abs(root)
 	command.Dir = rootDir

--- a/internal/lefthook/runner/executor.go
+++ b/internal/lefthook/runner/executor.go
@@ -1,0 +1,11 @@
+package runner
+
+import (
+	"bytes"
+)
+
+// Executor provides an interface for command execution.
+// It is used here for testing purpose mostly.
+type Executor interface {
+	Execute(root string, args []string) (*bytes.Buffer, error)
+}

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -30,6 +30,7 @@ type Runner struct {
 	args       []string
 	failed     bool
 	resultChan chan Result
+	exec       Executor
 }
 
 func NewRunner(
@@ -45,6 +46,7 @@ func NewRunner(
 		hook:       hook,
 		args:       args,
 		resultChan: resultChan,
+		exec:       CommandExecutor{},
 	}
 }
 
@@ -270,7 +272,7 @@ func prepareFiles(command *config.Command, files []string) string {
 }
 
 func (r *Runner) run(name, root, failText string, args []string) {
-	out, err := Execute(root, args)
+	out, err := r.exec.Execute(root, args)
 
 	var execName string
 	if err != nil {

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -1,0 +1,266 @@
+package runner
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/evilmartians/lefthook/internal/config"
+	"github.com/evilmartians/lefthook/internal/git"
+)
+
+type TestExecutor struct{}
+
+func (e TestExecutor) Execute(root string, args []string) (out *bytes.Buffer, err error) {
+	out = bytes.NewBuffer(make([]byte, 0))
+
+	if args[0] == "success" {
+		err = nil
+	} else {
+		err = errors.New(args[0])
+	}
+
+	return
+}
+
+func TestRunAll(t *testing.T) {
+	root, err := filepath.Abs("src")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	gitPath := filepath.Join(root, ".git")
+	repo := &git.Repository{
+		HooksPath: filepath.Join(gitPath, "hooks"),
+		RootPath:  root,
+		GitPath:   gitPath,
+		InfoPath:  filepath.Join(gitPath, "info"),
+	}
+
+	for i, tt := range [...]struct {
+		name          string
+		args          []string
+		scriptDirs    []string
+		existingFiles []string
+		hook          *config.Hook
+		success, fail []Result
+	}{
+		{
+			name: "empty hook",
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{},
+				Scripts:  map[string]*config.Script{},
+				Piped:    true,
+			},
+		},
+		{
+			name: "with simple command",
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{
+					"test": &config.Command{
+						Run: "success",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{{Name: "test", Status: StatusOk}},
+		},
+		{
+			name: "with multiple commands ran in parallel",
+			hook: &config.Hook{
+				Parallel: true,
+				Commands: map[string]*config.Command{
+					"test": &config.Command{
+						Run: "success",
+					},
+					"lint": &config.Command{
+						Run: "success",
+					},
+					"type-check": &config.Command{
+						Run: "fail",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{
+				{Name: "lint", Status: StatusOk},
+				{Name: "test", Status: StatusOk},
+			},
+			fail: []Result{{Name: "type-check", Status: StatusErr}},
+		},
+		{
+			name: "with exclude tags",
+			hook: &config.Hook{
+				ExcludeTags: []string{"tests"},
+				Commands: map[string]*config.Command{
+					"test": &config.Command{
+						Run:  "success",
+						Tags: []string{"tests"},
+					},
+					"lint": &config.Command{
+						Run:  "success",
+						Tags: []string{"linters"},
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{{Name: "lint", Status: StatusOk}},
+		},
+		{
+			name: "with skip boolean option",
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{
+					"test": &config.Command{
+						Run:  "success",
+						Skip: true,
+					},
+					"lint": &config.Command{
+						Run: "success",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{{Name: "lint", Status: StatusOk}},
+		},
+		{
+			name: "with skip merge",
+			existingFiles: []string{
+				filepath.Join(gitPath, "MERGE_HEAD"),
+			},
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{
+					"test": &config.Command{
+						Run:  "success",
+						Skip: "merge",
+					},
+					"lint": &config.Command{
+						Run: "success",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{{Name: "lint", Status: StatusOk}},
+		},
+		{
+			name: "with skip rebase and merge in an array",
+			existingFiles: []string{
+				filepath.Join(gitPath, "rebase-merge"),
+				filepath.Join(gitPath, "rebase-apply"),
+			},
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{
+					"test": &config.Command{
+						Run:  "success",
+						Skip: []interface{}{"merge", "rebase"},
+					},
+					"lint": &config.Command{
+						Run: "success",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{{Name: "lint", Status: StatusOk}},
+		},
+		{
+			name: "with fail test",
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{
+					"test": &config.Command{
+						Run:      "fail",
+						FailText: "try 'success'",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			fail: []Result{{Name: "test", Status: StatusErr, Text: "try 'success'"}},
+		},
+		{
+			name: "with simple scripts",
+			scriptDirs: []string{
+				filepath.Join(root, config.DefaultSourceDir),
+			},
+			existingFiles: []string{
+				filepath.Join(root, config.DefaultSourceDir, "script.sh"),
+				filepath.Join(root, config.DefaultSourceDir, "failing.js"),
+			},
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{},
+				Scripts: map[string]*config.Script{
+					"script.sh": &config.Script{
+						Runner: "success",
+					},
+					"failing.js": &config.Script{
+						Runner:   "fail",
+						FailText: "install node",
+					},
+				},
+			},
+			success: []Result{{Name: "script.sh", Status: StatusOk}},
+			fail:    []Result{{Name: "failing.js", Status: StatusErr, Text: "install node"}},
+		},
+	} {
+		fs := afero.NewMemMapFs()
+		repo.Fs = fs
+		resultChan := make(chan Result, len(tt.hook.Commands)+len(tt.hook.Scripts))
+		executor := TestExecutor{}
+		runner := &Runner{
+			fs:         fs,
+			repo:       repo,
+			hook:       tt.hook,
+			args:       tt.args,
+			resultChan: resultChan,
+			exec:       executor,
+		}
+
+		for _, file := range tt.existingFiles {
+			if err := fs.MkdirAll(filepath.Base(file), 0o755); err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if err := afero.WriteFile(fs, file, []byte{}, 0o755); err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+		}
+
+		t.Run(fmt.Sprintf("%d: %s", i, tt.name), func(t *testing.T) {
+			runner.RunAll(tt.scriptDirs)
+			close(resultChan)
+
+			var success, fail []Result
+			for res := range resultChan {
+				if res.Status == StatusOk {
+					success = append(success, res)
+				} else {
+					fail = append(fail, res)
+				}
+			}
+
+			if !resultsEqual(success, tt.success) {
+				t.Errorf("success results are not matching")
+			}
+
+			if !resultsEqual(fail, tt.fail) {
+				t.Errorf("fail results are not matching")
+			}
+		})
+	}
+}
+
+func resultsEqual(a, b []Result) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i, item := range a {
+		if item.Name != b[i].Name ||
+			item.Status != b[i].Status ||
+			item.Text != b[i].Text {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -61,7 +61,7 @@ func TestRunAll(t *testing.T) {
 			name: "with simple command",
 			hook: &config.Hook{
 				Commands: map[string]*config.Command{
-					"test": &config.Command{
+					"test": {
 						Run: "success",
 					},
 				},
@@ -74,13 +74,13 @@ func TestRunAll(t *testing.T) {
 			hook: &config.Hook{
 				Parallel: true,
 				Commands: map[string]*config.Command{
-					"test": &config.Command{
+					"test": {
 						Run: "success",
 					},
-					"lint": &config.Command{
+					"lint": {
 						Run: "success",
 					},
-					"type-check": &config.Command{
+					"type-check": {
 						Run: "fail",
 					},
 				},
@@ -97,11 +97,11 @@ func TestRunAll(t *testing.T) {
 			hook: &config.Hook{
 				ExcludeTags: []string{"tests"},
 				Commands: map[string]*config.Command{
-					"test": &config.Command{
+					"test": {
 						Run:  "success",
 						Tags: []string{"tests"},
 					},
-					"lint": &config.Command{
+					"lint": {
 						Run:  "success",
 						Tags: []string{"linters"},
 					},
@@ -114,11 +114,11 @@ func TestRunAll(t *testing.T) {
 			name: "with skip boolean option",
 			hook: &config.Hook{
 				Commands: map[string]*config.Command{
-					"test": &config.Command{
+					"test": {
 						Run:  "success",
 						Skip: true,
 					},
-					"lint": &config.Command{
+					"lint": {
 						Run: "success",
 					},
 				},
@@ -133,11 +133,11 @@ func TestRunAll(t *testing.T) {
 			},
 			hook: &config.Hook{
 				Commands: map[string]*config.Command{
-					"test": &config.Command{
+					"test": {
 						Run:  "success",
 						Skip: "merge",
 					},
-					"lint": &config.Command{
+					"lint": {
 						Run: "success",
 					},
 				},
@@ -153,11 +153,11 @@ func TestRunAll(t *testing.T) {
 			},
 			hook: &config.Hook{
 				Commands: map[string]*config.Command{
-					"test": &config.Command{
+					"test": {
 						Run:  "success",
 						Skip: []interface{}{"merge", "rebase"},
 					},
-					"lint": &config.Command{
+					"lint": {
 						Run: "success",
 					},
 				},
@@ -169,7 +169,7 @@ func TestRunAll(t *testing.T) {
 			name: "with fail test",
 			hook: &config.Hook{
 				Commands: map[string]*config.Command{
-					"test": &config.Command{
+					"test": {
 						Run:      "fail",
 						FailText: "try 'success'",
 					},
@@ -190,10 +190,10 @@ func TestRunAll(t *testing.T) {
 			hook: &config.Hook{
 				Commands: map[string]*config.Command{},
 				Scripts: map[string]*config.Script{
-					"script.sh": &config.Script{
+					"script.sh": {
 						Runner: "success",
 					},
-					"failing.js": &config.Script{
+					"failing.js": {
 						Runner:   "fail",
 						FailText: "install node",
 					},


### PR DESCRIPTION
**Summary :broom:**

- [x] Created an interface for executor - to allow testing command execution in MemFs
- [x] Added basic tests on runner
- [x] Fixed golangci-lint version: is was complaining on comments in v1.48.0

Things to be done:
- Test files filtering
- Test skipping if filters are empty
- Test args coming to Executor