### PR TITLE
fix: correct merging of extends from remote config

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -159,7 +159,9 @@ func mergeRemote(fs afero.Fs, repo *git.Repository, v *viper.Viper) error {
 	}
 
 	// Reset extends to omit issues when extending with remote extends.
-	v.MergeConfigMap(map[string]interface{}{"extends": nil})
+	if err := v.MergeConfigMap(map[string]interface{}{"extends": nil}); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -158,6 +158,9 @@ func mergeRemote(fs afero.Fs, repo *git.Repository, v *viper.Viper) error {
 		return err
 	}
 
+	// Reset extends to omit issues when extending with remote extends.
+	v.MergeConfigMap(map[string]interface{}{"extends": nil})
+
 	return nil
 }
 
@@ -171,6 +174,7 @@ func extend(v *viper.Viper, root string) error {
 			return err
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/528

**:wrench: Summary**

After merging extends from remote -- clear the `extends` value.