### PR TITLE
fix: fail on non existing hook name

### DIFF
--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -97,8 +98,12 @@ Run 'lefthook install' manually.`,
 	// Find the hook
 	hook, ok := cfg.Hooks[hookName]
 	if !ok {
-		log.Debugf("[lefthook] skip: Hook %s doesn't exist in the config", hookName)
-		return nil
+		if slices.Contains(config.AvailableHooks[:], hookName) {
+			log.Debugf("[lefthook] skip: Hook %s doesn't exist in the config", hookName)
+			return nil
+		}
+
+		return fmt.Errorf("Hook %s doesn't exist in the config", hookName)
 	}
 	if err := hook.Validate(); err != nil {
 		return err

--- a/internal/lefthook/run_test.go
+++ b/internal/lefthook/run_test.go
@@ -47,7 +47,7 @@ func TestRun(t *testing.T) {
 	}{
 		{
 			name: "Skip case",
-			hook: "any-hook",
+			hook: "pre-commit",
 			envs: map[string]string{
 				"LEFTHOOK": "0",
 			},
@@ -55,7 +55,7 @@ func TestRun(t *testing.T) {
 		},
 		{
 			name: "Skip case",
-			hook: "any-hook",
+			hook: "pre-commit",
 			envs: map[string]string{
 				"LEFTHOOK": "false",
 			},
@@ -63,7 +63,7 @@ func TestRun(t *testing.T) {
 		},
 		{
 			name: "Invalid version",
-			hook: "any-hook",
+			hook: "pre-commit",
 			config: `
 min_version: 23.0.1
 `,
@@ -71,7 +71,7 @@ min_version: 23.0.1
 		},
 		{
 			name: "Valid version, no hook",
-			hook: "any-hook",
+			hook: "pre-commit",
 			config: `
 min_version: 0.7.9
 `,

--- a/testdata/run_non_existing.txt
+++ b/testdata/run_non_existing.txt
@@ -1,0 +1,8 @@
+exec git init
+exec lefthook run pre-commit
+! stdout 'Error.*'
+! exec lefthook run no-a-hook
+stdout 'Error.*'
+
+-- lefthook.yml --
+# empty


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/405

**:wrench: Summary**

Return an error on non-existing hook if it is not a git hook