### PR TITLE
feat: don't show when commands are skipped because of no matched files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,7 +111,7 @@ min_version: 1.1.3
 
 You can manage the verbosity using the `skip_output` config. You can set whether lefthook should print some parts of its output.
 
-Possible values are `meta,success,failure,summary,execution`.
+Possible values are `meta,success,failure,summary,execution,skip`.
 
 This config quiets all outputs except for errors.
 
@@ -126,6 +126,7 @@ skip_output:
   - success    # Skips successful steps printing
   - failure    # Skips failed steps printing
   - execution  # Skips printing successfully executed commands and their output (but still prints failed executions)
+  - skip       # Skips skip printing (ie no files matched)
 ```
 
 You can also *extend* this list with an environment variable `LEFTHOOK_QUIET`:

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -351,9 +351,9 @@ func (r *Runner) runCommands() {
 func (r *Runner) runCommand(name string, command *config.Command) {
 	args, err := r.prepareCommand(name, command)
 	if err != nil {
-    if (!(r.SkipSettings.SkipSkip() && err.Error() == "no files for inspection" || err.Error() == "no matching staged_files")) {
-      logSkip(name, err.Error())
-    }
+		if !(r.SkipSettings.SkipSkip() && err.Error() == "no files for inspection" || err.Error() == "no matching staged_files") {
+			logSkip(name, err.Error())
+		}
 		return
 	}
 

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -63,7 +63,7 @@ func (r *Runner) RunAll(sourceDirs []string) {
 	}
 
 	if r.Hook.Skip != nil && r.Hook.DoSkip(r.Repo.State()) {
-		logSkip(r.HookName, "hook setting")
+		r.logSkip(r.HookName, "hook setting")
 		return
 	}
 
@@ -229,12 +229,12 @@ func (r *Runner) runScripts(dir string) {
 	for _, file := range files {
 		script, ok := r.Hook.Scripts[file.Name()]
 		if !ok {
-			logSkip(file.Name(), "not specified in config file")
+			r.logSkip(file.Name(), "not specified in config file")
 			continue
 		}
 
 		if r.failed.Load() && r.Hook.Piped {
-			logSkip(file.Name(), "broken pipe")
+			r.logSkip(file.Name(), "broken pipe")
 			continue
 		}
 
@@ -261,7 +261,7 @@ func (r *Runner) runScripts(dir string) {
 	for _, file := range interactiveScripts {
 		script := r.Hook.Scripts[file.Name()]
 		if r.failed.Load() {
-			logSkip(file.Name(), "non-interactive scripts failed")
+			r.logSkip(file.Name(), "non-interactive scripts failed")
 			continue
 		}
 
@@ -274,7 +274,7 @@ func (r *Runner) runScripts(dir string) {
 func (r *Runner) runScript(script *config.Script, path string, file os.FileInfo) {
 	args, err := r.prepareScript(script, path, file)
 	if err != nil {
-		logSkip(file.Name(), err.Error())
+		r.logSkip(file.Name(), err.Error())
 		return
 	}
 
@@ -316,7 +316,7 @@ func (r *Runner) runCommands() {
 
 	for _, name := range commands {
 		if r.failed.Load() && r.Hook.Piped {
-			logSkip(name, "broken pipe")
+			r.logSkip(name, "broken pipe")
 			continue
 		}
 
@@ -340,7 +340,7 @@ func (r *Runner) runCommands() {
 
 	for _, name := range interactiveCommands {
 		if r.failed.Load() {
-			logSkip(name, "non-interactive commands failed")
+			r.logSkip(name, "non-interactive commands failed")
 			continue
 		}
 
@@ -351,10 +351,7 @@ func (r *Runner) runCommands() {
 func (r *Runner) runCommand(name string, command *config.Command) {
 	args, err := r.prepareCommand(name, command)
 	if err != nil {
-		if r.SkipSettings.SkipSkips() && (err.Error() == "no files for inspection" || err.Error() == "no matching staged_files") {
-			return
-		}
-		logSkip(name, err.Error())
+		r.logSkip(name, err.Error())
 		return
 	}
 
@@ -456,7 +453,11 @@ func intersect(a, b []string) bool {
 	return false
 }
 
-func logSkip(name, reason string) {
+func (r *Runner) logSkip(name, reason string) {
+	if r.SkipSettings.SkipSkips() {
+		return
+	}
+
 	log.Info(
 		fmt.Sprintf(
 			"%s: %s %s",

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -351,9 +351,10 @@ func (r *Runner) runCommands() {
 func (r *Runner) runCommand(name string, command *config.Command) {
 	args, err := r.prepareCommand(name, command)
 	if err != nil {
-		if !(r.SkipSettings.SkipSkip() && err.Error() == "no files for inspection" || err.Error() == "no matching staged_files") {
-			logSkip(name, err.Error())
+		if r.SkipSettings.SkipSkips() && (err.Error() == "no files for inspection" || err.Error() == "no matching staged_files") {
+			return
 		}
+		logSkip(name, err.Error())
 		return
 	}
 

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -351,7 +351,9 @@ func (r *Runner) runCommands() {
 func (r *Runner) runCommand(name string, command *config.Command) {
 	args, err := r.prepareCommand(name, command)
 	if err != nil {
-		logSkip(name, err.Error())
+    if (!(r.SkipSettings.SkipSkip() && err.Error() == "no files for inspection" || err.Error() == "no matching staged_files")) {
+      logSkip(name, err.Error())
+    }
 		return
 	}
 

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -6,7 +6,7 @@ const (
 	skipFailure
 	skipSummary
 	skipExecution
-  skipSkip
+	skipSkip
 )
 
 type SkipSettings int8
@@ -21,8 +21,8 @@ func (s *SkipSettings) ApplySetting(setting string) {
 		*s |= skipFailure
 	case "summary":
 		*s |= skipSummary
-  case "skip":
-    *s |= skipSkip
+	case "skip":
+		*s |= skipSkip
 	case "execution":
 		*s |= skipExecution
 	}
@@ -49,7 +49,7 @@ func (s SkipSettings) SkipExecution() bool {
 }
 
 func (s SkipSettings) SkipSkip() bool {
-  return s.doSkip(skipSkip)
+	return s.doSkip(skipSkip)
 }
 
 func (s SkipSettings) doSkip(option int8) bool {

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -6,7 +6,7 @@ const (
 	skipFailure
 	skipSummary
 	skipExecution
-	skipSkip
+	skipSkips
 )
 
 type SkipSettings int8
@@ -21,8 +21,8 @@ func (s *SkipSettings) ApplySetting(setting string) {
 		*s |= skipFailure
 	case "summary":
 		*s |= skipSummary
-	case "skip":
-		*s |= skipSkip
+	case "skips":
+		*s |= skipSkips
 	case "execution":
 		*s |= skipExecution
 	}
@@ -48,8 +48,8 @@ func (s SkipSettings) SkipExecution() bool {
 	return s.doSkip(skipExecution)
 }
 
-func (s SkipSettings) SkipSkip() bool {
-	return s.doSkip(skipSkip)
+func (s SkipSettings) SkipSkips() bool {
+	return s.doSkip(skipSkips)
 }
 
 func (s SkipSettings) doSkip(option int8) bool {

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -6,6 +6,7 @@ const (
 	skipFailure
 	skipSummary
 	skipExecution
+  skipSkip
 )
 
 type SkipSettings int8
@@ -20,6 +21,8 @@ func (s *SkipSettings) ApplySetting(setting string) {
 		*s |= skipFailure
 	case "summary":
 		*s |= skipSummary
+  case "skip":
+    *s |= skipSkip
 	case "execution":
 		*s |= skipExecution
 	}
@@ -43,6 +46,10 @@ func (s SkipSettings) SkipMeta() bool {
 
 func (s SkipSettings) SkipExecution() bool {
 	return s.doSkip(skipExecution)
+}
+
+func (s SkipSettings) SkipSkip() bool {
+  return s.doSkip(skipSkip)
 }
 
 func (s SkipSettings) doSkip(option int8) bool {


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/discussions/467

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

If you have lots of commands, and make small commits, you'll often see a lot of skipped commands:

```
sorbet: (SKIP. NO FILES FOR INSPECTION)
stylelint: (SKIP. NO FILES FOR INSPECTION)
codeowners: (SKIP. NO FILES FOR INSPECTION)
authorization: (SKIP. NO FILES FOR INSPECTION)
svgo: (SKIP. NO FILES FOR INSPECTION)
syncpack: (SKIP. NO FILES FOR INSPECTION)
eslint: (SKIP. NO FILES FOR INSPECTION)
packwerk: (SKIP. NO FILES FOR INSPECTION)
rubocop: (SKIP. NO FILES FOR INSPECTION)
```

I wanted a way to skip this. I'm migrating from a home grown hook runner, and it had pretty concise output that I'm trying to recreate. I was able to do that with most of the other options, but still had this output.

I apologize in advance, this is my first go contribution to anything 🤪 

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
