### PR TITLE
chore: fix linter issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.53.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.53.3
+          version: v1.54.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.21.x
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters:
     - containedctx
     - contextcheck
     - decorder
-    - depguard
     - dogsled
     - dupl
     - dupword

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,10 @@ linters-settings:
     locale: US
   gci:
     local-prefixes: github.com/evilmartians/lefthook
+  revive:
+    rules:
+      - name: unused-parameter
+        disabled: true
 
 linters:
   disable-all: true

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ bench:
 
 bin/golangci-lint:
 	@test -x $$(go env GOPATH)/bin/golangci-lint || \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.53.3
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.54.1
 
 lint: bin/golangci-lint
 	$$(go env GOPATH)/bin/golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ bench:
 
 bin/golangci-lint:
 	@test -x $$(go env GOPATH)/bin/golangci-lint || \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.50.1
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.53.3
 
 lint: bin/golangci-lint
 	$$(go env GOPATH)/bin/golangci-lint run

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/evilmartians/lefthook/internal/version"
 )
 
-func newVersionCmd(opts *lefthook.Options) *cobra.Command {
+func newVersionCmd(_opts *lefthook.Options) *cobra.Command {
 	var verbose bool
 
 	versionCmd := cobra.Command{

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -83,9 +83,9 @@ func readOne(fs afero.Fs, path string, names []string) (*viper.Viper, error) {
 			var notFoundErr viper.ConfigFileNotFoundError
 			if ok := errors.As(err, &notFoundErr); ok {
 				continue
-			} else {
-				return nil, err
 			}
+
+			return nil, err
 		}
 
 		return v, nil
@@ -159,11 +159,7 @@ func mergeRemote(fs afero.Fs, repo *git.Repository, v *viper.Viper) error {
 	}
 
 	// Reset extends to omit issues when extending with remote extends.
-	if err := v.MergeConfigMap(map[string]interface{}{"extends": nil}); err != nil {
-		return err
-	}
-
-	return nil
+	return v.MergeConfigMap(map[string]interface{}{"extends": nil})
 }
 
 // extend merges all files listed in 'extends' option into the config.
@@ -186,11 +182,7 @@ func merge(name, path string, v *viper.Viper) error {
 	if len(path) > 0 {
 		v.SetConfigFile(path)
 	}
-	if err := v.MergeInConfig(); err != nil {
-		return err
-	}
-
-	return nil
+	return v.MergeInConfig()
 }
 
 func mergeOne(names []string, path string, v *viper.Viper) error {
@@ -198,11 +190,11 @@ func mergeOne(names []string, path string, v *viper.Viper) error {
 		err := merge(name, path, v)
 		if err == nil {
 			break
-		} else {
-			var notFoundErr viper.ConfigFileNotFoundError
-			if ok := errors.As(err, &notFoundErr); !ok {
-				return err
-			}
+		}
+
+		var notFoundErr viper.ConfigFileNotFoundError
+		if ok := errors.As(err, &notFoundErr); !ok {
+			return err
 		}
 	}
 
@@ -241,11 +233,8 @@ func unmarshalConfigs(base, extra *viper.Viper, c *Config) error {
 	if err := base.MergeConfigMap(extra.AllSettings()); err != nil {
 		return err
 	}
-	if err := base.Unmarshal(c); err != nil {
-		return err
-	}
 
-	return nil
+	return base.Unmarshal(c)
 }
 
 func addHook(hookName string, base, extra *viper.Viper, c *Config) error {

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -128,9 +128,5 @@ func unmarshalScripts(s map[string]interface{}) (map[string]*Script, error) {
 // This is not an expected behavior and cannot be controlled yet
 // Working with GetStringMap is the only way to get the structure "as is".
 func unmarshal(input, output interface{}) error {
-	if err := mapstructure.WeakDecode(input, &output); err != nil {
-		return err
-	}
-
-	return nil
+	return mapstructure.WeakDecode(input, &output)
 }

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -50,18 +50,10 @@ func (r *Repository) SyncRemote(url, ref string) error {
 
 	_, err = r.Fs.Stat(remotePath)
 	if err == nil {
-		if err := r.updateRemote(remotePath, ref); err != nil {
-			return err
-		}
-
-		return nil
+		return r.updateRemote(remotePath, ref)
 	}
 
-	if err := r.cloneRemote(remotesPath, url, ref); err != nil {
-		return err
-	}
-
-	return nil
+	return r.cloneRemote(remotesPath, url, ref)
 }
 
 func (r *Repository) updateRemote(path, ref string) error {

--- a/internal/lefthook/lefthook.go
+++ b/internal/lefthook/lefthook.go
@@ -90,11 +90,7 @@ func (l *Lefthook) cleanHook(hook string, force bool) error {
 
 	// Just remove lefthook hook
 	if l.isLefthookFile(hookPath) {
-		if err = l.Fs.Remove(hookPath); err != nil {
-			return err
-		}
-
-		return nil
+		return l.Fs.Remove(hookPath)
 	}
 
 	// Check if .old file already exists before renaming.

--- a/internal/lefthook/run_test.go
+++ b/internal/lefthook/run_test.go
@@ -12,19 +12,19 @@ import (
 
 type GitMock struct{}
 
-func (g GitMock) Cmd(cmd string) (string, error) {
+func (g GitMock) Cmd(_cmd string) (string, error) {
 	return "", nil
 }
 
-func (g GitMock) CmdArgs(args ...string) (string, error) {
+func (g GitMock) CmdArgs(_args ...string) (string, error) {
 	return "", nil
 }
 
-func (g GitMock) CmdLines(cmd string) ([]string, error) {
+func (g GitMock) CmdLines(_cmd string) ([]string, error) {
 	return nil, nil
 }
 
-func (g GitMock) RawCmd(cmd string) (string, error) {
+func (g GitMock) RawCmd(_cmd string) (string, error) {
 	return "", nil
 }
 

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -314,7 +314,6 @@ func (r *Runner) runCommands() {
 		if len(r.RunOnlyCommands) == 0 || slices.Contains(r.RunOnlyCommands, name) {
 			commands = append(commands, name)
 		}
-
 	}
 
 	sort.Strings(commands)

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -18,7 +18,7 @@ import (
 
 type TestExecutor struct{}
 
-func (e TestExecutor) Execute(opts ExecuteOptions, out io.Writer) (err error) {
+func (e TestExecutor) Execute(opts ExecuteOptions, _out io.Writer) (err error) {
 	if opts.args[0] == "success" {
 		err = nil
 	} else {
@@ -28,7 +28,7 @@ func (e TestExecutor) Execute(opts ExecuteOptions, out io.Writer) (err error) {
 	return
 }
 
-func (e TestExecutor) RawExecute(command []string, out io.Writer) error {
+func (e TestExecutor) RawExecute(_command []string, _out io.Writer) error {
 	return nil
 }
 

--- a/internal/lefthook/uninstall.go
+++ b/internal/lefthook/uninstall.go
@@ -47,11 +47,7 @@ func (l *Lefthook) Uninstall(args *UninstallArgs) error {
 		}
 	}
 
-	if err := l.Fs.RemoveAll(l.repo.RemotesFolder()); err != nil {
-		return err
-	}
-
-	return nil
+	return l.Fs.RemoveAll(l.repo.RemotesFolder())
 }
 
 func (l *Lefthook) deleteHooks(force bool) error {


### PR DESCRIPTION
**:broom: Summary**

- Update golangci-lint version 
- Remove odd revive rule
- Remove depguard (no need for it right now)
- Update golang version in CI workflows
