### PR TITLE
feat: add execution_out to skip output settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,7 +111,7 @@ min_version: 1.1.3
 
 You can manage the verbosity using the `skip_output` config. You can set whether lefthook should print some parts of its output.
 
-Possible values are `meta,success,failure,summary,execution,skips`.
+Possible values are `meta,success,failure,summary,execution,execution_out,skips`.
 
 This config quiets all outputs except for errors.
 
@@ -121,12 +121,13 @@ This config quiets all outputs except for errors.
 # lefthook.yml
 
 skip_output:
-  - meta       # Skips lefthook version printing
-  - summary    # Skips summary block (successful and failed steps) printing
-  - success    # Skips successful steps printing
-  - failure    # Skips failed steps printing
-  - execution  # Skips printing successfully executed commands and their output (but still prints failed executions)
-  - skips      # Skips "skip" printing (i.e. no files matched)
+  - meta          # Skips lefthook version printing
+  - summary       # Skips summary block (successful and failed steps) printing
+  - success       # Skips successful steps printing
+  - failure       # Skips failed steps printing
+  - execution     # Skips printing successfully executed commands and their output (but still prints failed executions)
+  - execution_out # Skips printing commands output (but still prints failed commands output)
+  - skips         # Skips "skip" printing (i.e. no files matched)
 ```
 
 You can also *extend* this list with an environment variable `LEFTHOOK_QUIET`:

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	envEnabled    = "LEFTHOOK"         // "0", "false"
-	envSkipOutput = "LEFTHOOK_QUIET"   // "meta,success,failure,summary,execution"
+	envSkipOutput = "LEFTHOOK_QUIET"   // "meta,success,failure,summary,execution,execution_out,skips"
 	envVerbose    = "LEFTHOOK_VERBOSE" // keep all output
 )
 

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -427,7 +427,12 @@ func (r *Runner) run(opts ExecuteOptions, follow bool) bool {
 		return false
 	}
 
-	log.Infof("%s\n%s", execName, out)
+	if r.SkipSettings.SkipExecutionOutput() {
+		log.Infof("%s\n", execName)
+	} else {
+		log.Infof("%s\n%s", execName, out)
+	}
+
 	if err != nil {
 		log.Infof("%s", err)
 	}

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -6,10 +6,11 @@ const (
 	skipFailure
 	skipSummary
 	skipExecution
+	skipExecutionOutput
 	skipSkips
 )
 
-type SkipSettings int8
+type SkipSettings int16
 
 func (s *SkipSettings) ApplySetting(setting string) {
 	switch setting {
@@ -25,6 +26,8 @@ func (s *SkipSettings) ApplySetting(setting string) {
 		*s |= skipSkips
 	case "execution":
 		*s |= skipExecution
+	case "execution_out":
+		*s |= skipExecutionOutput
 	}
 }
 
@@ -48,10 +51,14 @@ func (s SkipSettings) SkipExecution() bool {
 	return s.doSkip(skipExecution)
 }
 
+func (s SkipSettings) SkipExecutionOutput() bool {
+	return s.doSkip(skipExecutionOutput)
+}
+
 func (s SkipSettings) SkipSkips() bool {
 	return s.doSkip(skipSkips)
 }
 
-func (s SkipSettings) doSkip(option int8) bool {
-	return int8(s)&option != 0
+func (s SkipSettings) doSkip(option int16) bool {
+	return int16(s)&option != 0
 }

--- a/internal/log/skip_settings_test.go
+++ b/internal/log/skip_settings_test.go
@@ -22,13 +22,15 @@ func TestSkipSetting(t *testing.T) {
 			},
 		},
 		{
-			settings: []string{"meta", "summary", "success", "failure", "execution"},
+			settings: []string{"meta", "summary", "success", "failure", "execution", "execution_out", "skips"},
 			results: map[string]bool{
-				"meta":      true,
-				"summary":   true,
-				"success":   true,
-				"failure":   true,
-				"execution": true,
+				"meta":          true,
+				"summary":       true,
+				"success":       true,
+				"failure":       true,
+				"execution":     true,
+				"execution_out": true,
+				"skips":         true,
 			},
 		},
 	} {
@@ -57,6 +59,14 @@ func TestSkipSetting(t *testing.T) {
 
 			if settings.SkipExecution() != tt.results["execution"] {
 				t.Errorf("expected SkipExecution to be %v", tt.results["execution"])
+			}
+
+			if settings.SkipExecutionOutput() != tt.results["execution_out"] {
+				t.Errorf("expected SkipExecutionOutput to be %v", tt.results["execution_out"])
+			}
+
+			if settings.SkipSkips() != tt.results["skips"] {
+				t.Errorf("expected SkipSkips to be %v", tt.results["skip"])
 			}
 		})
 	}


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/473

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Adds `execution_out` to `skip_output` setting (or LEFTHOOK_QUIET)

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
