### PR TITLE
Exclude by command names too

### DIFF
--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -451,10 +451,10 @@ LEFTHOOK=0 git commit -am "Lefthook skipped"
 
 ## Skip some tags on the fly
 
-Use LEFTHOOK_EXCLUDE={list of tags to be excluded} for that
+Use LEFTHOOK_EXCLUDE={list of tags or command names to be excluded} for that
 
 ```bash
-LEFTHOOK_EXCLUDE=ruby,security git commit -am "Skip some tag checks"
+LEFTHOOK_EXCLUDE=ruby,security,lint git commit -am "Skip some tag checks"
 ```
 
 ## Concurrent files overrides

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -261,6 +261,11 @@ func (r *Runner) runCommand(name string, command *config.Command) {
 		return
 	}
 
+	if intersect(r.hook.ExcludeTags, []string{name}) {
+		logSkip(name, "(SKIP BY NAME)")
+		return
+	}
+
 	if err := command.Validate(); err != nil {
 		r.fail(name, "")
 		return

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -101,11 +101,14 @@ func TestRunAll(t *testing.T) {
 		{
 			name: "with exclude tags",
 			hook: &config.Hook{
-				ExcludeTags: []string{"tests"},
+				ExcludeTags: []string{"tests", "formatter"},
 				Commands: map[string]*config.Command{
 					"test": {
 						Run:  "success",
 						Tags: []string{"tests"},
+					},
+					"formatter": {
+						Run: "success",
 					},
 					"lint": {
 						Run:  "success",


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/317

**Summary :zap:**

- [x] Also exclude commands if their names are listed in exclude tags list (or provided via LEFTHOOK_EXCLUDE env)