### PR TITLE
fix: don't fail on missing config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     target-branch: "dependencies"
-    open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
       day: "monday"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- fix: don't fail on missing config file ([#450](https://github.com/evilmartians/lefthook/pull/450)) by @mrexox
+
 ## 1.3.6 (2024-03-16)
 
 - fix: stage fixed when root specified ([#449](https://github.com/evilmartians/lefthook/pull/449)) by @mrexox

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -47,6 +47,12 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 	// Load config
 	cfg, err := config.Load(l.Fs, l.repo)
 	if err != nil {
+		var notFoundErr config.NotFoundError
+		if ok := errors.As(err, &notFoundErr); ok {
+			log.Warn(err.Error())
+			return nil
+		}
+
 		return err
 	}
 	if err = cfg.Validate(); err != nil {


### PR DESCRIPTION
Relates to https://github.com/evilmartians/lefthook/issues/212

**:wrench: Summary**

When there's no lefthook.yml we should't fail. No config == empty config (but still with a warning).