### PR TITLE
feat: Initial support for Swift Plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,6 @@ version:
 	@read -p "New version: " version
 	sed -i "s/const version = .*/const version = \"$$version\"/" internal/version/version.go
 	sed -i "s/VERSION := .*/VERSION := $$version/" packaging/Makefile
+	sed -i "s/lefthook-plugin.git\", exact: \".*\"/lefthook-plugin.git\", exact: \"$$version\"/" docs/install.md
 	make -C packaging clean set-version
-	git add internal/version/version.go packaging/*
+	git add internal/version/version.go packaging/* docs/install.md

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,6 +6,7 @@ Choose your fighter:
 - [Node.js](#node)
 - [Go](#go)
 - [Python](#python)
+- [Swift](#swift)
 - [Scoop](#scoop)
 - [Homebrew](#homebrew)
 - [Winget](#winget)
@@ -68,6 +69,14 @@ You can find Python wrapper here [package](https://github.com/life4/lefthook)
 
 ```sh
 python3 -m pip install --user lefthook
+```
+
+## <a id="swift"></a> Swift
+
+You can find the Swift wrapper plugin [here](https://github.com/csjones/lefthook-plugin). To utilize lefthook, include the plugin in the dependencies section of your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/csjones/lefthook-plugin.git", exact: "1.5.0"),
 ```
 
 ## <a id="scoop"></a> Scoop for Windowss

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -46,6 +46,9 @@ call_lefthook()
   elif command -v npx >/dev/null 2>&1
   then
     npx @evilmartians/lefthook "$@"
+  elif swift package plugin lefthook >/dev/null 2>&1
+  then
+    swift package --disable-sandbox plugin lefthook $@
   else
     echo "Can't find lefthook in PATH"
     {{- if .AssertLefthookInstalled}}


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/544

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

Updated the `hooks.tmpl` file to support executing lefthook from a Swift Plugin. Additionally, added a note into `docs/installation.md` with a link to the plugin repository.

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
- [x] Add documentation
