### PR TITLE
fix: Use correct branch for {push_files} template

### DIFF
--- a/internal/git/exec.go
+++ b/internal/git/exec.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/evilmartians/lefthook/internal/log"
 )
 
 type Exec interface {
@@ -56,10 +58,14 @@ func (o *OsExec) RawCmd(cmd string) (string, error) {
 // rawExecArgs executes git command with LEFTHOOK=0 in order
 // to prevent calling subsequent lefthook hooks.
 func (o *OsExec) rawExecArgs(args ...string) (string, error) {
+	log.Debug("[lefthook] cmd: ", args)
+
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Env = append(os.Environ(), "LEFTHOOK=0")
 
 	out, err := cmd.CombinedOutput()
+	log.Debug("[lefthook] err: ", err)
+	log.Debug("[lefthook] out: ", string(out))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/374

**:wrench: Summary**

- Try using @{push}
- If it doesn't work - find out the branch name looking at remote's HEAD and use it