### PR TITLE
docs: add scoop installation method

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,6 +6,7 @@ Choose your fighter:
 - [Node.js](#node)
 - [Go](#go)
 - [Python](#python)
+- [Scoop](#scoop)
 - [Homebrew](#homebrew)
 - [Snap](#snap)
 - [Debian-based distro](#deb)
@@ -68,6 +69,11 @@ You can find Python wrapper here [package](https://github.com/life4/lefthook)
 python3 -m pip install --user lefthook
 ```
 
+## <a id="scoop"></a> Scoop for Windowss
+
+```sh
+scoop install lefthook
+```
 
 ## <a id="homebrew"></a> Homebrew for MacOS and Linux
 


### PR DESCRIPTION
Related to #136

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

Add Scoop installation method. Lefthook was recently added to the Main bucket: https://github.com/ScoopInstaller/Main/pull/4967

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
