### PR TITLE
fix: Make info dir when it is absent

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -18,6 +18,7 @@ const (
 	cmdStagedFiles = "git diff --name-only --cached"
 	cmdAllFiles    = "git ls-files --cached"
 	cmdPushFiles   = "git diff --name-only HEAD @{push} || git diff --name-only HEAD master"
+	infoDirMode    = 0o775
 )
 
 // Repository represents a git repository.
@@ -48,8 +49,12 @@ func NewRepository(fs afero.Fs) (*Repository, error) {
 	if err != nil {
 		return nil, err
 	}
-	if exists, _ := afero.DirExists(fs, filepath.Join(rootPath, infoPath)); exists {
-		infoPath = filepath.Join(rootPath, infoPath)
+	infoPath = filepath.Join(rootPath, infoPath)
+	if exists, _ := afero.DirExists(fs, infoPath); !exists {
+		err = fs.Mkdir(infoPath, infoDirMode)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	gitPath, err := execGit(cmdGitPath)


### PR DESCRIPTION
Closes #413

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary
<!-- Brief description of what was done -->
The presence of `.git/info` directory has been taken for granted, but it can be actually nonexistent. This results in an unhandled enoent. I've changed it so the presence of it is made sure when initializing Repository. 

The point I believe is that `.git/info` could be absent. On the other hand I'm not sure if we can take for granted that `.git/hooks` always exists, or the same mishap can occur. At least in my environment the hooks dir is provisioned automatically (where the info is not) but I haven't been able to reason about it documentationally.

This does fix my problems but since I'm not really sure what the scope of fix should be, any feedback is welcome. Thanks in advance!

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
