### PR TITLE
fix: Do not print extraneous newlines when executionInfo output is hidden

### DIFF
--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -485,12 +485,12 @@ func (r *Runner) logExecute(name string, err error, out io.Reader) {
 		execLog = fmt.Sprint(log.Cyan("\n  EXECUTE > "), log.Bold(name))
 	}
 
+	log.Info(execLog)
+
 	if err == nil && r.SkipSettings.SkipExecutionOutput() {
-		log.Info(execLog)
 		return
 	}
 
-	log.Info(execLog)
 	if out != nil {
 		log.Info(out)
 	}

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -478,14 +478,16 @@ func (r *Runner) logExecute(name string, err error, out io.Reader) {
 	var execLog string
 	switch {
 	case r.SkipSettings.SkipExecutionInfo():
-		execLog = "\n"
+		execLog = ""
 	case err != nil:
 		execLog = fmt.Sprint(log.Red("\n  EXECUTE > "), log.Bold(name))
 	default:
 		execLog = fmt.Sprint(log.Cyan("\n  EXECUTE > "), log.Bold(name))
 	}
 
-	log.Info(execLog)
+	if execLog != "" {
+		log.Info(execLog)
+	}
 
 	if err == nil && r.SkipSettings.SkipExecutionOutput() {
 		return

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -485,12 +485,12 @@ func (r *Runner) logExecute(name string, err error, out io.Reader) {
 		execLog = fmt.Sprint(log.Cyan("\n  EXECUTE > "), log.Bold(name))
 	}
 
-	if err == nil && r.SkipSettings.SkipExecutionOutput() {
-		return
-	}
-
 	if execLog != "" {
 		log.Info(execLog)
+	}
+
+	if err == nil && r.SkipSettings.SkipExecutionOutput() {
+		return
 	}
 
 	if out != nil {

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -485,12 +485,12 @@ func (r *Runner) logExecute(name string, err error, out io.Reader) {
 		execLog = fmt.Sprint(log.Cyan("\n  EXECUTE > "), log.Bold(name))
 	}
 
-	if execLog != "" {
-		log.Info(execLog)
-	}
-
 	if err == nil && r.SkipSettings.SkipExecutionOutput() {
 		return
+	}
+
+	if execLog != "" {
+		log.Info(execLog)
 	}
 
 	if out != nil {


### PR DESCRIPTION
Closes #494

#### :zap: Summary

Prevents printing blank lines when `exececutionInfo` is not printed.

Previously, two newlines would be printed for each command (Effectively `fmt.Println("\n")`). This fixes that.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
