### PR TITLE
feat: configure hook remote repositories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
+	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde h1:ejfdSekXMDxDLbRrJMwUk6KnSLZ2McaUCVcIKM+N6jc=
+golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,12 +7,19 @@ import (
 type Config struct {
 	Colors         bool     `mapstructure:"colors"`
 	Extends        []string `mapstructure:"extends"`
+	Remotes        []Remote `mapstructure:"remotes"`
 	MinVersion     string   `mapstructure:"min_version"`
 	SkipOutput     []string `mapstructure:"skip_output"`
 	SourceDir      string   `mapstructure:"source_dir"`
 	SourceDirLocal string   `mapstructure:"source_dir_local"`
 
 	Hooks map[string]*Hook
+}
+
+type Remote struct {
+	URL     string   `mapstructure:"url"`
+	Rev     string   `mapstructure:"rev"`
+	Configs []string `mapstructure:"configs"`
 }
 
 func (c *Config) Validate() error {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -154,7 +154,7 @@ func remotes(fs afero.Fs, v *viper.Viper) error {
 	sort.SliceStable(configPaths, func(i, j int) bool { return configPaths[i] < configPaths[j] })
 
 	for _, configPath := range configPaths {
-		log.Infof("Merging remote path: %v\n", configPath)
+		log.Debugf("Merging remote config: %v", configPath)
 		if err := merge(fs, configPath, v); err != nil {
 			return err
 		}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -1,0 +1,62 @@
+package git
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+var defaultRemotePath = mustGetDefaultRemotesDir()
+
+// mustGetDefaultRemotesDir returns the default directory for the lefthook remotes.
+func mustGetDefaultRemotesDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(homeDir, ".lefthook-remotes")
+}
+
+// InitRemote clones or pulls the latest changes for a git repository that was specified as
+// a remote configuration. If successful, the path to the root of the repository will be
+// returned.
+func InitRemote(fs afero.Fs, url, rev string) (string, error) {
+	root := getRemoteDir(url)
+
+	_, err := fs.Stat(root)
+	if err == nil {
+		cmdFetch := strings.Join([]string{"git", "-C", root, "pull", "-q"}, " ")
+		_, err = execGit(cmdFetch)
+		if err != nil {
+			return "", err
+		}
+
+		return root, nil
+	}
+
+	err = fs.MkdirAll(defaultRemotePath, 0755)
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		return "", err
+	}
+
+	cmdClone := []string{"git", "-C", defaultRemotePath, "clone", "-q"}
+	if len(rev) > 0 {
+		cmdClone = append(cmdClone, "-b", rev)
+	}
+	cmdClone = append(cmdClone, url)
+	_, err = execGit(strings.Join(cmdClone, " "))
+	if err != nil {
+		return "", err
+	}
+
+	return root, nil
+}
+
+func getRemoteDir(url string) string {
+	// Removes any suffix that might have been used in the url like '.git'.
+	trimmedURL := strings.TrimSuffix(url, filepath.Ext(url))
+	return filepath.Join(defaultRemotePath, filepath.Base(trimmedURL))
+}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/evilmartians/lefthook/internal/log"
 	"github.com/spf13/afero"
 )
 
@@ -21,38 +22,55 @@ func mustGetDefaultRemotesDir() string {
 }
 
 // InitRemote clones or pulls the latest changes for a git repository that was specified as
-// a remote configuration. If successful, the path to the root of the repository will be
+// a remote config repository. If successful, the path to the root of the repository will be
 // returned.
 func InitRemote(fs afero.Fs, url, rev string) (string, error) {
-	root := getRemoteDir(url)
-
-	_, err := fs.Stat(root)
-	if err == nil {
-		cmdFetch := strings.Join([]string{"git", "-C", root, "pull", "-q"}, " ")
-		_, err = execGit(cmdFetch)
-		if err != nil {
-			return "", err
-		}
-
-		return root, nil
-	}
-
-	err = fs.MkdirAll(defaultRemotePath, 0755)
+	err := fs.MkdirAll(defaultRemotePath, 0755)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		return "", err
 	}
 
+	root := getRemoteDir(url)
+
+	_, err = fs.Stat(root)
+	if err == nil {
+		if err := updateRemote(fs, root, url, rev); err != nil {
+			return "", err
+		}
+		return root, nil
+	}
+
+	if err := cloneRemote(fs, root, url, rev); err != nil {
+		return "", err
+	}
+	return root, nil
+}
+
+func updateRemote(fs afero.Fs, root, url, rev string) error {
+	log.Debugf("Updating remote config repository: %v", root)
+	cmdFetch := []string{"git", "-C", root, "pull", "-q"}
+	if len(rev) == 0 {
+		cmdFetch = append(cmdFetch, "origin", rev)
+	}
+	_, err := execGit(strings.Join(cmdFetch, " "))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func cloneRemote(fs afero.Fs, root, url, rev string) error {
+	log.Debugf("Cloning remote config repository: %v", root)
 	cmdClone := []string{"git", "-C", defaultRemotePath, "clone", "-q"}
 	if len(rev) > 0 {
 		cmdClone = append(cmdClone, "-b", rev)
 	}
 	cmdClone = append(cmdClone, url)
-	_, err = execGit(strings.Join(cmdClone, " "))
+	_, err := execGit(strings.Join(cmdClone, " "))
 	if err != nil {
-		return "", err
+		return err
 	}
-
-	return root, nil
+	return nil
 }
 
 func getRemoteDir(url string) string {


### PR DESCRIPTION
# Summary

This PR adds a feature to utilize shared hooks as explained in #155. It works by utilizing a `.lefthook-remotes` directory inside of the home directory to store all of the git repositories. If the repository exists, then it will pull changes instead of cloning a new repository.

Defining them looks like the following:

```yaml
remotes:
  # All git urls are supported e.g. file paths, ssh, https.
  # See https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols for more info.
  - url: git@github.com:oatovar/shared-hooks.git
    rev: v1.0.0 # This can be a tag or branch name.
    configs: # The files to include from the remote repository.
      - main.yml
```

The new order of config merges is as follows.

```mermaid
flowchart LR
    id1(lefthook) --> id2(lefthook-local) --> id3(remotes) --> id4(extends)
```

Resolves #155 