### PR TITLE
fix: Double quote eval statements with $dir

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -27,13 +27,13 @@ call_lefthook()
   {{end -}}
   elif test -f "$dir/node_modules/lefthook/bin/index.js"
   then
-    eval "$dir/node_modules/lefthook/bin/index.js $@"
+    eval "\"$dir/node_modules/lefthook/bin/index.js\" $@"
   elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
   then
-    eval "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}} $@"
+    eval "\"$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}\" $@"
   elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
   then
-    eval "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}} $@"
+    eval "\"$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}\" $@"
   elif bundle exec lefthook -h >/dev/null 2>&1
   then
     bundle exec lefthook $@


### PR DESCRIPTION
Closes #403 

#### :zap: Summary

Added double-quotes to `eval` statements that use $dir

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
