### PR TITLE
fix: Allow changing refs for remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- fix: Allow changing refs for remote ([PR #363](https://github.com/evilmartians/lefthook/pull/363) by @mrexox)
+
 ## 1.2.0 (2022-11-7)
 
 - fix: Full support for interactive commands and scripts ([PR #352](https://github.com/evilmartians/lefthook/pull/352) by @mrexox)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,6 +195,7 @@ remote:
   ref: v1.0.0
 ```
 
+> :warning: Please, note that if you initially had `ref` option, ran `lefthook install`, and then removed it, lefthook won't decide which branch/tag to use as a ref. So, if you added it once, please, use it always to avoid issues in local setups.
 
 ### `config`
 

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -67,14 +67,24 @@ func (r *Repository) SyncRemote(url, ref string) error {
 func (r *Repository) updateRemote(path, ref string) error {
 	log.Debugf("Updating remote config repository: %s", path)
 
-	cmdFetch := []string{"git", "-C", path, "pull", "--quiet"}
-	if len(ref) == 0 {
-		cmdFetch = append(cmdFetch, "origin", ref)
-	}
+	if len(ref) != 0 {
+		cmdFetch := []string{"git", "-C", path, "fetch", "--quiet", "--depth", "1", "origin", ref}
+		_, err := execGit(strings.Join(cmdFetch, " "))
+		if err != nil {
+			return err
+		}
 
-	_, err := execGit(strings.Join(cmdFetch, " "))
-	if err != nil {
-		return err
+		cmdFetch = []string{"git", "-C", path, "checkout", "FETCH_HEAD"}
+		_, err = execGit(strings.Join(cmdFetch, " "))
+		if err != nil {
+			return err
+		}
+	} else {
+		cmdFetch := []string{"git", "-C", path, "pull", "--quiet"}
+		_, err := execGit(strings.Join(cmdFetch, " "))
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/discussions/358

**:wrench: Summary**

- [x] Support changing `ref` value (but not removing it, see below)

:warning: There is still a problem when you had a `ref`, then removed it and ran `lefthook install`. The reason for that is - we don't know which branch to use as a default. So, the suggestion is: decide whether you use ref or not, and if you added a `ref`, please keep it there.

