### PR TITLE
fix: Allow sh syntax in files

### DIFF
--- a/internal/git/exec.go
+++ b/internal/git/exec.go
@@ -65,7 +65,7 @@ func (o *OsExec) RawCmd(cmd string) (string, error) {
 // rawExecArgs executes git command with LEFTHOOK=0 in order
 // to prevent calling subsequent lefthook hooks.
 func (o *OsExec) rawExecArgs(args ...string) (string, error) {
-	log.Debugf("[lefthook] cmd: %v", args)
+	log.Debug("[lefthook] cmd: ", args)
 
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Env = append(os.Environ(), "LEFTHOOK=0")

--- a/internal/git/exec.go
+++ b/internal/git/exec.go
@@ -3,6 +3,7 @@ package git
 import (
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/evilmartians/lefthook/internal/log"
@@ -51,14 +52,20 @@ func (o *OsExec) CmdArgs(args ...string) (string, error) {
 
 // RawCmd runs a plain string command returning unprocessed output as string.
 func (o *OsExec) RawCmd(cmd string) (string, error) {
-	args := strings.Split(cmd, " ")
+	var args []string
+	if runtime.GOOS == "windows" {
+		args = strings.Split(cmd, " ")
+	} else {
+		args = []string{"sh", "-c", cmd}
+	}
+
 	return o.rawExecArgs(args...)
 }
 
 // rawExecArgs executes git command with LEFTHOOK=0 in order
 // to prevent calling subsequent lefthook hooks.
 func (o *OsExec) rawExecArgs(args ...string) (string, error) {
-	log.Debug("[lefthook] cmd: ", args)
+	log.Debugf("[lefthook] cmd: %v", args)
 
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Env = append(os.Environ(), "LEFTHOOK=0")


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/433

**:wrench: Summary**

- [x] Allow `git --diff | grep ...` and other sh syntax in `files` option (works for *nix systems only)
