### PR TITLE
Check for lefthook.bat in hook template

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -17,9 +17,12 @@ call_lefthook()
   if lefthook{{.Extension}} -h >/dev/null 2>&1
   then
     eval lefthook{{.Extension}} $@
-  elif [ -n "{{.Extension}}" ] && lefthook.bat -h >/dev/null 2>&1
+  {{if .Extension -}}
+  {{/* Check if lefthook.bat exists. Ruby bundler creates such a wrapper */ -}}
+  elif lefthook.bat -h >/dev/null 2>&1
   then
     eval lefthook.bat $@
+  {{end -}}
   elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
   then
     eval "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}} $@"

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -17,6 +17,9 @@ call_lefthook()
   if lefthook{{.Extension}} -h >/dev/null 2>&1
   then
     eval lefthook{{.Extension}} $@
+  elif [ -n "{{.Extension}}" ] && lefthook.bat -h >/dev/null 2>&1
+  then
+    eval lefthook.bat $@
   elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
   then
     eval "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}} $@"


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/298

**Summary :wrench:**

If we have `.Extension` we must be on Windows. Check for lefthook.bat executable too. 