### PR TITLE
Create Go-syntax representation of the value

### DIFF
--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -222,9 +222,7 @@ func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.F
 		args = strings.Split(script.Runner, " ")
 	}
 
-	quotedScriptPath := fmt.Sprintf("%#v", unquotedPath)
-
-	args = append(args, quotedScriptPath)
+	args = append(args, fmt.Sprintf("%#v", unquotedPath))
 	args = append(args, r.args[:]...)
 
 	if script.Interactive {

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -222,7 +222,8 @@ func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.F
 		args = strings.Split(script.Runner, " ")
 	}
 
-	quotedScriptPath := shellescape.Quote(unquotedPath)
+	quotedScriptPath := fmt.Sprintf("%#v", unquotedPath)
+
 	args = append(args, quotedScriptPath)
 	args = append(args, r.args[:]...)
 


### PR DESCRIPTION
The best I can tell the root of the issue is that the filepath for the script is converted to a single quote and this combined with the exec.Command causes the windows shell to not handle things correct.

This is the only simple change that I could come up with.  It tested with windows and wsl (ubuntu) and both didn't have issues.  The other alternatives that I could think of is rather than combining the args up front and then passing to downstream executioners instead keep the script path as an os.FileInfo type until it gets to the executioners (execute_windows.go & execute_unix).

The last option was to use exec.Command("cmd", "/c", ...) or exec.Command("powershell", "-c", ...) where it just passes n the raw built up command.  Downside is with windows at least you might lose some functionality with cmd/pwsh/powershell based on the shell configuration.