### PR TITLE
fix: Do not enable export when sourcing rc file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,7 +243,7 @@ pre-commit:
       run: npm run eslint {staged_files}
 ```
 
-Provide a tweak to access `npm` executable the same way you do it in your ~/<shell>rc
+Provide a tweak to access `npm` executable the same way you do it in your ~/<shell>rc.
 
 ```yml
 # lefthook-local.yml
@@ -254,16 +254,25 @@ Provide a tweak to access `npm` executable the same way you do it in your ~/<she
 rc: ~/.lefthookrc
 ```
 
+Or
+
+```yml
+# lefthook-local.yml
+
+# If the path contains spaces, you need to quote it.
+rc: '"${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc"'
+```
+
+In the rc file, export any new environment variables or modify existing ones.
+
 ```bash
 # ~/.lefthookrc
 
 # An nvm way
-
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
 # Or maybe just
-
 PATH=$PATH:$HOME/.nvm/versions/node/v15.14.0/bin
 ```
 

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -5,8 +5,7 @@ if [ "$LEFTHOOK" = "0" ]; then
 fi
 
 {{- if .Rc}}
-{{/* Load rc file and export all ENV vars defined in it */}}
-set -a
+{{/* Load rc file, which may export ENV variables */}}
 [ -f {{.Rc}} ] && . {{.Rc}}
 {{- end}}
 


### PR DESCRIPTION
Doesn't close any issue.

#### :zap: Summary

There's currently a discrepancy with the documentation on [rc](https://github.com/evilmartians/lefthook/blob/master/docs/configuration.md#rc) files and the actual behavior.

The documentation states:

> Provide a tweak to access npm executable the same way you do it in your ~/rc

However, `set -a` is not set by default (or at all in most people's configurations) in `~/.profile`, `~/.bashrc`, etc. If that were the case, then way too many environment variables would be added to the environment table of all child processes.

The correct behavior is already hinted at with the examples:

```sh
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
```

The `export` syntax is used, which implies that `set -a` is not enabled. Furthermore, when sourcing `"$NVM_DIR/nvm.sh"`, we wouldn't want all the regular variables (not environment variables) it defines to be loaded in as environment variables - again this behavior is different from standard rc files and is unintuitive. Other hook managers like [Husky](https://github.com/typicode/husky/blob/main/husky.sh) act like this.

This is a breaking change, but is in line with user expectations, the current documentation, and other popular Git hook managers.

This also adds documentation to make it clear how to properly use `rc` field when path contains spaces.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
