### PR TITLE
chore: debugs

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -150,7 +150,6 @@ func mergeRemote(fs afero.Fs, repo *git.Repository, v *viper.Viper) error {
 
 // extend merges all files listed in 'extends' option into the config.
 func extend(v *viper.Viper, root string) error {
-	log.Debugf("extends %v\n", v.GetStringSlice("extends"))
 	for i, path := range v.GetStringSlice("extends") {
 		if !filepath.IsAbs(path) {
 			path = filepath.Join(root, path)

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -99,6 +99,7 @@ Run 'lefthook install' manually.`,
 	// Find the hook
 	hook, ok := cfg.Hooks[hookName]
 	if !ok {
+		log.Debugf("[lefthook] skip: Hook %s doesn't exist in the config", hookName)
 		return nil
 	}
 	if err := hook.Validate(); err != nil {


### PR DESCRIPTION
Add a debug log when hook is being skipped because it doesn't exist in a config file.