### PR TITLE
Improve documentation and examples

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,7 +134,7 @@ min_version: 1.1.3
 
 You can manage the verbosity using the `skip_output` config. You can set whether lefthook should print some parts of its output.
 
-Possible values are `meta,success,failure,summary,execution,execution_out,skips`.
+Possible values are `meta,summary,success,failure,execution,execution_out,execution_info,skips`.
 
 This config quiets all outputs except for errors.
 

--- a/examples/verbose/lefthook.yml
+++ b/examples/verbose/lefthook.yml
@@ -12,26 +12,26 @@ pre-commit:
       glob: "*.{js,ts}"
       run: npx eslint --fix {staged_files} && git add {staged_files}
 
-  # `ruby-test` will skip execution only when in a merging or rebasing state.
-  ruby-test:
-    skip:
-      - merge
-      - rebase
-    run: bundle exec rspec
-    fail_text: Run bundle install
+    # `ruby-test` will skip execution only when in a merging or rebasing state.
+    ruby-test:
+      skip:
+        - merge
+        - rebase
+      run: bundle exec rspec
+      fail_text: Run bundle install
 
-  # `ruby-lint` has `files` option which is a git command for replacing
-  # the {files} template. Then lefthook applies glob pattern to the result.
-  # If the final list is empty, the command will be skipped.
-  # Otherwise the {files} templace will be replaces with list.
-  #
-  # Note: if a template has surrounding quotes, they will be used to wrap
-  # each file in the list.
-  # Double quotes `"` and single quotes `'` are supported.
-  ruby-lint:
-    glob: "*.rb"
-    files: git diff-tree -r --name-only --diff-filter=CDMR HEAD origin/master
-    run: bundle exec rubocop --force-exclusion --parallel '{files}'
+    # `ruby-lint` has `files` option which is a git command for replacing
+    # the {files} template. Then lefthook applies glob pattern to the result.
+    # If the final list is empty, the command will be skipped.
+    # Otherwise the {files} templace will be replaces with list.
+    #
+    # Note: if a template has surrounding quotes, they will be used to wrap
+    # each file in the list.
+    # Double quotes `"` and single quotes `'` are supported.
+    ruby-lint:
+      glob: "*.rb"
+      files: git diff-tree -r --name-only --diff-filter=CDMR HEAD origin/master
+      run: bundle exec rubocop --force-exclusion --parallel '{files}'
 
 # You can provide more hooks.
 pre-push:


### PR DESCRIPTION
While I was creating a schema for lefthook [at SchemaStore](https://github.com/SchemaStore/schemastore/pull/3066), it seemed that there were some typos that could be fixed.

This fixes those (missed indentation and improved enumeration of allowed values in a config key).

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
