### PR TITLE
Skip output for interactive commands

### DIFF
--- a/internal/lefthook/runner/execute_unix.go
+++ b/internal/lefthook/runner/execute_unix.go
@@ -47,7 +47,7 @@ func (e CommandExecutor) Execute(opts ExecuteOptions, out io.Writer) error {
 	command.Env = append(os.Environ(), envList...)
 
 	if opts.interactive {
-		command.Stdout = os.Stdout
+		command.Stdout = out
 		command.Stdin = stdin
 		command.Stderr = os.Stderr
 		err := command.Start()

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -402,7 +402,7 @@ func (r *Runner) run(opts ExecuteOptions, follow bool) bool {
 	defer log.UnsetName(opts.name)
 
 	if (follow || opts.interactive) && !r.SkipSettings.SkipExecution() {
-		log.Info(log.Cyan("\n  EXECUTE > "), log.Bold(opts.name))
+		log.Info(log.Cyan("\n  EXECUTE >"), log.Bold(opts.name))
 
 		var out io.Writer
 		if r.SkipSettings.SkipExecutionOutput() {


### PR DESCRIPTION
**:wrench: Summary**

When using `interactive` the commands and scripts actually output to STDOUT even if `execution_out` is passed to `skip_oputput` options. This PR fixes it.