### PR TITLE
Fix regression from #314 (chmod missed fix)

### DIFF
--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -167,17 +167,17 @@ func (r *Runner) runScripts(dir string) {
 			wg.Add(1)
 			go func(script *config.Script, path string, file os.FileInfo) {
 				defer wg.Done()
-				r.runScript(script, path, file, dir)
+				r.runScript(script, path, file)
 			}(script, unquotedScriptPath, file)
 		} else {
-			r.runScript(script, unquotedScriptPath, file, dir)
+			r.runScript(script, unquotedScriptPath, file)
 		}
 	}
 
 	wg.Wait()
 }
 
-func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.FileInfo, dir string) {
+func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.FileInfo) {
 	quotedScriptPath := shellescape.Quote(unquotedPath)
 	if script.DoSkip(r.repo.State()) {
 		logSkip(file.Name(), "(SKIP BY SETTINGS)")

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -178,7 +178,6 @@ func (r *Runner) runScripts(dir string) {
 }
 
 func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.FileInfo) {
-	quotedScriptPath := shellescape.Quote(unquotedPath)
 	if script.DoSkip(r.repo.State()) {
 		logSkip(file.Name(), "(SKIP BY SETTINGS)")
 		return
@@ -209,6 +208,7 @@ func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.F
 		args = strings.Split(script.Runner, " ")
 	}
 
+	quotedScriptPath := shellescape.Quote(unquotedPath)
 	args = append(args, quotedScriptPath)
 	args = append(args, r.args[:]...)
 


### PR DESCRIPTION
#314 introduced a [regression](https://github.com/evilmartians/lefthook/pull/314#issuecomment-1230927802) that passes quoted paths to `fs.chmod`. [`fs.Chmod`/`os.chmod` on windows](https://cs.opensource.google/go/go/+/master:src/syscall/syscall_windows.go;l=647;drc=242adb784cd64265ce803f6b0c59dbf126bcda9c) calls into the [`GetFileAttributes`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesw)/[`SetFileAttributes`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesw) win32 api directly. The win32 api expects a "strongly typed" path, without quotes, unlike a command line string, and doesn't try to *parse* it. Passing quoted paths to fs.Chmod causes the operation to fail - valid paths do not begin with quotes!

This change moves the path quoting down into `runScript`, so that we can pass the UNquoted path to `fs.Chmod`.

To my great surprise, it looks like go does NOT check `GetLastError` when `GetFileAttributes`/`SetFileAttributes` fails? This is disappointing, because somewhere down the stack, procmon says windows returns "NAME INVALID", which is probably `STATUS_OBJECT_NAME_INVALID`. Poking around kernelbase.dll in GHIDRA shows a couple places where it sets last error, and you can see plenty more in the ReactOS sources. Guess I'll have to file a bug in go to satisfy my OCD :)