### PR TITLE
fix: stage fixed when root specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+- fix: stage fixed when root specified ([#449](https://github.com/evilmartians/lefthook/pull/449)) by @mrexox
 - feat: implitic skip on missing files for pre-commit and pre-push hooks ([#448](https://github.com/evilmartians/lefthook/pull/448)) by @mrexox
 
 ## 1.3.5 (2024-03-15)

--- a/internal/lefthook/runner/prepare_command.go
+++ b/internal/lefthook/runner/prepare_command.go
@@ -89,8 +89,6 @@ func (r *Runner) buildCommandArgs(command *config.Command) (*commandArgs, error,
 
 	if len(filteredFiles) == 0 && config.HookUsesStagedFiles(r.HookName) {
 		files, err := r.Repo.StagedFiles()
-		log.Infof("FILES: %#v\n", files)
-		log.Infof("FILES Prepared: %#v\n", prepareFiles(command, files))
 		if err == nil {
 			if len(prepareFiles(command, files)) == 0 {
 				return nil, nil, errors.New("no matching staged files")

--- a/internal/lefthook/runner/prepare_command.go
+++ b/internal/lefthook/runner/prepare_command.go
@@ -89,6 +89,8 @@ func (r *Runner) buildCommandArgs(command *config.Command) (*commandArgs, error,
 
 	if len(filteredFiles) == 0 && config.HookUsesStagedFiles(r.HookName) {
 		files, err := r.Repo.StagedFiles()
+		log.Infof("FILES: %#v\n", files)
+		log.Infof("FILES Prepared: %#v\n", prepareFiles(command, files))
 		if err == nil {
 			if len(prepareFiles(command, files)) == 0 {
 				return nil, nil, errors.New("no matching staged files")

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -299,9 +299,7 @@ func (r *Runner) runScript(script *config.Script, path string, file os.FileInfo)
 			return
 		}
 
-		if err := r.Repo.AddFiles(files); err != nil {
-			log.Warn("Couldn't stage fixed files:", err)
-		}
+		r.addStagedFiles(files)
 	}
 }
 
@@ -388,9 +386,13 @@ func (r *Runner) runCommand(name string, command *config.Command) {
 			}
 		}
 
-		if err := r.Repo.AddFiles(files); err != nil {
-			log.Warn("Couldn't stage fixed files:", err)
-		}
+		r.addStagedFiles(files)
+	}
+}
+
+func (r *Runner) addStagedFiles(files []string) {
+	if err := r.Repo.AddFiles(files); err != nil {
+		log.Warn("Couldn't stage fixed files:", err)
 	}
 }
 

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -382,6 +382,12 @@ func (r *Runner) runCommand(name string, command *config.Command) {
 			files = prepareFiles(command, stagedFiles)
 		}
 
+		if len(command.Root) > 0 {
+			for i, file := range files {
+				files[i] = filepath.Join(command.Root, file)
+			}
+		}
+
 		if err := r.Repo.AddFiles(files); err != nil {
 			log.Warn("Couldn't stage fixed files:", err)
 		}

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -62,7 +62,7 @@ func (g *GitMock) CmdLines(cmd string) ([]string, error) {
 		cmd == "git diff --name-only HEAD @{push}" {
 		root, _ := filepath.Abs("src")
 		return []string{
-			filepath.Join(root, "script.sh"),
+			filepath.Join(root, "scripts", "script.sh"),
 			filepath.Join(root, "README.md"),
 		}, nil
 	}
@@ -423,7 +423,7 @@ func TestRunAll(t *testing.T) {
 			existingFiles: []string{
 				filepath.Join(root, config.DefaultSourceDir, "pre-commit", "success.sh"),
 				filepath.Join(root, config.DefaultSourceDir, "pre-commit", "failing.js"),
-				filepath.Join(root, "script.sh"),
+				filepath.Join(root, "scripts", "script.sh"),
 				filepath.Join(root, "README.md"),
 			},
 			hook: &config.Hook{
@@ -489,6 +489,32 @@ func TestRunAll(t *testing.T) {
 				"git diff --name-only --cached --diff-filter=ACMR",
 				"git diff --name-only --cached --diff-filter=ACMR",
 				"git add .*README.md",
+				"git apply -v --whitespace=nowarn --recount --unidiff-zero ",
+				"git stash list",
+			},
+		},
+		{
+			name:     "pre-commit hook with stage_fixed under root",
+			hookName: "pre-commit",
+			existingFiles: []string{
+				filepath.Join(root, "scripts", "script.sh"),
+				filepath.Join(root, "README.md"),
+			},
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{
+					"ok": {
+						Run:        "success",
+						Root:       filepath.Join(root, "scripts"),
+						StageFixed: true,
+					},
+				},
+			},
+			success: []Result{{Name: "ok", Status: StatusOk}},
+			gitCommands: []string{
+				"git status --short",
+				"git diff --name-only --cached --diff-filter=ACMR",
+				"git diff --name-only --cached --diff-filter=ACMR",
+				"git add .*scripts.*script.sh",
 				"git apply -v --whitespace=nowarn --recount --unidiff-zero ",
 				"git stash list",
 			},


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/447

**:wrench: Summary**

- [x] Fix a special case for `root` option when calling `git add` - use full file path.