### PR TITLE
fix: Remove quoting for scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+- fix: Remove quoting for scripts ([PR #371](https://github.com/evilmartians/lefthook/pull/371) by @stonesbg + @mrexox)
 - fix: remove lefthook.checksum on uninstall ([PR #370](https://github.com/evilmartians/lefthook/pull370) by @JuliusHenke)
 - fix: Print prepare-commit-msg hook if it exists in config ([PR #368](https://github.com/evilmartians/lefthook/pull/368) by @mrexox)
 - fix: Allow changing refs for remote ([PR #363](https://github.com/evilmartians/lefthook/pull/363) by @mrexox)

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -163,16 +163,16 @@ func (r *Runner) runScripts(dir string) {
 			continue
 		}
 
-		unquotedScriptPath := filepath.Join(dir, file.Name())
+		path := filepath.Join(dir, file.Name())
 
 		if r.hook.Parallel {
 			wg.Add(1)
 			go func(script *config.Script, path string, file os.FileInfo) {
 				defer wg.Done()
 				r.runScript(script, path, file)
-			}(script, unquotedScriptPath, file)
+			}(script, path, file)
 		} else {
-			r.runScript(script, unquotedScriptPath, file)
+			r.runScript(script, path, file)
 		}
 	}
 
@@ -185,13 +185,13 @@ func (r *Runner) runScripts(dir string) {
 			continue
 		}
 
-		unquotedScriptPath := filepath.Join(dir, file.Name())
+		path := filepath.Join(dir, file.Name())
 
-		r.runScript(script, unquotedScriptPath, file)
+		r.runScript(script, path, file)
 	}
 }
 
-func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.FileInfo) {
+func (r *Runner) runScript(script *config.Script, path string, file os.FileInfo) {
 	if script.DoSkip(r.repo.State()) {
 		logSkip(file.Name(), "(SKIP BY SETTINGS)")
 		return
@@ -210,7 +210,7 @@ func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.F
 
 	// Make sure file is executable
 	if (file.Mode() & executableMask) == 0 {
-		if err := r.fs.Chmod(unquotedPath, executableFileMode); err != nil {
+		if err := r.fs.Chmod(path, executableFileMode); err != nil {
 			log.Errorf("Couldn't change file mode to make file executable: %s", err)
 			r.fail(file.Name(), "")
 			return
@@ -222,7 +222,7 @@ func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.F
 		args = strings.Split(script.Runner, " ")
 	}
 
-	args = append(args, fmt.Sprintf("%#v", unquotedPath))
+	args = append(args, path)
 	args = append(args, r.args[:]...)
 
 	if script.Interactive {

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -222,9 +222,7 @@ func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.F
 		args = strings.Split(script.Runner, " ")
 	}
 
-	quotedScriptPath := fmt.Sprintf("%#v", unquotedPath)
-
-	args = append(args, quotedScriptPath)
+	args = append(args, fmt.Sprintf("%#v", unquotedPath))
 	args = append(args, r.args[:]...)
 
 	if script.Interactive {

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -222,7 +222,8 @@ func (r *Runner) runScript(script *config.Script, unquotedPath string, file os.F
 		args = strings.Split(script.Runner, " ")
 	}
 
-	quotedScriptPath := shellescape.Quote(unquotedPath)
+	quotedScriptPath := fmt.Sprintf("%#v", unquotedPath)
+
 	args = append(args, quotedScriptPath)
 	args = append(args, r.args[:]...)
 


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/367, https://github.com/evilmartians/lefthook/pull/369

**:wrench: Summary**

Thanks to @stonesbg who found a regression. No need to quote the scripts path. This leads to a bug on Windows system.