### PR TITLE
fix: Improve script performance and reliability

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -9,45 +9,33 @@ fi
 [ -f {{.Rc}} ] && . {{.Rc}}
 {{- end}}
 
-call_lefthook()
-{
-  dir="$(git rev-parse --show-toplevel)"
+call_lefthook() {
   osArch=$(uname | tr '[:upper:]' '[:lower:]')
   cpuArch=$(uname -m | sed 's/aarch64/arm64/')
 
-  if lefthook{{.Extension}} -h >/dev/null 2>&1
-  then
-    lefthook{{.Extension}} "$@"
+  if command -v lefthook{{.Extension}} >/dev/null 2>&1; then
+    exec lefthook{{.Extension}} "$@"
   {{if .Extension -}}
   {{/* Check if lefthook.bat exists. Ruby bundler creates such a wrapper */ -}}
-  elif lefthook.bat -h >/dev/null 2>&1
-  then
-    lefthook.bat "$@"
+  elif command -v lefthook.bat >/dev/null 2>&1; then
+    exec lefthook.bat "$@"
   {{end -}}
-  elif test -f "$dir/node_modules/lefthook/bin/index.js"
-  then
-    "$dir/node_modules/lefthook/bin/index.js" "$@"
-  elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
-  then
-    "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
-  elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
-  then
-    "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
-  elif bundle exec lefthook -h >/dev/null 2>&1
-  then
-    bundle exec lefthook "$@"
-  elif yarn lefthook -h >/dev/null 2>&1
-  then
-    yarn lefthook "$@"
-  elif pnpm lefthook -h >/dev/null 2>&1
-  then
-    pnpm lefthook "$@"
-  elif command -v npx >/dev/null 2>&1
-  then
-    npx @evilmartians/lefthook "$@"
-  elif swift package plugin lefthook >/dev/null 2>&1
-  then
-    swift package --disable-sandbox plugin lefthook "$@"
+  fi
+
+  try_exec "./node_modules/lefthook/bin/index.js" "$@"
+  try_exec "./node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
+  try_exec "./node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
+
+  if bundle exec lefthook -h >/dev/null 2>&1; then
+    exec bundle exec lefthook "$@"
+  elif yarn lefthook -h >/dev/null 2>&1; then
+    exec yarn lefthook "$@"
+  elif pnpm lefthook -h >/dev/null 2>&1; then
+    exec pnpm lefthook "$@"
+  elif command -v npx >/dev/null 2>&1; then
+    exec npx @evilmartians/lefthook "$@"
+  elif swift package plugin lefthook >/dev/null 2>&1; then
+    exec swift package --disable-sandbox plugin lefthook "$@"
   else
     echo "Can't find lefthook in PATH"
     {{- if .AssertLefthookInstalled}}
@@ -56,6 +44,14 @@ call_lefthook()
     echo "To skip these checks use --no-verify git argument or set LEFTHOOK=0 env variable."
     exit 1
     {{- end}}
+  fi
+}
+
+try_exec() {
+  _path=$1; shift
+
+  if [ -x "$_path" ]; then
+    exec "$_path" "$@"
   fi
 }
 


### PR DESCRIPTION
~~Previously, only lefthook stuff under the current `$PWD/node_modules` was checked. Now, the current directory up until the Git root is checked (see `try_exec` function.~~

I did chang the formatting since it was really difficult to parse the shell script. If you want to change it back, let me know.

#### :zap: Summary

Optimizations:

- ~~Don't waste time running a subshell with `git rev-parse --show-toplevel` when it is not needed~~
- Does not attempt to run `lefthook` to determine if `lefthook` can be run (use `command -v` instead)'
  - slight performance improvement 
- Use `exec` to run commands
  - Makes process signals more reliable (so that they are not ignored by the shell)

~~Note that this slightly changes the resolution algorithm. Before, it would look for `./node_modules/lefthook/bin/index.js`, then `./node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}`, etc. Now, it looks for `./node_modules/lefthook/bin/index.js`, then `../node_modules/lefthook/bin/index.js`, etc., all the way up to the git root. Once it reaches git root, _then_ it goes back to the original `$PWD` and looks for `./node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}`, and climbs up the directory tree for that path.~~

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
