### PR TITLE
Windows escaping issues

### DIFF
--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -168,6 +168,24 @@ pre-commit:
 
 Note: If using `all_files` with RuboCop, it will ignore RuboCop's `Exclude` configuration setting. To avoid this, pass `--force-exclusion`.
 
+If you want to have all you files quoted with double quotes `"` or single quotes `'`, quote the appropriate shorthand:
+
+```yml
+pre-commit
+  commands:
+    lint:
+      glob: "*.js"
+      # Quoting with double quotes `"` might be helpful for Windows users
+      run: yarn eslint "{staged_files}" # will run `yarn eslint "file1.js" "file2.js" "[strange name].js"`
+    test:
+      glob: "*.{spec.js}"
+      run: yarn test '{staged_files}' # will run `yarn eslint 'file1.spec.js' 'file2.spec.js' '[strange name].spec.js'`
+    format:
+      glob: "*.js"
+      # Will quote where needed with single quotes
+      run: yarn test {staged_files} # will run `yarn eslint file1.js file2.js '[strange name].spec.js'`
+```
+
 ## Custom file list
 
 Lefthook can be even more specific in selecting files.

--- a/internal/lefthook/runner/execute_windows.go
+++ b/internal/lefthook/runner/execute_windows.go
@@ -5,12 +5,18 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"syscall"
 )
 
 type CommandExecutor struct{}
 
 func (e CommandExecutor) Execute(root string, args []string) (*bytes.Buffer, error) {
-	command := exec.Command(args[0], args[1:]...)
+	command := exec.Command(args[0])
+	command.SysProcAttr = &syscall.SysProcAttr{
+		CmdLine: strings.Join(args, " "),
+	}
+
 	rootDir, _ := filepath.Abs(root)
 	command.Dir = rootDir
 


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/269

**Summary :wrench:**

This bug is from go `exec` builtin package: https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/os/exec/exec.go;l=269. They suggest passing args directly with syscall attrs. This is what is done with this PR.

Also fixed a thing: if the {staged_files} or any other template is quoted like "{staged_files}", all the files from substitution will be quoted. Previously the whole line was quoted, and this is not what you want on Windows, I think.