### PR TITLE
Don't render bold ANSI sequence when colors are disabled

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -193,6 +193,10 @@ func Gray(s string) string {
 }
 
 func Bold(s string) string {
+	if !std.colors {
+		return lipgloss.NewStyle().Render(s)
+	}
+
 	return lipgloss.NewStyle().Bold(true).Render(s)
 }
 


### PR DESCRIPTION
When providing the `--no-colors` or `colors: false` options to Lefthook, it will still render an ANSI
sequence for bold, causing noise in the terminal.

Before
```
Lefthook v1.4.1
RUNNING HOOK: ^[[1mpre-commit^[[0m
^[[1mstandardrb^[[0m: (skip) no matching staged files

SUMMARY: (SKIP EMPTY)
```

After
```
Lefthook v1.4.3
RUNNING HOOK: pre-commit
standardrb: (skip) no matching staged files

SUMMARY: (SKIP EMPTY)
```

#### :zap: Summary

Add a similar check for `std.colors` to the `Bold` function.

#### :ballot_box_with_check: Checklist

- [X] Check locally
- [ ] Add tests
