### PR TITLE
feat: add interrupt (Ctrl-C) handling

### DIFF
--- a/internal/lefthook/run/exec/execute_windows.go
+++ b/internal/lefthook/run/exec/execute_windows.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -18,7 +19,7 @@ type executeArgs struct {
 	root string
 }
 
-func (e CommandExecutor) Execute(opts Options, out io.Writer) error {
+func (e CommandExecutor) Execute(ctx context.Context, opts Options, out io.Writer) error {
 	root, _ := filepath.Abs(opts.Root)
 	envs := make([]string, len(opts.Env))
 	for name, value := range opts.Env {
@@ -44,7 +45,7 @@ func (e CommandExecutor) Execute(opts Options, out io.Writer) error {
 	return nil
 }
 
-func (e CommandExecutor) RawExecute(command []string, out io.Writer) error {
+func (e CommandExecutor) RawExecute(ctx context.Context, command []string, out io.Writer) error {
 	cmd := exec.Command(command[0], command[1:]...)
 
 	cmd.Stdout = out

--- a/internal/lefthook/run/exec/executor.go
+++ b/internal/lefthook/run/exec/executor.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"context"
 	"io"
 )
 
@@ -15,6 +16,6 @@ type Options struct {
 // Executor provides an interface for command execution.
 // It is used here for testing purpose mostly.
 type Executor interface {
-	Execute(opts Options, out io.Writer) error
-	RawExecute(command []string, out io.Writer) error
+	Execute(ctx context.Context, opts Options, out io.Writer) error
+	RawExecute(ctx context.Context, command []string, out io.Writer) error
 }

--- a/internal/lefthook/run/runner_test.go
+++ b/internal/lefthook/run/runner_test.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -19,7 +20,7 @@ import (
 
 type TestExecutor struct{}
 
-func (e TestExecutor) Execute(opts exec.Options, _out io.Writer) (err error) {
+func (e TestExecutor) Execute(_ctx context.Context, opts exec.Options, _out io.Writer) (err error) {
 	if strings.HasPrefix(opts.Commands[0], "success") {
 		err = nil
 	} else {
@@ -29,7 +30,7 @@ func (e TestExecutor) Execute(opts exec.Options, _out io.Writer) (err error) {
 	return
 }
 
-func (e TestExecutor) RawExecute(_command []string, _out io.Writer) error {
+func (e TestExecutor) RawExecute(_ctx context.Context, _command []string, _out io.Writer) error {
 	return nil
 }
 
@@ -755,7 +756,7 @@ func TestRunAll(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("%d: %s", i, tt.name), func(t *testing.T) {
-			runner.RunAll(tt.sourceDirs)
+			runner.RunAll(context.Background(), tt.sourceDirs)
 			close(resultChan)
 
 			var success, fail []Result

--- a/testdata/run_interrupt.txt
+++ b/testdata/run_interrupt.txt
@@ -1,0 +1,52 @@
+chmod 0700 hook.sh
+chmod 0700 commit-with-interrupt.sh
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec lefthook install
+exec git add -A
+
+exec git commit -m 'init'
+stderr 'hook-done'
+
+exec ./commit-with-interrupt.sh
+stderr 'script-done'
+! stderr 'hook-done'
+stderr 'signal: killed'
+stderr 'Error: Interrupted'
+grep unstaged newfile.txt
+exec git stash list
+! stdout 'lefthook auto backup'
+
+-- lefthook.yml --
+pre-commit:
+  commands:
+    slow_job:
+      run: ./hook.sh
+
+-- hook.sh --
+#!/usr/bin/env bash
+
+sleep 2
+>&2 echo hook-done
+
+-- newfile.txt --
+staged
+
+-- commit-with-interrupt.sh --
+#!/usr/bin/env bash
+
+echo staged >> newfile.txt
+git add newfile.txt
+echo unstaged >> newfile.txt
+
+# ctrl-c is emulated by sending SIGINT to a process group
+# so we first need to emulate being a terminal and enable
+# job monitoring so that new PGIDs are assigned.
+set -m
+nohup git commit -m test &
+pgid=$!
+sleep 1
+kill -SIGINT -$pgid
+wait
+>&2 echo 'script-done'


### PR DESCRIPTION
Closes #542

#### :zap: Summary

Hitting Ctrl-C during commit would terminate `lefthook` immediately, and stashed changes would not be restored. This can be improved by using a `NotifyContext` which prevents `lefthook` from being killed while still terminating subprocesses.

#### Test Plan

1. In this repo…
2. Added to `.lefthook.toml`
   ```
   [pre-commit.commands.sleep]
   run = "sleep 10 && exit 1"
   ```
3. Staged that change
4. Added `# unstaged` at the end of `.lefthook.toml`
5. Ran `git commit -m 'test'`
6. Hit `Ctrl-C`
7. Ran `git status` && `git stash list`
8. Before:
   - Output: `⠏ waiting: sleep^C`
   - The `unstaged` comment was missing
   - Found `stash@{0}: lefthook auto backup`
9. After:
   - Output:
     ```
     ⠦ waiting: sleep^C

     EXECUTE > sleep

     Error: Interrupted
     ```
   - The `unstaged` comment was restored
   - Stash list was empty

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
- [ ] Add documentation (N/A)
