### PR TITLE
Add support for skipping empty summaries

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,7 @@ This config quiets all outputs except for errors.
 skip_output:
   - meta           # Skips lefthook version printing
   - summary        # Skips summary block (successful and failed steps) printing
+  - empty_summary  # Skips summary heading when there are no steps to run
   - success        # Skips successful steps printing
   - failure        # Skips failed steps printing
   - execution      # Skips printing any execution logs (but prints if the execution failed)

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -162,9 +162,9 @@ func printSummary(
 	logSettings log.SkipSettings,
 ) {
 	if len(results) == 0 {
-    if !logSettings.SkipEmptySummary() {
-      log.Info(log.Cyan("\nSUMMARY: (SKIP EMPTY)"))
-    }
+		if !logSettings.SkipEmptySummary() {
+			log.Info(log.Cyan("\nSUMMARY: (SKIP EMPTY)"))
+		}
 		return
 	}
 

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -162,7 +162,9 @@ func printSummary(
 	logSettings log.SkipSettings,
 ) {
 	if len(results) == 0 {
-		log.Info(log.Cyan("\nSUMMARY: (SKIP EMPTY)"))
+    if !logSettings.SkipEmptySummary() {
+      log.Info(log.Cyan("\nSUMMARY: (SKIP EMPTY)"))
+    }
 		return
 	}
 

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -9,7 +9,7 @@ const (
 	skipExecution
 	skipExecutionOutput
 	skipExecutionInfo
-  skipEmptySummary
+	skipEmptySummary
 )
 
 type SkipSettings int16
@@ -32,8 +32,8 @@ func (s *SkipSettings) ApplySetting(setting string) {
 		*s |= skipExecutionOutput
 	case "execution_info":
 		*s |= skipExecutionInfo
-  case "empty_summary":
-    *s |= skipEmptySummary
+	case "empty_summary":
+		*s |= skipEmptySummary
 	}
 }
 
@@ -70,7 +70,7 @@ func (s SkipSettings) SkipSkips() bool {
 }
 
 func (s SkipSettings) SkipEmptySummary() bool {
-  return s.doSkip(skipEmptySummary)
+	return s.doSkip(skipEmptySummary)
 }
 
 func (s SkipSettings) doSkip(option int16) bool {

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -9,6 +9,7 @@ const (
 	skipExecution
 	skipExecutionOutput
 	skipExecutionInfo
+  skipEmptySummary
 )
 
 type SkipSettings int16
@@ -31,6 +32,8 @@ func (s *SkipSettings) ApplySetting(setting string) {
 		*s |= skipExecutionOutput
 	case "execution_info":
 		*s |= skipExecutionInfo
+  case "empty_summary":
+    *s |= skipEmptySummary
 	}
 }
 
@@ -64,6 +67,10 @@ func (s SkipSettings) SkipExecutionInfo() bool {
 
 func (s SkipSettings) SkipSkips() bool {
 	return s.doSkip(skipSkips)
+}
+
+func (s SkipSettings) SkipEmptySummary() bool {
+  return s.doSkip(skipEmptySummary)
 }
 
 func (s SkipSettings) doSkip(option int16) bool {

--- a/internal/log/skip_settings_test.go
+++ b/internal/log/skip_settings_test.go
@@ -31,6 +31,7 @@ func TestSkipSetting(t *testing.T) {
 				"execution",
 				"execution_out",
 				"execution_info",
+        "empty_summary"
 			},
 			results: map[string]bool{
 				"meta":           true,
@@ -41,6 +42,7 @@ func TestSkipSetting(t *testing.T) {
 				"execution":      true,
 				"execution_out":  true,
 				"execution_info": true,
+        "empty_summary": true,
 			},
 		},
 	} {
@@ -78,6 +80,10 @@ func TestSkipSetting(t *testing.T) {
 			if settings.SkipExecutionInfo() != tt.results["execution_info"] {
 				t.Errorf("expected SkipExecutionInfo to be %v", tt.results["execution_info"])
 			}
+
+      if settings.SkipEmptySummary() != tt.results["empty-summary"] {
+        t.Errorf("expected SkipEmptySummary to be %v", tt.results["empty-summary"])
+      }
 
 			if settings.SkipSkips() != tt.results["skips"] {
 				t.Errorf("expected SkipSkips to be %v", tt.results["skip"])

--- a/internal/log/skip_settings_test.go
+++ b/internal/log/skip_settings_test.go
@@ -31,7 +31,7 @@ func TestSkipSetting(t *testing.T) {
 				"execution",
 				"execution_out",
 				"execution_info",
-        "empty_summary"
+				"empty_summary",
 			},
 			results: map[string]bool{
 				"meta":           true,
@@ -42,7 +42,7 @@ func TestSkipSetting(t *testing.T) {
 				"execution":      true,
 				"execution_out":  true,
 				"execution_info": true,
-        "empty_summary": true,
+				"empty_summary":  true,
 			},
 		},
 	} {
@@ -81,9 +81,9 @@ func TestSkipSetting(t *testing.T) {
 				t.Errorf("expected SkipExecutionInfo to be %v", tt.results["execution_info"])
 			}
 
-      if settings.SkipEmptySummary() != tt.results["empty-summary"] {
-        t.Errorf("expected SkipEmptySummary to be %v", tt.results["empty-summary"])
-      }
+			if settings.SkipEmptySummary() != tt.results["empty_summary"] {
+				t.Errorf("expected SkipEmptySummary to be %v", tt.results["empty_summary"])
+			}
 
 			if settings.SkipSkips() != tt.results["skips"] {
 				t.Errorf("expected SkipSkips to be %v", tt.results["skip"])


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/530

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Add `empty_summary` to values of `skip_output` for those cases when there's commands to run for a hook (ie all have been skipped, or there's no files matching command patterns)

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
- [x] Update documentation
