### PR TITLE
feat: add `files`, `all-files` and `commands` as flags

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -26,5 +26,10 @@ func newRunCmd(opts *lefthook.Options) *cobra.Command {
 		"run hook non-interactively, disable spinner",
 	)
 
+	runCmd.Flags().BoolVar(
+		&runArgs.AllFiles, "all-files", false,
+		"run hooks on all files",
+	)
+
 	return &runCmd
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,5 +31,7 @@ func newRunCmd(opts *lefthook.Options) *cobra.Command {
 		"run hooks on all files",
 	)
 
+	runCmd.Flags().StringSliceVar(&runArgs.RunOnlyCommands, "commands", nil, "run only specified commands")
+
 	return &runCmd
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,6 +31,8 @@ func newRunCmd(opts *lefthook.Options) *cobra.Command {
 		"run hooks on all files",
 	)
 
+	runCmd.Flags().StringSliceVar(&runArgs.Files, "files", nil, "run on specified files. takes precedence over --all-files")
+
 	runCmd.Flags().StringSliceVar(&runArgs.RunOnlyCommands, "commands", nil, "run only specified commands")
 
 	return &runCmd

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,6 +115,21 @@ Or run manually also
 $ lefthook run pre-commit
 ```
 
+You can also specify a flag to run only some commands:
+
+```bash
+$ lefthook run pre-commit --commands lint
+```
+
+and optionally run either on all files (any `{staged_files}` placeholder acts as `{all_files}`) or a list of files:
+
+```bash
+$ lefthook run pre-commit --all-files
+$ lefthook run pre-commit --files file1.js,file2.js
+```
+
+(if both are specified, `--all-files` is ignored)
+
 ### `lefthook version`
 
 You can check version with `lefthook version` and you can also check the commit hash with `lefthook version --full`

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -20,8 +20,9 @@ const (
 )
 
 type RunArgs struct {
-	NoTTY    bool
-	AllFiles bool
+	NoTTY           bool
+	AllFiles        bool
+	RunOnlyCommands []string
 }
 
 func Run(opts *Options, args RunArgs, hookName string, gitArgs []string) error {
@@ -107,15 +108,16 @@ Run 'lefthook install' manually.`,
 
 	run := runner.NewRunner(
 		runner.Opts{
-			Fs:           l.Fs,
-			Repo:         l.repo,
-			Hook:         hook,
-			HookName:     hookName,
-			GitArgs:      gitArgs,
-			ResultChan:   resultChan,
-			SkipSettings: logSettings,
-			DisableTTY:   cfg.NoTTY || args.NoTTY,
-			AllFiles:     args.AllFiles,
+			Fs:              l.Fs,
+			Repo:            l.repo,
+			Hook:            hook,
+			HookName:        hookName,
+			GitArgs:         gitArgs,
+			ResultChan:      resultChan,
+			SkipSettings:    logSettings,
+			DisableTTY:      cfg.NoTTY || args.NoTTY,
+			AllFiles:        args.AllFiles,
+			RunOnlyCommands: args.RunOnlyCommands,
 		},
 	)
 

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -20,7 +20,8 @@ const (
 )
 
 type RunArgs struct {
-	NoTTY bool
+	NoTTY    bool
+	AllFiles bool
 }
 
 func Run(opts *Options, args RunArgs, hookName string, gitArgs []string) error {
@@ -114,6 +115,7 @@ Run 'lefthook install' manually.`,
 			ResultChan:   resultChan,
 			SkipSettings: logSettings,
 			DisableTTY:   cfg.NoTTY || args.NoTTY,
+			AllFiles:     args.AllFiles,
 		},
 	)
 

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -22,6 +22,7 @@ const (
 type RunArgs struct {
 	NoTTY           bool
 	AllFiles        bool
+	Files           []string
 	RunOnlyCommands []string
 }
 
@@ -117,6 +118,7 @@ Run 'lefthook install' manually.`,
 			SkipSettings:    logSettings,
 			DisableTTY:      cfg.NoTTY || args.NoTTY,
 			AllFiles:        args.AllFiles,
+			Files:           args.Files,
 			RunOnlyCommands: args.RunOnlyCommands,
 		},
 	)

--- a/internal/lefthook/runner/prepare_command.go
+++ b/internal/lefthook/runner/prepare_command.go
@@ -52,8 +52,13 @@ func (r *Runner) buildCommandArgs(command *config.Command) (*commandArgs, error,
 		filesCommand = command.Files
 	}
 
+	stagedFiles := r.Repo.StagedFiles
+	if r.AllFiles {
+		stagedFiles = r.Repo.AllFiles
+	}
+
 	filesTypeToFn := map[string]func() ([]string, error){
-		config.SubStagedFiles: r.Repo.StagedFiles,
+		config.SubStagedFiles: stagedFiles,
 		config.PushFiles:      r.Repo.PushFiles,
 		config.SubAllFiles:    r.Repo.AllFiles,
 		config.SubFiles: func() ([]string, error) {

--- a/internal/lefthook/runner/prepare_command.go
+++ b/internal/lefthook/runner/prepare_command.go
@@ -53,7 +53,9 @@ func (r *Runner) buildCommandArgs(command *config.Command) (*commandArgs, error,
 	}
 
 	stagedFiles := r.Repo.StagedFiles
-	if r.AllFiles {
+	if len(r.Files) > 0 {
+		stagedFiles = func() ([]string, error) { return r.Files, nil }
+	} else if r.AllFiles {
 		stagedFiles = r.Repo.AllFiles
 	}
 

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -40,6 +40,7 @@ type Opts struct {
 	SkipSettings    log.SkipSettings
 	DisableTTY      bool
 	AllFiles        bool
+	Files           []string
 	RunOnlyCommands []string
 }
 

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -38,6 +38,7 @@ type Opts struct {
 	ResultChan   chan Result
 	SkipSettings log.SkipSettings
 	DisableTTY   bool
+	AllFiles     bool
 }
 
 // Runner responds for actual execution and handling the results.

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -30,15 +31,16 @@ const (
 var surroundingQuotesRegexp = regexp.MustCompile(`^'(.*)'$`)
 
 type Opts struct {
-	Fs           afero.Fs
-	Repo         *git.Repository
-	Hook         *config.Hook
-	HookName     string
-	GitArgs      []string
-	ResultChan   chan Result
-	SkipSettings log.SkipSettings
-	DisableTTY   bool
-	AllFiles     bool
+	Fs              afero.Fs
+	Repo            *git.Repository
+	Hook            *config.Hook
+	HookName        string
+	GitArgs         []string
+	ResultChan      chan Result
+	SkipSettings    log.SkipSettings
+	DisableTTY      bool
+	AllFiles        bool
+	RunOnlyCommands []string
 }
 
 // Runner responds for actual execution and handling the results.
@@ -308,7 +310,10 @@ func (r *Runner) runScript(script *config.Script, path string, file os.FileInfo)
 func (r *Runner) runCommands() {
 	commands := make([]string, 0, len(r.Hook.Commands))
 	for name := range r.Hook.Commands {
-		commands = append(commands, name)
+		if len(r.RunOnlyCommands) == 0 || slices.Contains(r.RunOnlyCommands, name) {
+			commands = append(commands, name)
+		}
+
 	}
 
 	sort.Strings(commands)


### PR DESCRIPTION
Closes #120

#### :zap: Summary

Adds `--all-files`, `--files`, and `--commands` to run lefthook on a subset of hooks and/or files in the repo.

New usage text:

```sh
$ lefthook run --help

Execute group of hooks

Usage:
  lefthook run hook-name [git args...] [flags]

Examples:
lefthook run pre-commit

Flags:
      --all-files          run hooks on all files
      --commands strings   run only specified commands
      --files strings      run on specified files. takes precedence over --all-files
  -h, --help               help for run
  -n, --no-tty             run hook non-interactively, disable spinner

Global Flags:
      --no-colors   disable colored output
  -v, --verbose     verbose output
```
#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [x] Add documentation

I'm not sure how to add a test for these - there aren't any existing tests that operate on the `cmd/run.go` level and test the whole flow – how would you like that to be done?