### PR TITLE
fix: `LEFTHOOK_VERBOSE` properly overrides `--verbose` flag

### DIFF
--- a/internal/lefthook/lefthook.go
+++ b/internal/lefthook/lefthook.go
@@ -14,7 +14,10 @@ import (
 	"github.com/evilmartians/lefthook/internal/templates"
 )
 
-const hookFileMode = 0o755
+const (
+	hookFileMode = 0o755
+	envVerbose   = "LEFTHOOK_VERBOSE" // keep all output
+)
 
 var lefthookContentRegexp = regexp.MustCompile("LEFTHOOK")
 

--- a/internal/lefthook/lefthook.go
+++ b/internal/lefthook/lefthook.go
@@ -3,6 +3,7 @@ package lefthook
 import (
 	"bufio"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -35,6 +36,10 @@ type Lefthook struct {
 
 // New returns an instance of Lefthook.
 func initialize(opts *Options) (*Lefthook, error) {
+	if os.Getenv(envVerbose) == "1" || os.Getenv(envVerbose) == "true" {
+		opts.Verbose = true
+	}
+
 	if opts.Verbose {
 		log.SetLevel(log.DebugLevel)
 	}

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -15,9 +15,8 @@ import (
 )
 
 const (
-	envEnabled    = "LEFTHOOK"         // "0", "false"
-	envSkipOutput = "LEFTHOOK_QUIET"   // "meta,success,failure,summary,skips,execution,execution_out,execution_info"
-	envVerbose    = "LEFTHOOK_VERBOSE" // keep all output
+	envEnabled    = "LEFTHOOK"       // "0", "false"
+	envSkipOutput = "LEFTHOOK_QUIET" // "meta,success,failure,summary,skips,execution,execution_out,execution_info"
 )
 
 type RunArgs struct {

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -39,7 +39,7 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 	}
 
 	var verbose bool
-	if l.Verbose || os.Getenv(envVerbose) == "1" || os.Getenv(envVerbose) == "true" {
+	if l.Verbose {
 		log.SetLevel(log.DebugLevel)
 		verbose = true
 	}


### PR DESCRIPTION
Closes # (issue)

#### :zap: Summary

Previously, setting `LEFTHOOK_VERBOSE` would have no effect since cobra defaulted `options.Verbose` to false. And because `options.Verbose` wasn't overridden from the start, it would remain `false`.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
