### PR TITLE
feat: allow extra hooks in local config

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -186,7 +186,8 @@ func unmarshalConfigs(base, extra *viper.Viper, c *Config) error {
 
 	// For extra non-git hooks.
 	// This behavior may be deprecated in next versions.
-	for _, maybeHook := range base.AllKeys() {
+	// Notice that with append we're allowing extra hooks to be added in local config
+	for _, maybeHook := range append(base.AllKeys(), extra.AllKeys()...) {
 		if !hookKeyRegexp.MatchString(maybeHook) {
 			continue
 		}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -181,6 +181,43 @@ lints:
 			},
 		},
 		{
+			name: "with extra hooks only in local config",
+			global: `
+tests:
+  commands:
+    tests:
+      run: go test ./...
+`,
+			local: `
+lints:
+  scripts:
+    "linter.sh":
+      runner: bash
+`,
+			result: &Config{
+				SourceDir:      DefaultSourceDir,
+				SourceDirLocal: DefaultSourceDirLocal,
+				Colors:         DefaultColorsEnabled,
+				Hooks: map[string]*Hook{
+					"tests": {
+						Parallel: false,
+						Commands: map[string]*Command{
+							"tests": {
+								Run: "go test ./...",
+							},
+						},
+					},
+					"lints": {
+						Scripts: map[string]*Script{
+							"linter.sh": {
+								Runner: "bash",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "with remote",
 			global: `
 remote:


### PR DESCRIPTION
Without this patch is not possible to define extra hooks in local config, e.g.

```yaml
# lefthook.yml
tests:
  commands:
    tests:
      run: go test ./...
```

and 

```yml
# lefthook-local.yml
lints:
  scripts:
    "linter.sh":
      runner: bash
```

Won't work, it wont be possible to run `lefthook run lints`

#### :zap: Summary

Iterate against both global and local top level keys when adding custom hooks.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
