### PR TITLE
Fix template for non-gzipped MacOS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ archives:
       {{ .ProjectName }}_
       {{- .Version }}_
       {{- if eq .Os "darwin" }}MacOS
-      {{- else }}{{ title .Os }}_{{ end }}
+      {{- else }}{{ title .Os }}{{ end }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{ end }}
   - id: lefthook-gz


### PR DESCRIPTION
Non .gz artefacts are missing `_` in between OS and arch. eg. [here](https://github.com/evilmartians/lefthook/releases/tag/v1.3.1)

lefthook_1.3.1_MacOSarm64
lefthook_1.3.1_MacOSx86_64
lefthook_1.3.1_MacOS_arm64.gz
lefthook_1.3.1_MacOS_x86_64.gz

Closes # (issue)

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
