### PR TITLE
fix: Remove quotes for rc in template

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -7,7 +7,7 @@ fi
 {{- if .Rc}}
 {{/* Load rc file and export all ENV vars defined in it */}}
 set -a
-[ -f '{{.Rc}}' ] && source '{{.Rc}}'
+[ -f {{.Rc}} ] && source {{.Rc}}
 {{- end}}
 
 call_lefthook()


### PR DESCRIPTION
Fixes https://github.com/evilmartians/lefthook/pull/392#issuecomment-1350252074

**:wrench: Summary**

Remove quoting in a hook template for `rc` option, so values like `~/.lefthookrc` and `$HOME/lefthookrc` could be applied.