### PR TITLE
Add skip option for the summary separator

### DIFF
--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -195,9 +195,13 @@ func printSummary(
 		return
 	}
 
-	log.Separate(
-		log.Cyan("summary: ") + log.Gray(fmt.Sprintf("(done in %.2f seconds)", duration.Seconds())),
-	)
+	if logSettings.SkipSummarySeparator() {
+		log.Info(log.Cyan("summary: ") + log.Gray(fmt.Sprintf("(done in %.2f seconds)", duration.Seconds())))
+	} else {
+		log.Separate(
+			log.Cyan("summary: ") + log.Gray(fmt.Sprintf("(done in %.2f seconds)", duration.Seconds())),
+		)
+	}
 
 	if !logSettings.SkipSuccess() {
 		for _, result := range results {

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -10,6 +10,7 @@ const (
 	skipExecutionOutput
 	skipExecutionInfo
 	skipEmptySummary
+	skipSummarySeparator
 )
 
 type SkipSettings int16
@@ -34,6 +35,8 @@ func (s *SkipSettings) ApplySetting(setting string) {
 		*s |= skipExecutionInfo
 	case "empty_summary":
 		*s |= skipEmptySummary
+	case "summary_separator":
+		*s |= skipSummarySeparator
 	}
 }
 
@@ -71,6 +74,10 @@ func (s SkipSettings) SkipSkips() bool {
 
 func (s SkipSettings) SkipEmptySummary() bool {
 	return s.doSkip(skipEmptySummary)
+}
+
+func (s SkipSettings) SkipSummarySeparator() bool {
+	return s.doSkip(skipSummarySeparator)
 }
 
 func (s SkipSettings) doSkip(option int16) bool {


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/560

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Adds yet another `skip` option 😅  this time for the separator before a summary. I don't know if there is a point when there are too many skips, and what that point is though...

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
- [ ] Add documentation
