### PR TITLE
Add support for git lfs

### DIFF
--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -549,6 +549,15 @@ SHA1=$3
 # ...
 ```
 
+## Git LFS support
+
+Lefthook runs LFS hooks internally for the following hooks:
+
+- post-checkout
+- post-commit
+- post-merge
+- pre-push
+
 ## Change directory for script files
 
 You can do this through this config keys:

--- a/internal/git/lfs.go
+++ b/internal/git/lfs.go
@@ -1,0 +1,34 @@
+package git
+
+import (
+	"os/exec"
+)
+
+const (
+	LFSRequiredFile = ".lfs-required"
+	LFSConfigFile   = ".lfsconfig"
+)
+
+var lfsHooks = [...]string{
+	"post-checkout",
+	"post-commit",
+	"post-merge",
+	"pre-push",
+}
+
+// IsLFSAvailable returns 'true' if git-lfs is installed.
+func IsLFSAvailable() bool {
+	_, err := exec.LookPath("git-lfs")
+
+	return err == nil
+}
+
+func IsLFSHook(hookName string) bool {
+	for _, lfsHookName := range lfsHooks {
+		if lfsHookName == hookName {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/git/lfs.go
+++ b/internal/git/lfs.go
@@ -23,6 +23,7 @@ func IsLFSAvailable() bool {
 	return err == nil
 }
 
+// IsLFSHook returns whether the hookName is supported by Git LFS.
 func IsLFSHook(hookName string) bool {
 	for _, lfsHookName := range lfsHooks {
 		if lfsHookName == hookName {

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -110,10 +109,8 @@ Run 'lefthook install' manually.`,
 
 	go func() {
 		run.RunAll(
-			[]string{
-				filepath.Join(cfg.SourceDir, hookName),
-				filepath.Join(cfg.SourceDirLocal, hookName),
-			},
+			hookName,
+			[]string{cfg.SourceDir, cfg.SourceDirLocal},
 		)
 		close(resultChan)
 	}()

--- a/internal/lefthook/runner/execute_unix.go
+++ b/internal/lefthook/runner/execute_unix.go
@@ -6,6 +6,7 @@ package runner
 import (
 	"bytes"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -29,4 +30,12 @@ func (e CommandExecutor) Execute(root string, args []string) (*bytes.Buffer, err
 	_, _ = io.Copy(out, ptyOut)
 
 	return out, command.Wait()
+}
+
+func (e CommandExecutor) RawExecute(command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
 }

--- a/internal/lefthook/runner/execute_windows.go
+++ b/internal/lefthook/runner/execute_windows.go
@@ -25,3 +25,11 @@ func (e CommandExecutor) Execute(root string, args []string) (*bytes.Buffer, err
 	}
 	return &out, command.Wait()
 }
+
+func (e CommandExecutor) RawExecute(command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/internal/lefthook/runner/executor.go
+++ b/internal/lefthook/runner/executor.go
@@ -8,4 +8,5 @@ import (
 // It is used here for testing purpose mostly.
 type Executor interface {
 	Execute(root string, args []string) (*bytes.Buffer, error)
+	RawExecute(command string, args ...string) error
 }


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/276

**Summary :zap:**

The approach is [taken from Githooks](https://github.com/gabyx/Githooks/blob/8025718df966574e12485ecdb8bbe5b6ffd050f1/githooks/apps/runner/runner.go#L379-L409):

- [x] Check if git-lfs is installed and the hook is supported by Git LFS
- [x] Run Git LFS hook before all the other hooks
- [x] Successful execution of LFS hooks is not mandatory for now. This might be changed in next major release.

Tested locally, noticed that `git lfs ...` hangs only if I set `cmd.Stdin = os.Stdin`. This is because `pre-push` hook reads from STDIN: https://www.mankier.com/1/git-lfs-pre-push. :warning: Lefthook won't support this for now.