### PR TITLE
Improve hook template

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -43,7 +43,7 @@ call_lefthook()
   elif pnpm lefthook -h >/dev/null 2>&1
   then
     pnpm lefthook "$@"
-  elif npx @evilmartians/lefthook -h >/dev/null 2>&1
+  elif command -v npx >/dev/null 2>&1
   then
     npx @evilmartians/lefthook "$@"
   else

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -13,8 +13,8 @@ set -a
 call_lefthook()
 {
   dir="$(git rev-parse --show-toplevel)"
-  osArch=$(echo "$(uname)" | tr '[:upper:]' '[:lower:]')
-  cpuArch=$(echo "$(uname -m)" | sed 's/aarch64/arm64/')
+  osArch=$(uname | tr '[:upper:]' '[:lower:]')
+  cpuArch=$(uname -m | sed 's/aarch64/arm64/')
 
   if lefthook{{.Extension}} -h >/dev/null 2>&1
   then

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -18,37 +18,37 @@ call_lefthook()
 
   if lefthook{{.Extension}} -h >/dev/null 2>&1
   then
-    eval lefthook{{.Extension}} $@
+    lefthook{{.Extension}} "$@"
   {{if .Extension -}}
   {{/* Check if lefthook.bat exists. Ruby bundler creates such a wrapper */ -}}
   elif lefthook.bat -h >/dev/null 2>&1
   then
-    eval lefthook.bat $@
+    lefthook.bat "$@"
   {{end -}}
   elif test -f "$dir/node_modules/lefthook/bin/index.js"
   then
-    eval "\"$dir/node_modules/lefthook/bin/index.js\" $@"
+    "$dir/node_modules/lefthook/bin/index.js" "$@"
   elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
   then
-    eval "\"$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}\" $@"
+    "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
   elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
   then
-    eval "\"$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}\" $@"
+    "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
   elif bundle exec lefthook -h >/dev/null 2>&1
   then
-    bundle exec lefthook $@
+    bundle exec lefthook "$@"
   elif yarn lefthook -h >/dev/null 2>&1
   then
-    yarn lefthook $@
+    yarn lefthook "$@"
   elif pnpm lefthook -h >/dev/null 2>&1
   then
-    pnpm lefthook $@
+    pnpm lefthook "$@"
   elif npx @evilmartians/lefthook -h >/dev/null 2>&1
   then
-    npx @evilmartians/lefthook $@
+    npx @evilmartians/lefthook "$@"
   else
     echo "Can't find lefthook in PATH"
   fi
 }
 
-call_lefthook "run {{.HookName}} $@"
+call_lefthook run "{{.HookName}}" "$@"


### PR DESCRIPTION
Related to #510

#### :zap: Summary

This improves `hook.tmpl` by removing extra work and fixing subtle bugs in passing arguments with whitespace.

- The first commit removes a useless echo (more info can be found [here](https://www.shellcheck.net/wiki/SC2116))
- The second commit removes all "eval" builtins as they are not necessary. `$@` has been quoted in all places as should be to properly preserve whitespace.
- The third commit partially solves #510. I think it is OK to assume that `@evilmartians/lefthook` will be executed if `npx` exists. Cases where it may not may include when a directory has incorrect permissions or the registry cannot be resolved - cases in which the user has a broken configuration already. It is more frustrating when it is artificially slow, especially since `npx` kind of slow by itself.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
