### PR TITLE
fix: Don't join info path with root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- fix: Don't join info path with root ([#418](https://github.com/evilmartians/lefthook/pull/418)) by @mrexox
+
 ## 1.2.7 (2023-01-10)
 
 - fix: Make info dir when it is absent ([#414](https://github.com/evilmartians/lefthook/pull/414)) by @sato11

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -49,7 +49,7 @@ func NewRepository(fs afero.Fs) (*Repository, error) {
 	if err != nil {
 		return nil, err
 	}
-	infoPath = filepath.Join(rootPath, infoPath)
+	infoPath = filepath.Clean(infoPath)
 	if exists, _ := afero.DirExists(fs, infoPath); !exists {
 		err = fs.Mkdir(infoPath, infoDirMode)
 		if err != nil {


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/417

**:wrench: Summary**

When repo is added as a worktree, its info path is absolute, but when not, it is relative. So, just `Clean`-ing the path to make sure it is correctly interpreted.