### PR TITLE
fix: make hook template compatible with shells without source command

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -7,7 +7,7 @@ fi
 {{- if .Rc}}
 {{/* Load rc file and export all ENV vars defined in it */}}
 set -a
-[ -f {{.Rc}} ] && source {{.Rc}}
+[ -f {{.Rc}} ] && . {{.Rc}}
 {{- end}}
 
 call_lefthook()


### PR DESCRIPTION
#### :zap: Summary

On Linux Ubuntu 22.04, `/bin/sh` doesn't support `source` command, so if you run this template you get an error like the following one:

```
> git commit -m wip
.git/hooks/pre-commit: 8: source: not found
```

Replacing `source` with `.` fixed it. Also, [`dot` seems to be the POSIX standard](https://stackoverflow.com/q/11588583).

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
