### PR TITLE
Also glob commands without templates & `files`

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,10 +33,15 @@ func newRunCmd(opts *lefthook.Options) *cobra.Command {
 
 	runCmd.Flags().BoolVar(
 		&runArgs.AllFiles, "all-files", false,
-		"run hooks on all files",
+		"run hooks on all files in the Git index",
 	)
 
-	runCmd.Flags().StringSliceVar(&runArgs.Files, "files", nil, "run on specified files. takes precedence over --all-files")
+	runCmd.Flags().BoolVar(
+		&runArgs.AllFilesIncludingUntracked, "all-including-untracked-files", false,
+		"run hooks on all files, including untracked ones",
+	)
+
+	runCmd.Flags().StringSliceVar(&runArgs.Files, "files", nil, "run on specified files. takes precedence over --all-files and --all-including-untracked-filesß")
 
 	runCmd.Flags().StringSliceVar(&runArgs.RunOnlyCommands, "commands", nil, "run only specified commands")
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -130,7 +130,7 @@ You can also specify a flag to run only some commands:
 $ lefthook run pre-commit --commands lint
 ```
 
-and optionally run either on all files (any `{staged_files}` placeholder acts as `{all_files}`) or a list of files:
+and optionally run either on all files in the Git index (any `{staged_files}` placeholder acts as `{all_files}`) or a list of files:
 
 ```bash
 $ lefthook run pre-commit --all-files
@@ -138,6 +138,8 @@ $ lefthook run pre-commit --files file1.js,file2.js
 ```
 
 (if both are specified, `--all-files` is ignored)
+
+In the same way, you can use `--all-including-untracked-files`.
 
 ### `lefthook version`
 

--- a/internal/config/files.go
+++ b/internal/config/files.go
@@ -3,10 +3,11 @@ package config
 import "strings"
 
 const (
-	SubFiles       string = "{files}"
-	SubAllFiles    string = "{all_files}"
-	SubStagedFiles string = "{staged_files}"
-	PushFiles      string = "{push_files}"
+	SubFiles                      string = "{files}"
+	SubAllFiles                   string = "{all_files}"
+	SubAllFilesIncludingUntracked string = "{all_including_untracked_files}"
+	SubStagedFiles                string = "{staged_files}"
+	PushFiles                     string = "{push_files}"
 )
 
 func isRunnerFilesCompatible(runner string) bool {

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -11,17 +11,18 @@ import (
 )
 
 const (
-	cmdRootPath      = "git rev-parse --show-toplevel"
-	cmdHooksPath     = "git rev-parse --git-path hooks"
-	cmdInfoPath      = "git rev-parse --git-path info"
-	cmdGitPath       = "git rev-parse --git-dir"
-	cmdStagedFiles   = "git diff --name-only --cached --diff-filter=ACMR"
-	cmdAllFiles      = "git ls-files --cached"
-	cmdPushFilesBase = "git diff --name-only HEAD @{push}"
-	cmdPushFilesHead = "git diff --name-only HEAD %s"
-	cmdStatusShort   = "git status --short"
-	cmdCreateStash   = "git stash create"
-	cmdListStash     = "git stash list"
+	cmdRootPath                   = "git rev-parse --show-toplevel"
+	cmdHooksPath                  = "git rev-parse --git-path hooks"
+	cmdInfoPath                   = "git rev-parse --git-path info"
+	cmdGitPath                    = "git rev-parse --git-dir"
+	cmdStagedFiles                = "git diff --name-only --cached --diff-filter=ACMR"
+	cmdAllFiles                   = "git ls-files --cached"
+	cmdAllFilesIncludingUntracked = "git ls-files --cached --others --exclude-standard"
+	cmdPushFilesBase              = "git diff --name-only HEAD @{push}"
+	cmdPushFilesHead              = "git diff --name-only HEAD %s"
+	cmdStatusShort                = "git status --short"
+	cmdCreateStash                = "git stash create"
+	cmdListStash                  = "git stash list"
 
 	stashMessage      = "lefthook auto backup"
 	unstagedPatchName = "lefthook-unstaged.patch"
@@ -101,6 +102,12 @@ func (r *Repository) StagedFiles() ([]string, error) {
 // or an error if git command fails.
 func (r *Repository) AllFiles() ([]string, error) {
 	return r.FilesByCommand(cmdAllFiles)
+}
+
+// StagedFiles returns a list of all files in repository
+// or an error if git command fails.
+func (r *Repository) AllFilesIncludingUntracked() ([]string, error) {
+	return r.FilesByCommand(cmdAllFilesIncludingUntracked)
 }
 
 // PushFiles returns a list of files that are ready to be pushed

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -23,11 +23,12 @@ const (
 )
 
 type RunArgs struct {
-	NoTTY           bool
-	AllFiles        bool
-	Force           bool
-	Files           []string
-	RunOnlyCommands []string
+	NoTTY                      bool
+	AllFiles                   bool
+	AllFilesIncludingUntracked bool
+	Force                      bool
+	Files                      []string
+	RunOnlyCommands            []string
 }
 
 func Run(opts *Options, args RunArgs, hookName string, gitArgs []string) error {
@@ -116,17 +117,18 @@ Run 'lefthook install' manually.`,
 
 	runner := run.NewRunner(
 		run.Options{
-			Repo:            l.repo,
-			Hook:            hook,
-			HookName:        hookName,
-			GitArgs:         gitArgs,
-			ResultChan:      resultChan,
-			SkipSettings:    logSettings,
-			DisableTTY:      cfg.NoTTY || args.NoTTY,
-			AllFiles:        args.AllFiles,
-			Files:           args.Files,
-			Force:           args.Force,
-			RunOnlyCommands: args.RunOnlyCommands,
+			Repo:                       l.repo,
+			Hook:                       hook,
+			HookName:                   hookName,
+			GitArgs:                    gitArgs,
+			ResultChan:                 resultChan,
+			SkipSettings:               logSettings,
+			DisableTTY:                 cfg.NoTTY || args.NoTTY,
+			Files:                      args.Files,
+			AllFiles:                   args.AllFiles,
+			AllFilesIncludingUntracked: args.AllFilesIncludingUntracked,
+			Force:                      args.Force,
+			RunOnlyCommands:            args.RunOnlyCommands,
 		},
 	)
 

--- a/internal/lefthook/run/prepare_command.go
+++ b/internal/lefthook/run/prepare_command.go
@@ -79,14 +79,17 @@ func (r *Runner) buildRun(command *config.Command) (*run, error, error) {
 		stagedFiles = func() ([]string, error) { return r.Files, nil }
 	case r.AllFiles:
 		stagedFiles = r.Repo.AllFiles
+	case r.AllFilesIncludingUntracked:
+		stagedFiles = r.Repo.AllFilesIncludingUntracked
 	default:
 		stagedFiles = r.Repo.StagedFiles
 	}
 
 	filesFns := map[string]func() ([]string, error){
-		config.SubStagedFiles: stagedFiles,
-		config.PushFiles:      r.Repo.PushFiles,
-		config.SubAllFiles:    r.Repo.AllFiles,
+		config.SubStagedFiles:               stagedFiles,
+		config.PushFiles:                    r.Repo.PushFiles,
+		config.SubAllFiles:                  r.Repo.AllFiles,
+		config.SubAllFilesIncludingUntracked: r.Repo.AllFilesIncludingUntracked,
 		config.SubFiles: func() ([]string, error) {
 			return r.Repo.FilesByCommand(filesCmd)
 		},

--- a/internal/lefthook/run/runner.go
+++ b/internal/lefthook/run/runner.go
@@ -38,17 +38,18 @@ const (
 var surroundingQuotesRegexp = regexp.MustCompile(`^'(.*)'$`)
 
 type Options struct {
-	Repo            *git.Repository
-	Hook            *config.Hook
-	HookName        string
-	GitArgs         []string
-	ResultChan      chan Result
-	SkipSettings    log.SkipSettings
-	DisableTTY      bool
-	AllFiles        bool
-	Force           bool
-	Files           []string
-	RunOnlyCommands []string
+	Repo                       *git.Repository
+	Hook                       *config.Hook
+	HookName                   string
+	GitArgs                    []string
+	ResultChan                 chan Result
+	SkipSettings               log.SkipSettings
+	DisableTTY                 bool
+	AllFiles                   bool
+	AllFilesIncludingUntracked bool
+	Force                      bool
+	Files                      []string
+	RunOnlyCommands            []string
 }
 
 // Runner responds for actual execution and handling the results.


### PR DESCRIPTION
Closes # (issue)

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

Commands that neither had templates in `run` nor `files` didn't apply file globs, even if the`--all-files` or `all-including-untracked-files` CLI param was set. Applying globs is useful to limit commands that run on a fixed path (e.g., `src/`) and don't use templates, but should only run if relevant paths have changed.

#### :ballot_box_with_check: Checklist

Please merge #594 first. 

- [x] Check locally
- [ ] Add tests
- [x] Add documentation: should not be needed, since this behavior is in line with the current docs. In that sense, this change fixes a defect.
