### PR TITLE
chore: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "6:00"  # 6:00 UTC
+    assignees:
+      - "mrexox"
+    reviewers:
+      - "mrexox"
+    commit-message:
+      prefix: "deps"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
**:broom: Summary**

- Add dependabot auto updates for Go modules every Monday at 6:00 UTC
