### PR TITLE
feature: Add remote config support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,10 @@
   - [`skip_output`](#skip_output)
   - [`source_dir`](#source_dir)
   - [`source_dir_local`](#source_dir_local)
+- [`remote` (Beta :test_tube:)](#remote)
+  - [`git_url`](#git_url)
+  - [`ref`](#ref)
+  - [`config`](#config)
 - [Hook](#git-hook)
   - [`files`](#files-global)
   - [`parallel`](#parallel)
@@ -137,6 +141,76 @@ Example of directory tree:
 Change a directory for *local* script files (not stored in VCS).
 
 This option is useful if you have a `lefthook-local.yml` config file and want to reference different scripts there.
+
+## `remote`
+
+> :test_tube: This feature is in **Beta** version
+
+You can provide a remote config if you want to share your lefthook configuration across many projects. Lefthook will automatically download and merge the configuration into your local `lefthook.yml`.
+
+**Note**
+
+Configuration in `remote` will be merged to confiuration in `lefthook.yml`, so the priority will be the following:
+
+- `lefthook.yml`
+- `remote`
+- `lefthook-local.yml`
+
+This can be changed in the future. For convenience, please use `remote` configuration without any hooks configuration in `lefthook.yml`.
+
+### `git_url`
+
+A URL to Git repository. It will be accessed with priveleges of the machine lefthook runs on.
+
+**Example**
+
+```yml
+# lefthook.yml
+
+remote:
+  git_url: git@github.com:evilmartians/lefthook
+```
+
+Or
+
+```yml
+# lefthook.yml
+
+remote:
+  git_url: https://github.com/evilmartians/lefthook
+```
+
+### `ref`
+
+An optional *branch* or *tag* name.
+
+**Example**
+
+```yml
+# lefthook.yml
+
+remote:
+  git_url: git@github.com:evilmartians/lefthook
+  ref: v1.0.0
+```
+
+
+### `config`
+
+**Default:** `lefthook.yml`
+
+An optional config path from remote's root.
+
+**Example**
+
+```yml
+# lefthook.yml
+
+remote:
+  git_url: git@github.com:evilmartians/remote
+  ref: v1.0.0
+  config: examples/ruby-linter.yml
+```
 
 ## Git hook
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ colors: false
 
 ### `extends`
 
-You can extend your config with another one YAML file.
+You can extend your config with another one YAML file. Its content will be merged. Extends for `lefthook.yml`, `lefthook-local.yml`, and [`remote`](#remote) configs are handled separately, so you can have different extends in these files.
 
 **Example**
 
@@ -69,14 +69,11 @@ You can extend your config with another one YAML file.
 # lefthook.yml
 
 extends:
-  - $HOME/work/lefthook-extend.yml
-  - $HOME/work/lefthook-extend-2.yml
+  - /home/user/work/lefthook-extend.yml
+  - /home/user/work/lefthook-extend-2.yml
+  - lefthook-extends/file.yml
+  - ../extend.yml
 ```
-
-**Notes**
-
-Files for extend should *not* be named "lefthook.yml". All file names should be unique.
-
 
 ### `min_version`
 
@@ -147,6 +144,10 @@ This option is useful if you have a `lefthook-local.yml` config file and want to
 > :test_tube: This feature is in **Beta** version
 
 You can provide a remote config if you want to share your lefthook configuration across many projects. Lefthook will automatically download and merge the configuration into your local `lefthook.yml`.
+
+You can use [`extends`](#extends) related to the config file (not absolute paths).
+
+If you provide [`scripts`](#scripts) in a remote file, the [scripts](#source_dir) folder must be in the **root of the repository**.
 
 **Note**
 

--- a/examples/remote/ping.yml
+++ b/examples/remote/ping.yml
@@ -1,0 +1,13 @@
+# Test `remote` config of lefthook.
+#
+# # lefthook.yml
+#
+# remote:
+#   git_url: git@github.com:evilmartians/lefthook
+#   config: examples/remote/ping.yml
+#
+# $ lefthook run pre-commit
+
+pre-commit:
+  commands:
+    run: echo pong

--- a/go.mod
+++ b/go.mod
@@ -24,14 +24,13 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-isatty v0.0.14
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
-	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
+	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde h1:ejfdSekXMDxDLbRrJMwUk6KnSLZ2McaUCVcIKM+N6jc=
+golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,6 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde h1:ejfdSekXMDxDLbRrJMwUk6KnSLZ2McaUCVcIKM+N6jc=
-golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,19 +7,13 @@ import (
 type Config struct {
 	Colors         bool     `mapstructure:"colors"`
 	Extends        []string `mapstructure:"extends"`
-	Remotes        []Remote `mapstructure:"remotes"`
+	Remote         Remote   `mapstructure:"remote"`
 	MinVersion     string   `mapstructure:"min_version"`
 	SkipOutput     []string `mapstructure:"skip_output"`
 	SourceDir      string   `mapstructure:"source_dir"`
 	SourceDirLocal string   `mapstructure:"source_dir_local"`
 
 	Hooks map[string]*Hook
-}
-
-type Remote struct {
-	URL     string   `mapstructure:"url"`
-	Rev     string   `mapstructure:"rev"`
-	Configs []string `mapstructure:"configs"`
 }
 
 func (c *Config) Validate() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,12 +7,19 @@ import (
 type Config struct {
 	Colors         bool     `mapstructure:"colors"`
 	Extends        []string `mapstructure:"extends"`
+	Remotes        []Remote `mapstructure:"remotes"`
 	MinVersion     string   `mapstructure:"min_version"`
 	SkipOutput     []string `mapstructure:"skip_output"`
 	SourceDir      string   `mapstructure:"source_dir"`
 	SourceDirLocal string   `mapstructure:"source_dir_local"`
 
 	Hooks map[string]*Hook
+}
+
+type Remote struct {
+	URL     string   `mapstructure:"url"`
+	Rev     string   `mapstructure:"rev"`
+	Configs []string `mapstructure:"configs"`
 }
 
 func (c *Config) Validate() error {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -94,6 +94,7 @@ func mergeAll(fs afero.Fs, path string) (*viper.Viper, error) {
 	return extends, nil
 }
 
+// mergeRemote merges remote config to the current one.
 func mergeRemote(fs afero.Fs, v *viper.Viper) error {
 	var remote Remote
 	err := v.UnmarshalKey("remote", &remote)
@@ -123,7 +124,10 @@ func mergeRemote(fs afero.Fs, v *viper.Viper) error {
 		return nil
 	}
 
-	if err := merge(fs, configPath, v); err != nil {
+	// TODO: Rewrite using common merge()
+	v.SetConfigName("remote")
+	v.SetConfigFile(configPath)
+	if err := v.MergeInConfig(); err != nil {
 		return err
 	}
 
@@ -139,6 +143,7 @@ func extend(fs afero.Fs, v *viper.Viper) error {
 	return nil
 }
 
+// FIXME: Use MergeInConfig because MergeConfigMap destroys scripts names.
 func merge(fs afero.Fs, path string, v *viper.Viper) error {
 	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -73,11 +73,11 @@ func mergeAll(fs afero.Fs, repo *git.Repository) (*viper.Viper, error) {
 		return nil, err
 	}
 
-	if err := mergeRemote(fs, repo, extends); err != nil {
+	if err := extend(extends); err != nil {
 		return nil, err
 	}
 
-	if err := extend(extends); err != nil {
+	if err := mergeRemote(fs, repo, extends); err != nil {
 		return nil, err
 	}
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -154,7 +154,7 @@ func remotes(fs afero.Fs, v *viper.Viper) error {
 	sort.SliceStable(configPaths, func(i, j int) bool { return configPaths[i] < configPaths[j] })
 
 	for _, configPath := range configPaths {
-		log.Infof("Merging remote path: %v\n", configPath)
+		log.Debugf("Merging remote config: %v", configPath)
 		if err := merge(fs, configPath, v); err != nil {
 			return err
 		}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -77,7 +77,7 @@ func mergeAll(fs afero.Fs, repo *git.Repository) (*viper.Viper, error) {
 		return nil, err
 	}
 
-	if err := extend(fs, extends); err != nil {
+	if err := extend(extends); err != nil {
 		return nil, err
 	}
 
@@ -87,7 +87,7 @@ func mergeAll(fs afero.Fs, repo *git.Repository) (*viper.Viper, error) {
 		}
 	}
 
-	if err := extend(fs, extends); err != nil {
+	if err := extend(extends); err != nil {
 		return nil, err
 	}
 
@@ -128,7 +128,7 @@ func mergeRemote(fs afero.Fs, repo *git.Repository, v *viper.Viper) error {
 }
 
 // extend merges all files listed in 'extends' option into the config.
-func extend(fs afero.Fs, v *viper.Viper) error {
+func extend(v *viper.Viper) error {
 	for i, path := range v.GetStringSlice("extends") {
 		if err := merge(fmt.Sprintf("extend_%d", i), path, v); err != nil {
 			return err

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -5,10 +5,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/evilmartians/lefthook/internal/git"
-	"github.com/evilmartians/lefthook/internal/log"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
+
+	"github.com/evilmartians/lefthook/internal/git"
+	"github.com/evilmartians/lefthook/internal/log"
 )
 
 const (

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -73,7 +73,7 @@ func mergeAll(fs afero.Fs, repo *git.Repository) (*viper.Viper, error) {
 		return nil, err
 	}
 
-	if err := extend(extends); err != nil {
+	if err := extend(extends, repo.RootPath); err != nil {
 		return nil, err
 	}
 
@@ -87,7 +87,7 @@ func mergeAll(fs afero.Fs, repo *git.Repository) (*viper.Viper, error) {
 		}
 	}
 
-	if err := extend(extends); err != nil {
+	if err := extend(extends, repo.RootPath); err != nil {
 		return nil, err
 	}
 
@@ -124,12 +124,19 @@ func mergeRemote(fs afero.Fs, repo *git.Repository, v *viper.Viper) error {
 		return err
 	}
 
+	if err := extend(v, filepath.Dir(configPath)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // extend merges all files listed in 'extends' option into the config.
-func extend(v *viper.Viper) error {
+func extend(v *viper.Viper, root string) error {
 	for i, path := range v.GetStringSlice("extends") {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(root, path)
+		}
 		if err := merge(fmt.Sprintf("extend_%d", i), path, v); err != nil {
 			return err
 		}

--- a/internal/config/remote.go
+++ b/internal/config/remote.go
@@ -1,0 +1,11 @@
+package config
+
+type Remote struct {
+	GitURL string `mapstructure:"git_url"`
+	Ref    string `mapstructure:"ref"`
+	Config string `mapstructure:"config"`
+}
+
+func (r Remote) Configured() bool {
+	return len(r.GitURL) > 0
+}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -9,7 +9,10 @@ import (
 	"github.com/evilmartians/lefthook/internal/log"
 )
 
-const remotesFolder = "remotes"
+const (
+	remotesFolder     = "remotes"
+	remotesFolderMode = 0o755
+)
 
 func RemoteFolder(url string) (string, error) {
 	infoPath, err := execGit(cmdInfoPath)
@@ -32,7 +35,8 @@ func RemoteFolder(url string) (string, error) {
 // of the repository will be returned.
 func (r *Repository) SyncRemote(url, ref string) error {
 	remotesPath := filepath.Join(r.InfoPath, remotesFolder)
-	err := r.Fs.MkdirAll(remotesPath, 0755)
+
+	err := r.Fs.MkdirAll(remotesPath, remotesFolderMode)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		return err
 	}
@@ -46,7 +50,7 @@ func (r *Repository) SyncRemote(url, ref string) error {
 
 	_, err = r.Fs.Stat(remotePath)
 	if err == nil {
-		if err := r.updateRemote(remotePath, url, ref); err != nil {
+		if err := r.updateRemote(remotePath, ref); err != nil {
 			return err
 		}
 
@@ -60,7 +64,7 @@ func (r *Repository) SyncRemote(url, ref string) error {
 	return nil
 }
 
-func (r *Repository) updateRemote(path, url, ref string) error {
+func (r *Repository) updateRemote(path, ref string) error {
 	log.Debugf("Updating remote config repository: %s", path)
 
 	cmdFetch := []string{"git", "-C", path, "pull", "--quiet"}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -14,22 +14,6 @@ const (
 	remotesFolderMode = 0o755
 )
 
-func RemoteFolder(url string) (string, error) {
-	infoPath, err := execGit(cmdInfoPath)
-	if err != nil {
-		return "", err
-	}
-
-	remotesPath := filepath.Join(infoPath, remotesFolder)
-
-	return filepath.Join(
-		remotesPath,
-		filepath.Base(
-			strings.TrimSuffix(url, filepath.Ext(url)),
-		),
-	), nil
-}
-
 func (r *Repository) RemoteFolder(url string) string {
 	remotesPath := filepath.Join(r.InfoPath, remotesFolder)
 

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -30,6 +30,17 @@ func RemoteFolder(url string) (string, error) {
 	), nil
 }
 
+func (r *Repository) RemoteFolder(url string) string {
+	remotesPath := filepath.Join(r.InfoPath, remotesFolder)
+
+	return filepath.Join(
+		remotesPath,
+		filepath.Base(
+			strings.TrimSuffix(url, filepath.Ext(url)),
+		),
+	)
+}
+
 // SyncRemote clones or pulls the latest changes for a git repository that was
 // specified as a remote config repository. If successful, the path to the root
 // of the repository will be returned.

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -7,74 +7,88 @@ import (
 	"strings"
 
 	"github.com/evilmartians/lefthook/internal/log"
-	"github.com/spf13/afero"
 )
 
-var defaultRemotePath = mustGetDefaultRemotesDir()
+const remotesFolder = "remotes"
 
-// mustGetDefaultRemotesDir returns the default directory for the lefthook remotes.
-func mustGetDefaultRemotesDir() string {
-	homeDir, err := os.UserHomeDir()
+func RemoteFolder(url string) (string, error) {
+	infoPath, err := execGit(cmdInfoPath)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	return filepath.Join(homeDir, ".lefthook-remotes")
+
+	remotesPath := filepath.Join(infoPath, remotesFolder)
+
+	return filepath.Join(
+		remotesPath,
+		filepath.Base(
+			strings.TrimSuffix(url, filepath.Ext(url)),
+		),
+	), nil
 }
 
-// InitRemote clones or pulls the latest changes for a git repository that was specified as
-// a remote config repository. If successful, the path to the root of the repository will be
-// returned.
-func InitRemote(fs afero.Fs, url, rev string) (string, error) {
-	err := fs.MkdirAll(defaultRemotePath, 0755)
+// SyncRemote clones or pulls the latest changes for a git repository that was
+// specified as a remote config repository. If successful, the path to the root
+// of the repository will be returned.
+func (r *Repository) SyncRemote(url, ref string) error {
+	remotesPath := filepath.Join(r.InfoPath, remotesFolder)
+	err := r.Fs.MkdirAll(remotesPath, 0755)
 	if err != nil && !errors.Is(err, os.ErrExist) {
-		return "", err
+		return err
 	}
 
-	root := getRemoteDir(url)
+	remotePath := filepath.Join(
+		remotesPath,
+		filepath.Base(
+			strings.TrimSuffix(url, filepath.Ext(url)),
+		),
+	)
 
-	_, err = fs.Stat(root)
+	_, err = r.Fs.Stat(remotePath)
 	if err == nil {
-		if err := updateRemote(fs, root, url, rev); err != nil {
-			return "", err
+		if err := r.updateRemote(remotePath, url, ref); err != nil {
+			return err
 		}
-		return root, nil
+
+		return nil
 	}
 
-	if err := cloneRemote(fs, root, url, rev); err != nil {
-		return "", err
+	if err := r.cloneRemote(remotesPath, url, ref); err != nil {
+		return err
 	}
-	return root, nil
+
+	return nil
 }
 
-func updateRemote(fs afero.Fs, root, url, rev string) error {
-	log.Debugf("Updating remote config repository: %v", root)
-	cmdFetch := []string{"git", "-C", root, "pull", "-q"}
-	if len(rev) == 0 {
-		cmdFetch = append(cmdFetch, "origin", rev)
+func (r *Repository) updateRemote(path, url, ref string) error {
+	log.Debugf("Updating remote config repository: %s", path)
+
+	cmdFetch := []string{"git", "-C", path, "pull", "--quiet"}
+	if len(ref) == 0 {
+		cmdFetch = append(cmdFetch, "origin", ref)
 	}
+
 	_, err := execGit(strings.Join(cmdFetch, " "))
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
-func cloneRemote(fs afero.Fs, root, url, rev string) error {
-	log.Debugf("Cloning remote config repository: %v", root)
-	cmdClone := []string{"git", "-C", defaultRemotePath, "clone", "-q"}
-	if len(rev) > 0 {
-		cmdClone = append(cmdClone, "-b", rev)
+func (r *Repository) cloneRemote(path, url, ref string) error {
+	log.Debugf("Cloning remote config repository: %v", path)
+
+	cmdClone := []string{"git", "-C", path, "clone", "--quiet", "--depth", "1"}
+	if len(ref) > 0 {
+		cmdClone = append(cmdClone, "--branch", ref)
 	}
 	cmdClone = append(cmdClone, url)
+
 	_, err := execGit(strings.Join(cmdClone, " "))
 	if err != nil {
 		return err
 	}
-	return nil
-}
 
-func getRemoteDir(url string) string {
-	// Removes any suffix that might have been used in the url like '.git'.
-	trimmedURL := strings.TrimSuffix(url, filepath.Ext(url))
-	return filepath.Join(defaultRemotePath, filepath.Base(trimmedURL))
+	return nil
 }

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -1,0 +1,62 @@
+package git
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+var defaultRemotePath = mustGetDefaultRemotesDir()
+
+// mustGetDefaultRemotesDir returns the default directory for the lefthook remotes.
+func mustGetDefaultRemotesDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(homeDir, ".lefthook-remotes")
+}
+
+// InitRemote clones or pulls the latest changes for a git repository that was specified as
+// a remote configuration. If successful, the path to the root of the repository will be
+// returned.
+func InitRemote(fs afero.Fs, url, rev string) (string, error) {
+	root := getRemoteDir(url)
+
+	_, err := fs.Stat(root)
+	if err == nil {
+		cmdFetch := strings.Join([]string{"git", "-C", root, "pull", "-q"}, " ")
+		_, err = execGit(cmdFetch)
+		if err != nil {
+			return "", err
+		}
+
+		return root, nil
+	}
+
+	err = fs.MkdirAll(defaultRemotePath, 0755)
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		return "", err
+	}
+
+	cmdClone := []string{"git", "-C", defaultRemotePath, "clone", "-q"}
+	if len(rev) > 0 {
+		cmdClone = append(cmdClone, "-b", rev)
+	}
+	cmdClone = append(cmdClone, url)
+	_, err = execGit(strings.Join(cmdClone, " "))
+	if err != nil {
+		return "", err
+	}
+
+	return root, nil
+}
+
+func getRemoteDir(url string) string {
+	// Removes any suffix that might have been used in the url like '.git'.
+	trimmedURL := strings.TrimSuffix(url, filepath.Ext(url))
+	return filepath.Join(defaultRemotePath, filepath.Base(trimmedURL))
+}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/evilmartians/lefthook/internal/log"
 	"github.com/spf13/afero"
 )
 
@@ -21,38 +22,55 @@ func mustGetDefaultRemotesDir() string {
 }
 
 // InitRemote clones or pulls the latest changes for a git repository that was specified as
-// a remote configuration. If successful, the path to the root of the repository will be
+// a remote config repository. If successful, the path to the root of the repository will be
 // returned.
 func InitRemote(fs afero.Fs, url, rev string) (string, error) {
-	root := getRemoteDir(url)
-
-	_, err := fs.Stat(root)
-	if err == nil {
-		cmdFetch := strings.Join([]string{"git", "-C", root, "pull", "-q"}, " ")
-		_, err = execGit(cmdFetch)
-		if err != nil {
-			return "", err
-		}
-
-		return root, nil
-	}
-
-	err = fs.MkdirAll(defaultRemotePath, 0755)
+	err := fs.MkdirAll(defaultRemotePath, 0755)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		return "", err
 	}
 
+	root := getRemoteDir(url)
+
+	_, err = fs.Stat(root)
+	if err == nil {
+		if err := updateRemote(fs, root, url, rev); err != nil {
+			return "", err
+		}
+		return root, nil
+	}
+
+	if err := cloneRemote(fs, root, url, rev); err != nil {
+		return "", err
+	}
+	return root, nil
+}
+
+func updateRemote(fs afero.Fs, root, url, rev string) error {
+	log.Debugf("Updating remote config repository: %v", root)
+	cmdFetch := []string{"git", "-C", root, "pull", "-q"}
+	if len(rev) == 0 {
+		cmdFetch = append(cmdFetch, "origin", rev)
+	}
+	_, err := execGit(strings.Join(cmdFetch, " "))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func cloneRemote(fs afero.Fs, root, url, rev string) error {
+	log.Debugf("Cloning remote config repository: %v", root)
 	cmdClone := []string{"git", "-C", defaultRemotePath, "clone", "-q"}
 	if len(rev) > 0 {
 		cmdClone = append(cmdClone, "-b", rev)
 	}
 	cmdClone = append(cmdClone, url)
-	_, err = execGit(strings.Join(cmdClone, " "))
+	_, err := execGit(strings.Join(cmdClone, " "))
 	if err != nil {
-		return "", err
+		return err
 	}
-
-	return root, nil
+	return nil
 }
 
 func getRemoteDir(url string) string {

--- a/internal/lefthook/add.go
+++ b/internal/lefthook/add.go
@@ -61,7 +61,7 @@ func (l *Lefthook) getSourceDirs() (global, local string) {
 	global = config.DefaultSourceDir
 	local = config.DefaultSourceDirLocal
 
-	cfg, err := config.Load(l.Fs, l.repo.RootPath)
+	cfg, err := config.Load(l.Fs, l.repo)
 	if err == nil {
 		if len(cfg.SourceDir) > 0 {
 			global = cfg.SourceDir

--- a/internal/lefthook/add_test.go
+++ b/internal/lefthook/add_test.go
@@ -144,7 +144,7 @@ source_dir_local: .source_dir_local
 
 			for hook, content := range tt.existingHooks {
 				path := hookPath(hook)
-				if err := fs.MkdirAll(filepath.Base(path), 0o755); err != nil {
+				if err := fs.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 					t.Errorf("unexpected error: %s", err)
 				}
 				if err := afero.WriteFile(fs, path, []byte(content), 0o644); err != nil {

--- a/internal/lefthook/install.go
+++ b/internal/lefthook/install.go
@@ -53,6 +53,9 @@ func (l *Lefthook) Install(args *InstallArgs) error {
 		} else {
 			// Reread the config file with synced remotes
 			cfg, err = l.readOrCreateConfig()
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/lefthook/install.go
+++ b/internal/lefthook/install.go
@@ -74,7 +74,7 @@ func (l *Lefthook) readOrCreateConfig() (*config.Config, error) {
 		}
 	}
 
-	return config.Load(l.Fs, l.repo.RootPath)
+	return config.Load(l.Fs, l.repo)
 }
 
 func (l *Lefthook) configExists(path string) bool {

--- a/internal/lefthook/install_test.go
+++ b/internal/lefthook/install_test.go
@@ -294,7 +294,7 @@ post-commit:
 			// Create files that should exist
 			for hook, content := range tt.existingHooks {
 				path := hookPath(hook)
-				if err := fs.MkdirAll(filepath.Base(path), 0o755); err != nil {
+				if err := fs.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 					t.Errorf("unexpected error: %s", err)
 				}
 				if err := afero.WriteFile(fs, path, []byte(content), 0o755); err != nil {

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -43,7 +43,7 @@ func (l *Lefthook) Run(hookName string, gitArgs []string) error {
 	}
 
 	// Load config
-	cfg, err := config.Load(l.Fs, l.repo.RootPath)
+	cfg, err := config.Load(l.Fs, l.repo)
 	if err != nil {
 		return err
 	}

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -71,7 +71,7 @@ func (r *Runner) RunAll(hookName string, sourceDirs []string) {
 	scriptDirs := make([]string, len(sourceDirs))
 	for _, sourceDir := range sourceDirs {
 		scriptDirs = append(scriptDirs, filepath.Join(
-			r.repo.RootPath, sourceDir, hookName,
+			sourceDir, hookName,
 		))
 	}
 

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -189,7 +189,7 @@ func TestRunAll(t *testing.T) {
 		},
 		{
 			name:       "with simple scripts",
-			sourceDirs: []string{config.DefaultSourceDir},
+			sourceDirs: []string{filepath.Join(root, config.DefaultSourceDir)},
 			existingFiles: []string{
 				filepath.Join(root, config.DefaultSourceDir, hookName, "script.sh"),
 				filepath.Join(root, config.DefaultSourceDir, hookName, "failing.js"),

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -224,7 +224,7 @@ func TestRunAll(t *testing.T) {
 		}
 
 		for _, file := range tt.existingFiles {
-			if err := fs.MkdirAll(filepath.Base(file), 0o755); err != nil {
+			if err := fs.MkdirAll(filepath.Dir(file), 0o755); err != nil {
 				t.Errorf("unexpected error: %s", err)
 			}
 			if err := afero.WriteFile(fs, file, []byte{}, 0o755); err != nil {

--- a/internal/lefthook/uninstall_test.go
+++ b/internal/lefthook/uninstall_test.go
@@ -111,7 +111,7 @@ func TestLefthookUninstall(t *testing.T) {
 			// Prepare files that should exist
 			for hook, content := range tt.existingHooks {
 				path := hookPath(hook)
-				if err = fs.MkdirAll(filepath.Base(path), 0o755); err != nil {
+				if err = fs.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 					t.Errorf("unexpected error: %s", err)
 				}
 				if err = afero.WriteFile(fs, path, []byte(content), 0o755); err != nil {


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/155, https://github.com/evilmartians/lefthook/pull/323

**:zap: Summary**

Remotes allow to share lefthook configurations without a need to maintain one `lefthook.yml` in all repos where you need it to be unique.

For example:

```yaml
remotes:
  git_url: git@github.com:evilmartians/lefthook # Repo URL (https:// or git@)
  ref: v1.2.0                                   # Optional reference (tag or branch)
  config: examples/ruby-linters.yml             # Optional file path (default is lefthook.yml)
```

**:tomato: This PR tasks**

- [x] Support `remote` option
  - [x] Support custom `config` name option
  - [x] Support custom `ref` option for referencing branches or tags
- [x] Sync or clone repo on `lefthook install`
- [x] Merge with remote configuration
- [x] Support `scripts` from remote
- [x] Support `extends` from remote
- [x] Add tests
- [x] Provide some config examples
- [x] Update docs