### PR TITLE
chore: bump go to 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -31,7 +31,7 @@ jobs:
   test-integrity:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build binaries
@@ -91,5 +91,5 @@ jobs:
     steps:
       - uses: coverallsapp/github-action@v2
         with:
-          carryforward: "integration-1.20.x ubuntu-latest,integration-1.20.x macos-latest,1.20.x ubuntu-latest,1.20.x macos-latest,1.20.x windows-latest"
+          carryforward: "integration-1.21.x ubuntu-latest,integration-1.21.x macos-latest,1.21.x ubuntu-latest,1.21.x macos-latest,1.21.x windows-latest"
           parallel-finished: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First off, thanks for taking the time to contribute! Feel free to make Pull Requ
 
 # Requirements
 
-Go >= 1.20.0
+Go >= 1.21.0
 
 # Process
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Fast and powerful Git hooks manager for Node.js, Ruby or any other type of proje
 
 ## Install
 
-With **Go** (>= 1.20):
+With **Go** (>= 1.21):
 
 ```bash
 go install github.com/evilmartians/lefthook@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evilmartians/lefthook
 
-go 1.20
+go 1.21
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
Closes: N/A

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Upgrade go to 1.21, to support using the new `slices.Contains` in #534

<!-- Brief description of what was done -->

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests - N/A
- [ ] Add documentation - N/A
