### PR TITLE
ci: add Winget Releaser action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,4 +72,5 @@ jobs:
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: evilmartians.lefthook
+          fork-user: mrexox
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 permissions:
   contents: write
@@ -67,3 +67,9 @@ jobs:
         with:
           formula: lefthook
           token: ${{secrets.HOMEBREW_TOKEN}}
+
+      - name: Publish to Winget
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: evilmartians.lefthook
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ skip_output:
 * [Install with Node.js](./docs/install.md#node)
 * [Install with Ruby](./docs/install.md#ruby)
 * [Install with Homebrew](./docs/install.md#homebrew)
+* [Install with Winget](./docs/install.md#winget)
 * [Install for Debian-based Linux](./docs/install.md#deb)
 * [Install for RPM-based Linux](./docs/install.md#rpm)
 * [Install for Arch Linux](./docs/install.md#arch)

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,6 +7,7 @@ Choose your fighter:
 - [Go](#go)
 - [Python](#python)
 - [Homebrew](#homebrew)
+- [Winget](#winget)
 - [Snap](#snap)
 - [Debian-based distro](#deb)
 - [RPM-based distro](#rpm)
@@ -73,6 +74,12 @@ python3 -m pip install --user lefthook
 
 ```bash
 brew install lefthook
+```
+
+## <a id="winget"></a> Winget for Windows
+
+```sh
+winget install evilmartians.lefthook
 ```
 
 ## <a id="snap"></a> Snap for Linux


### PR DESCRIPTION
Closes #136

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

[This action](https://github.com/vedantmgoyal2009/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

Lefthook is now available in Winget: https://github.com/microsoft/winget-pkgs/pull/112810. This action would be used to update it.

**Before merging this:**
1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`.

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @evilmartians. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
