### PR TITLE
fix: Omit lfs output unless it is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- fix: Omit LFS output unless it is required ([PR #373](https://github.com/evilmartians/lefthook/pull/373) by @mrexox)
+
 ## 1.2.1 (2022-11-17)
 
 - fix: Remove quoting for scripts ([PR #371](https://github.com/evilmartians/lefthook/pull/371) by @stonesbg + @mrexox)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -279,9 +279,13 @@ SHA1=$3
 
 ### Git LFS support
 
+> :warning: If git-lfs binary is not installed and not required in your project, LFS hooks won't be executed, and you won't be warned about it.
+
 Lefthook runs LFS hooks internally for the following hooks:
 
 - post-checkout
 - post-commit
 - post-merge
 - pre-push
+
+Errors are suppressed if git LFS is not required for the project. You can use [`LEFTHOOK_VERBOSE`](#lefthook_verbose) ENV to make lefthook show git LFS output.

--- a/internal/lefthook/runner/execute_unix.go
+++ b/internal/lefthook/runner/execute_unix.go
@@ -76,10 +76,13 @@ func (e CommandExecutor) Execute(opts ExecuteOptions) (*bytes.Buffer, error) {
 	return out, command.Wait()
 }
 
-func (e CommandExecutor) RawExecute(command string, args ...string) error {
+func (e CommandExecutor) RawExecute(command string, args ...string) (*bytes.Buffer, error) {
 	cmd := exec.Command(command, args...)
-	cmd.Stdout = os.Stdout
+
+	var out bytes.Buffer
+
+	cmd.Stdout = &out
 	cmd.Stderr = os.Stderr
 
-	return cmd.Run()
+	return &out, cmd.Run()
 }

--- a/internal/lefthook/runner/execute_windows.go
+++ b/internal/lefthook/runner/execute_windows.go
@@ -51,10 +51,13 @@ func (e CommandExecutor) Execute(opts ExecuteOptions) (*bytes.Buffer, error) {
 	return &out, command.Wait()
 }
 
-func (e CommandExecutor) RawExecute(command string, args ...string) error {
+func (e CommandExecutor) RawExecute(command string, args ...string) (*bytes.Buffer, error) {
 	cmd := exec.Command(command, args...)
-	cmd.Stdout = os.Stdout
+
+	var out bytes.Buffer
+
+	cmd.Stdout = &out
 	cmd.Stderr = os.Stderr
 
-	return cmd.Run()
+	return &out, cmd.Run()
 }

--- a/internal/lefthook/runner/executor.go
+++ b/internal/lefthook/runner/executor.go
@@ -16,5 +16,5 @@ type ExecuteOptions struct {
 // It is used here for testing purpose mostly.
 type Executor interface {
 	Execute(opts ExecuteOptions) (*bytes.Buffer, error)
-	RawExecute(command string, args ...string) error
+	RawExecute(command string, args ...string) (*bytes.Buffer, error)
 }

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -121,9 +121,8 @@ func (r *Runner) runLFSHook(hookName string) error {
 			)...,
 		)
 
-		var output string
-		if out != nil {
-			output = strings.Trim(out.String(), "\n")
+		output := strings.Trim(out.String(), "\n")
+		if output != "" {
 			log.Debug("[git-lfs] output: ", output)
 		}
 		if err != nil {
@@ -138,7 +137,11 @@ func (r *Runner) runLFSHook(hookName string) error {
 			log.Warn(output)
 			return fmt.Errorf("git-lfs command failed: %w", err)
 		}
-	} else if requiredExists || configExists {
+
+		return nil
+	}
+
+	if requiredExists || configExists {
 		log.Errorf(
 			"This repository requires Git LFS, but 'git-lfs' wasn't found.\n"+
 				"Install 'git-lfs' or consider reviewing the files:\n"+
@@ -219,7 +222,7 @@ func (r *Runner) runScript(script *config.Script, path string, file os.FileInfo)
 
 	// Skip non-regular files (dirs, symlinks, sockets, etc.)
 	if !file.Mode().IsRegular() {
-		log.Debugf("File %s is not a regular file, skipping", file.Name())
+		log.Debugf("[lefthook] file %s is not a regular file, skipping", file.Name())
 		return
 	}
 
@@ -392,7 +395,7 @@ func (r *Runner) buildCommandArgs(command *config.Command) ([]string, error) {
 		runString = strings.ReplaceAll(runString, fmt.Sprintf("{%d}", i+1), gitArg)
 	}
 
-	log.Debug("Executing command is: ", runString)
+	log.Debug("[lefthook] executing: ", runString)
 
 	return strings.Split(runString, " "), nil
 }
@@ -402,13 +405,13 @@ func prepareFiles(command *config.Command, files []string) []string {
 		return []string{}
 	}
 
-	log.Debug("Files before filters:\n", files)
+	log.Debug("[lefthook] files before filters:\n", files)
 
 	files = filterGlob(files, command.Glob)
 	files = filterExclude(files, command.Exclude)
 	files = filterRelative(files, command.Root)
 
-	log.Debug("Files after filters:\n", files)
+	log.Debug("[lefthook] files after filters:\n", files)
 
 	// Escape file names to prevent unexpected bugs
 	var filesEsc []string
@@ -418,7 +421,7 @@ func prepareFiles(command *config.Command, files []string) []string {
 		}
 	}
 
-	log.Debug("Files after escaping:\n", filesEsc)
+	log.Debug("[lefthook] files after escaping:\n", filesEsc)
 
 	return filesEsc
 }

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -27,8 +27,8 @@ func (e TestExecutor) Execute(opts ExecuteOptions) (out *bytes.Buffer, err error
 	return
 }
 
-func (e TestExecutor) RawExecute(command string, args ...string) error {
-	return nil
+func (e TestExecutor) RawExecute(command string, args ...string) (*bytes.Buffer, error) {
+	return nil, nil
 }
 
 func TestRunAll(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/356

**:wrench: Summary**

- [x] Omit printing output of git-lfs hooks when LFS is not required in a project
- [x] Add debug messages for LFS  if user wants to see LFS output anyway