### PR TITLE
fix: drop new argument for git diff compatibility

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -209,7 +209,6 @@ func (r *Repository) RestoreUnstaged() error {
 		"--whitespace=nowarn",
 		"--recount",
 		"--unidiff-zero",
-		"--allow-empty",
 		r.unstagedPatchPath,
 	)
 


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/584

**:wrench: Summary**

Compatibility is much more important here. Probably need another fix for empty diffs