### PR TITLE
fix: remove lefthook.checksum on uninstall

### DIFF
--- a/internal/lefthook/uninstall.go
+++ b/internal/lefthook/uninstall.go
@@ -26,6 +26,12 @@ func (l *Lefthook) Uninstall(args *UninstallArgs) error {
 		return err
 	}
 
+	if err := l.Fs.Remove(l.checksumFilePath()); err == nil {
+		log.Debugf("%s removed", l.checksumFilePath())
+	} else {
+		log.Errorf("Failed removing %s: %s\n", l.checksumFilePath(), err)
+	}
+
 	if args.RemoveConfig {
 		for _, glob := range []string{
 			"lefthook.y*ml",


### PR DESCRIPTION
This fix ensures that the `lefthook uninstall` command removes the `.git/info/lefthook.checksum` file.
It closes #366.