### PR TITLE
Allow setting env vars

### DIFF
--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -508,6 +508,21 @@ source_dir: ".lefthook"
 source_dir_local: ".lefthook-local"
 ```
 
+## Custom preset ENV variables
+
+Lefthook allows you to set ENV variables for the commands and scripts. This is helpful when you use lefthook on different OSes and need to pass ENV vars to your executables.
+
+```yml
+# lefthook.yml
+
+pre-commit:
+  commands:
+    test:
+      run: bundle exec rspec
+      env:
+        RAILS_ENV: test
+```
+
 ## Manage verbosity
 
 You can manage the verbosity using the `skip_output` config.

--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -14,10 +14,11 @@ var errFilesIncompatible = errors.New("One of your runners contains incompatible
 type Command struct {
 	Run string `mapstructure:"run"`
 
-	Skip  interface{} `mapstructure:"skip"`
-	Tags  []string    `mapstructure:"tags"`
-	Glob  string      `mapstructure:"glob"`
-	Files string      `mapstructure:"files"`
+	Skip  interface{}       `mapstructure:"skip"`
+	Tags  []string          `mapstructure:"tags"`
+	Glob  string            `mapstructure:"glob"`
+	Files string            `mapstructure:"files"`
+	Env   map[string]string `mapstructure:"env"`
 
 	Root    string `mapstructure:"root"`
 	Exclude string `mapstructure:"exclude"`

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -12,8 +12,9 @@ import (
 type Script struct {
 	Runner string `mapstructure:"runner"`
 
-	Skip interface{} `mapstructure:"skip"`
-	Tags []string    `mapstructure:"tags"`
+	Skip interface{}       `mapstructure:"skip"`
+	Tags []string          `mapstructure:"tags"`
+	Env  map[string]string `mapstructure:"env"`
 
 	FailText    string `mapstructure:"fail_text"`
 	Interactive bool   `mapstructure:"interactive"`

--- a/internal/lefthook/runner/execute_windows.go
+++ b/internal/lefthook/runner/execute_windows.go
@@ -13,7 +13,7 @@ import (
 type CommandExecutor struct{}
 
 func (e CommandExecutor) Execute(opts ExecuteOptions) (*bytes.Buffer, error) {
-	command := exec.Command(args[0])
+	command := exec.Command(opts.args[0])
 	command.SysProcAttr = &syscall.SysProcAttr{
 		CmdLine: strings.Join(opts.args, " "),
 	}

--- a/internal/lefthook/runner/execute_windows.go
+++ b/internal/lefthook/runner/execute_windows.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,13 +12,20 @@ import (
 
 type CommandExecutor struct{}
 
-func (e CommandExecutor) Execute(root string, args []string, _ bool) (*bytes.Buffer, error) {
+func (e CommandExecutor) Execute(opts ExecuteOptions) (*bytes.Buffer, error) {
 	command := exec.Command(args[0])
 	command.SysProcAttr = &syscall.SysProcAttr{
-		CmdLine: strings.Join(args, " "),
+		CmdLine: strings.Join(opts.args, " "),
 	}
 
-	rootDir, _ := filepath.Abs(root)
+	envList := make([]string, len(opts.env))
+	for name, value := range opts.env {
+		envList = append(envList, fmt.Sprintf("%s=%s", strings.ToUpper(name), value))
+	}
+
+	command.Env = append(os.Environ(), envList...)
+
+	rootDir, _ := filepath.Abs(opts.root)
 	command.Dir = rootDir
 
 	var out bytes.Buffer

--- a/internal/lefthook/runner/executor.go
+++ b/internal/lefthook/runner/executor.go
@@ -4,9 +4,17 @@ import (
 	"bytes"
 )
 
+// ExecutorOptions contains the options that control the execution.
+type ExecuteOptions struct {
+	name, root, failText string
+	args                 []string
+	interactive          bool
+	env                  map[string]string
+}
+
 // Executor provides an interface for command execution.
 // It is used here for testing purpose mostly.
 type Executor interface {
-	Execute(root string, args []string, interactive bool) (*bytes.Buffer, error)
+	Execute(opts ExecuteOptions) (*bytes.Buffer, error)
 	RawExecute(command string, args ...string) error
 }

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -15,13 +15,13 @@ import (
 
 type TestExecutor struct{}
 
-func (e TestExecutor) Execute(root string, args []string, interactive bool) (out *bytes.Buffer, err error) {
+func (e TestExecutor) Execute(opts ExecuteOptions) (out *bytes.Buffer, err error) {
 	out = bytes.NewBuffer(make([]byte, 0))
 
-	if args[0] == "success" {
+	if opts.args[0] == "success" {
 		err = nil
 	} else {
-		err = errors.New(args[0])
+		err = errors.New(opts.args[0])
 	}
 
 	return


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/247

**Summary :zap:**

There might be a need to pass an ENV variables to a command or a script. To make this thing simple and working on any OS I suggest an option `env` that can be applied to a command or script.