### PR TITLE
fix: use empty stdin by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+- fix: use empty stdin by default ([#590](https://github.com/evilmartians/lefthook/pull/590)) by @mrexox
 - feat: add priorities to commands ([#589](https://github.com/evilmartians/lefthook/pull/589)) by @mrexox
 
 ## 1.5.4 (2023-11-27)

--- a/internal/lefthook/run/exec/execute_unix.go
+++ b/internal/lefthook/run/exec/execute_unix.go
@@ -28,18 +28,11 @@ type executeArgs struct {
 	interactive, useStdin bool
 }
 
-type nullReader struct{}
-
-func (nullReader) Read(b []byte) (int, error) {
-	if len(b) == 0 {
-		return 0, nil
-	}
-
-	return 0, io.EOF
-}
-
 func (e CommandExecutor) Execute(ctx context.Context, opts Options, out io.Writer) error {
 	var in io.Reader = nullReader{}
+	if opts.UseStdin {
+		in = os.Stdin
+	}
 	if opts.Interactive && !isatty.IsTerminal(os.Stdin.Fd()) {
 		tty, err := os.Open("/dev/tty")
 		if err == nil {

--- a/internal/lefthook/run/exec/execute_unix.go
+++ b/internal/lefthook/run/exec/execute_unix.go
@@ -28,8 +28,18 @@ type executeArgs struct {
 	interactive, useStdin bool
 }
 
+type nullReader struct{}
+
+func (nullReader) Read(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+
+	return 0, io.EOF
+}
+
 func (e CommandExecutor) Execute(ctx context.Context, opts Options, out io.Writer) error {
-	in := os.Stdin
+	var in io.Reader = nullReader{}
 	if opts.Interactive && !isatty.IsTerminal(os.Stdin.Fd()) {
 		tty, err := os.Open("/dev/tty")
 		if err == nil {

--- a/internal/lefthook/run/exec/execute_windows.go
+++ b/internal/lefthook/run/exec/execute_windows.go
@@ -29,8 +29,13 @@ func (e CommandExecutor) Execute(ctx context.Context, opts Options, out io.Write
 		)
 	}
 
+	var in io.Reader = nullReader{}
+	if opts.Interactive || opts.UseStdin {
+		in = os.Stdin
+	}
+
 	args := &executeArgs{
-		in:   os.Stdin,
+		in:   in,
 		out:  out,
 		envs: envs,
 		root: root,

--- a/internal/lefthook/run/exec/nullReader.go
+++ b/internal/lefthook/run/exec/nullReader.go
@@ -1,0 +1,10 @@
+package exec
+
+import "io"
+
+// nullReader always returns EOF.
+type nullReader struct{}
+
+func (nullReader) Read(b []byte) (int, error) {
+	return 0, io.EOF
+}


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/588

**:wrench: Summary**

Right now commands that don't use STDIN still receive it, and lefthook copies STDIN from the TTY to those commands. This is not correct. This PRs enables STDIN forwarding only when an option is specified (`interactive` or `use_stdin`)