### PR TITLE
fix: allow skipping execution_out with interactive mode

### DIFF
--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -402,12 +403,21 @@ func (r *Runner) run(opts ExecuteOptions, follow bool) bool {
 
 	if (follow || opts.interactive) && !r.SkipSettings.SkipExecution() {
 		log.Info(log.Cyan("\n  EXECUTE > "), log.Bold(opts.name))
-		err := r.executor.Execute(opts, os.Stdout)
+
+		var out io.Writer
+		if r.SkipSettings.SkipExecutionOutput() {
+			out = io.Discard
+		} else {
+			out = os.Stdout
+		}
+
+		err := r.executor.Execute(opts, out)
 		if err != nil {
 			r.fail(opts.name, opts.failText)
 		} else {
 			r.success(opts.name)
 		}
+
 		return err == nil
 	}
 


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/473

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Make sure that command names are displayed when skipping `execution_out` with `follow`/`interactive` mode

