### PR TITLE
feat: add only option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@
   - [`config`](#config)
 - [Hook](#git-hook)
   - [`skip`](#skip)
+  - [`only`](#only)
   - [`files`](#files-global)
   - [`parallel`](#parallel)
   - [`piped`](#piped)
@@ -25,6 +26,7 @@
 - [Command](#command)
   - [`run`](#run)
   - [`skip`](#skip)
+  - [`only`](#only)
   - [`tags`](#tags)
   - [`glob`](#glob)
   - [`files`](#files)
@@ -37,6 +39,7 @@
 - [Script](#script)
   - [`runner`](#runner)
   - [`skip`](#skip)
+  - [`only`](#only)
   - [`tags`](#tags)
   - [`env`](#env)
   - [`fail_text`](#fail_text)
@@ -716,6 +719,49 @@ pre-commit:
   commands:
     lint:
       skip: true
+```
+
+### `only`
+
+You can force a command, script, or the whole hook to execute only in certain conditions. This option acts like the opposite of [`skip`](#skip). It accepts the same values but skips execution only if the condition is not satisfied.
+
+**Note**
+
+`skip` option takes precedence over `only` option, so if you have conflicting conditions the execution will be skipped.
+
+**Example**
+
+Execute a hook only for `dev/*` branches.
+
+```yml
+# lefthook.yml
+
+pre-commit:
+  only:
+    - ref: dev/*
+  commands:
+    lint:
+      run: yarn lint
+    test:
+      run: yarn test
+```
+
+When rebasing execute quick linter but skip usual linter and tests.
+
+```yml
+# lefthook.yml
+
+pre-commit:
+  commands:
+    lint:
+      skip: rebase
+      run: yarn lint
+    test:
+      skip: rebase
+      run: yarn test
+    lint-on-rebase:
+      only: rebase
+      run: yarn lint-quickly
 ```
 
 ### `tags`

--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -15,6 +15,7 @@ type Command struct {
 	Run string `mapstructure:"run"`
 
 	Skip  interface{}       `mapstructure:"skip"`
+	Only  interface{}       `mapstructure:"only"`
 	Tags  []string          `mapstructure:"tags"`
 	Glob  string            `mapstructure:"glob"`
 	Files string            `mapstructure:"files"`
@@ -37,10 +38,18 @@ func (c Command) Validate() error {
 }
 
 func (c Command) DoSkip(gitState git.State) bool {
+	var doSkip bool
 	if value := c.Skip; value != nil {
-		return isSkip(gitState, value)
+		doSkip = isSkip(gitState, value)
 	}
-	return false
+	if doSkip {
+		return true
+	}
+
+	if value := c.Only; value != nil {
+		doSkip = !isSkip(gitState, value)
+	}
+	return doSkip
 }
 
 type commandRunReplace struct {

--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -38,18 +38,7 @@ func (c Command) Validate() error {
 }
 
 func (c Command) DoSkip(gitState git.State) bool {
-	var doSkip bool
-	if value := c.Skip; value != nil {
-		doSkip = isSkip(gitState, value)
-	}
-	if doSkip {
-		return true
-	}
-
-	if value := c.Only; value != nil {
-		doSkip = !isSkip(gitState, value)
-	}
-	return doSkip
+	return doSkip(gitState, c.Skip, c.Only)
 }
 
 type commandRunReplace struct {

--- a/internal/config/hook.go
+++ b/internal/config/hook.go
@@ -43,18 +43,7 @@ func (h *Hook) Validate() error {
 }
 
 func (h *Hook) DoSkip(gitState git.State) bool {
-	var doSkip bool
-	if value := h.Skip; value != nil {
-		doSkip = isSkip(gitState, value)
-	}
-	if doSkip {
-		return true
-	}
-
-	if value := h.Only; value != nil {
-		doSkip = !isSkip(gitState, value)
-	}
-	return doSkip
+	return doSkip(gitState, h.Skip, h.Only)
 }
 
 func unmarshalHooks(base, extra *viper.Viper) (*Hook, error) {

--- a/internal/config/hook.go
+++ b/internal/config/hook.go
@@ -30,6 +30,7 @@ type Hook struct {
 	Piped       bool        `mapstructure:"piped"`
 	ExcludeTags []string    `mapstructure:"exclude_tags"`
 	Skip        interface{} `mapstructure:"skip"`
+	Only        interface{} `mapstructure:"only"`
 	Follow      bool        `mapstructure:"follow"`
 }
 
@@ -42,10 +43,18 @@ func (h *Hook) Validate() error {
 }
 
 func (h *Hook) DoSkip(gitState git.State) bool {
+	var doSkip bool
 	if value := h.Skip; value != nil {
-		return isSkip(gitState, value)
+		doSkip = isSkip(gitState, value)
 	}
-	return false
+	if doSkip {
+		return true
+	}
+
+	if value := h.Only; value != nil {
+		doSkip = !isSkip(gitState, value)
+	}
+	return doSkip
 }
 
 func unmarshalHooks(base, extra *viper.Viper) (*Hook, error) {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -97,7 +97,7 @@ pre-commit:
       run: docker exec -it ruby:2.7 {cmd}
   scripts:
     "format.sh":
-      skip: true
+      only: true
 
 pre-push:
   commands:
@@ -128,7 +128,7 @@ pre-push:
 						},
 						Scripts: map[string]*Script{
 							"format.sh": {
-								Skip:   true,
+								Only:   true,
 								Runner: "bash",
 							},
 						},
@@ -265,7 +265,7 @@ remote:
   config: examples/custom.yml
 
 pre-commit:
-  skip:
+  only:
     - ref: main
   commands:
     global:
@@ -277,11 +277,14 @@ pre-commit:
 pre-commit:
   commands:
     lint:
-      run: yarn lint
-      skip:
+      only:
         - merge
+        - rebase
+      run: yarn lint
   scripts:
     "test.sh":
+      skip:
+        - merge
       runner: bash
 `,
 			remoteConfigPath: filepath.Join(root, ".git", "info", "lefthook-remotes", "lefthook", "examples", "custom.yml"),
@@ -296,11 +299,11 @@ pre-commit:
 				},
 				Hooks: map[string]*Hook{
 					"pre-commit": {
-						Skip: []interface{}{map[string]interface{}{"ref": "main"}},
+						Only: []interface{}{map[string]interface{}{"ref": "main"}},
 						Commands: map[string]*Command{
 							"lint": {
 								Run:  "yarn lint",
-								Skip: []interface{}{"merge"},
+								Only: []interface{}{"merge", "rebase"},
 							},
 							"global": {
 								Run: "echo 'Global!'",
@@ -309,6 +312,7 @@ pre-commit:
 						Scripts: map[string]*Script{
 							"test.sh": {
 								Runner: "bash",
+								Skip:   []interface{}{"merge"},
 							},
 						},
 					},

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -23,18 +23,7 @@ type Script struct {
 }
 
 func (s Script) DoSkip(gitState git.State) bool {
-	var doSkip bool
-	if value := s.Skip; value != nil {
-		doSkip = isSkip(gitState, value)
-	}
-	if doSkip {
-		return true
-	}
-
-	if value := s.Only; value != nil {
-		doSkip = !isSkip(gitState, value)
-	}
-	return doSkip
+	return doSkip(gitState, s.Skip, s.Only)
 }
 
 type scriptRunnerReplace struct {

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -13,6 +13,7 @@ type Script struct {
 	Runner string `mapstructure:"runner"`
 
 	Skip interface{}       `mapstructure:"skip"`
+	Only interface{}       `mapstructure:"only"`
 	Tags []string          `mapstructure:"tags"`
 	Env  map[string]string `mapstructure:"env"`
 
@@ -22,10 +23,18 @@ type Script struct {
 }
 
 func (s Script) DoSkip(gitState git.State) bool {
+	var doSkip bool
 	if value := s.Skip; value != nil {
-		return isSkip(gitState, value)
+		doSkip = isSkip(gitState, value)
 	}
-	return false
+	if doSkip {
+		return true
+	}
+
+	if value := s.Only; value != nil {
+		doSkip = !isSkip(gitState, value)
+	}
+	return doSkip
 }
 
 type scriptRunnerReplace struct {

--- a/internal/config/skip.go
+++ b/internal/config/skip.go
@@ -6,7 +6,21 @@ import (
 	"github.com/evilmartians/lefthook/internal/git"
 )
 
-func isSkip(gitState git.State, value interface{}) bool {
+func doSkip(gitState git.State, skip, only interface{}) bool {
+	if skip != nil {
+		if matches(gitState, skip) {
+			return true
+		}
+	}
+
+	if only != nil {
+		return !matches(gitState, only)
+	}
+
+	return false
+}
+
+func matches(gitState git.State, value interface{}) bool {
 	switch typedValue := value.(type) {
 	case bool:
 		return typedValue

--- a/internal/lefthook/runner/prepare_command.go
+++ b/internal/lefthook/runner/prepare_command.go
@@ -17,7 +17,7 @@ type commandArgs struct {
 }
 
 func (r *Runner) prepareCommand(name string, command *config.Command) (*commandArgs, error) {
-	if command.Skip != nil && command.DoSkip(r.Repo.State()) {
+	if command.DoSkip(r.Repo.State()) {
 		return nil, errors.New("settings")
 	}
 

--- a/internal/lefthook/runner/prepare_script.go
+++ b/internal/lefthook/runner/prepare_script.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (r *Runner) prepareScript(script *config.Script, path string, file os.FileInfo) ([]string, error) {
-	if script.Skip != nil && script.DoSkip(r.Repo.State()) {
+	if script.DoSkip(r.Repo.State()) {
 		return nil, errors.New("settings")
 	}
 

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -63,7 +63,7 @@ func (r *Runner) RunAll(sourceDirs []string) {
 		log.Error(err)
 	}
 
-	if r.Hook.Skip != nil && r.Hook.DoSkip(r.Repo.State()) {
+	if r.Hook.DoSkip(r.Repo.State()) {
 		r.logSkip(r.HookName, "hook setting")
 		return
 	}

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -229,6 +229,46 @@ func TestRunAll(t *testing.T) {
 			success: []Result{{Name: "lint", Status: StatusOk}},
 		},
 		{
+			name:     "with only on merge",
+			hookName: "post-commit",
+			existingFiles: []string{
+				filepath.Join(gitPath, "MERGE_HEAD"),
+			},
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{
+					"test": {
+						Run:  "success",
+						Only: "merge",
+					},
+					"lint": {
+						Run: "success",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{
+				{Name: "lint", Status: StatusOk},
+				{Name: "test", Status: StatusOk},
+			},
+		},
+		{
+			name:     "with only on merge",
+			hookName: "post-commit",
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{
+					"test": {
+						Run:  "success",
+						Only: "merge",
+					},
+					"lint": {
+						Run: "success",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{{Name: "lint", Status: StatusOk}},
+		},
+		{
 			name:     "with global skip merge",
 			hookName: "post-commit",
 			existingFiles: []string{
@@ -247,6 +287,46 @@ func TestRunAll(t *testing.T) {
 				Scripts: map[string]*config.Script{},
 			},
 			success: []Result{},
+		},
+		{
+			name:     "with global only on merge",
+			hookName: "post-commit",
+			hook: &config.Hook{
+				Only: "merge",
+				Commands: map[string]*config.Command{
+					"test": {
+						Run: "success",
+					},
+					"lint": {
+						Run: "success",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{},
+		},
+		{
+			name:     "with global only on merge",
+			hookName: "post-commit",
+			existingFiles: []string{
+				filepath.Join(gitPath, "MERGE_HEAD"),
+			},
+			hook: &config.Hook{
+				Only: "merge",
+				Commands: map[string]*config.Command{
+					"test": {
+						Run: "success",
+					},
+					"lint": {
+						Run: "success",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{
+				{Name: "lint", Status: StatusOk},
+				{Name: "test", Status: StatusOk},
+			},
 		},
 		{
 			name:     "with skip rebase and merge in an array",
@@ -278,6 +358,51 @@ func TestRunAll(t *testing.T) {
 			hookName: "post-commit",
 			hook: &config.Hook{
 				Skip: []interface{}{"merge", map[string]interface{}{"ref": "main"}},
+				Commands: map[string]*config.Command{
+					"test": {
+						Run: "success",
+					},
+					"lint": {
+						Run: "success",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{},
+		},
+		{
+			name:   "with global only on ref",
+			branch: "main",
+			existingFiles: []string{
+				filepath.Join(gitPath, "HEAD"),
+			},
+			hookName: "post-commit",
+			hook: &config.Hook{
+				Only: []interface{}{"merge", map[string]interface{}{"ref": "main"}},
+				Commands: map[string]*config.Command{
+					"test": {
+						Run: "success",
+					},
+					"lint": {
+						Run: "success",
+					},
+				},
+				Scripts: map[string]*config.Script{},
+			},
+			success: []Result{
+				{Name: "lint", Status: StatusOk},
+				{Name: "test", Status: StatusOk},
+			},
+		},
+		{
+			name:   "with global only on ref",
+			branch: "develop",
+			existingFiles: []string{
+				filepath.Join(gitPath, "HEAD"),
+			},
+			hookName: "post-commit",
+			hook: &config.Hook{
+				Only: []interface{}{"merge", map[string]interface{}{"ref": "main"}},
 				Commands: map[string]*config.Command{
 					"test": {
 						Run: "success",
@@ -350,6 +475,57 @@ func TestRunAll(t *testing.T) {
 			},
 			success: []Result{{Name: "script.sh", Status: StatusOk}},
 			fail:    []Result{{Name: "failing.js", Status: StatusErr, Text: "install node"}},
+		},
+		{
+			name:       "with simple scripts and only option",
+			sourceDirs: []string{filepath.Join(root, config.DefaultSourceDir)},
+			existingFiles: []string{
+				filepath.Join(root, config.DefaultSourceDir, "post-commit", "script.sh"),
+				filepath.Join(root, config.DefaultSourceDir, "post-commit", "failing.js"),
+				filepath.Join(gitPath, "MERGE_HEAD"),
+			},
+			hookName: "post-commit",
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{},
+				Scripts: map[string]*config.Script{
+					"script.sh": {
+						Runner: "success",
+						Only:   "merge",
+					},
+					"failing.js": {
+						Only:     "merge",
+						Runner:   "fail",
+						FailText: "install node",
+					},
+				},
+			},
+			success: []Result{{Name: "script.sh", Status: StatusOk}},
+			fail:    []Result{{Name: "failing.js", Status: StatusErr, Text: "install node"}},
+		},
+		{
+			name:       "with simple scripts and only option",
+			sourceDirs: []string{filepath.Join(root, config.DefaultSourceDir)},
+			existingFiles: []string{
+				filepath.Join(root, config.DefaultSourceDir, "post-commit", "script.sh"),
+				filepath.Join(root, config.DefaultSourceDir, "post-commit", "failing.js"),
+			},
+			hookName: "post-commit",
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{},
+				Scripts: map[string]*config.Script{
+					"script.sh": {
+						Only:   "merge",
+						Runner: "success",
+					},
+					"failing.js": {
+						Only:     "merge",
+						Runner:   "fail",
+						FailText: "install node",
+					},
+				},
+			},
+			success: []Result{},
+			fail:    []Result{},
 		},
 		{
 			name:       "with interactive and parallel",


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/477

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Add `only` option to hook, command, and script which acts as the opposite of `skip` option.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests to runner_test.go
- [x] Add tests to load_test.go
- [x] Add docs
