### PR TITLE
More robust collection of file paths

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evilmartians/lefthook/internal/lefthook"
+	"github.com/evilmartians/lefthook/internal/log"
 )
 
 func newRunCmd(opts *lefthook.Options) *cobra.Command {
@@ -41,7 +42,12 @@ func newRunCmd(opts *lefthook.Options) *cobra.Command {
 		"get files from standard input, null-separated, instead of from CLI parameters --file(s)",
 	)
 
-	runCmd.Flags().StringSliceVar(&runArgs.Files, "files", nil, "[DEPRECATED] run on specified files, comma-separated. takes precedence over --all-files")
+	runCmd.Flags().StringSliceVar(&runArgs.Files, "files", nil, "run on specified files, comma-separated. takes precedence over --all-files")
+
+	err := runCmd.Flags().MarkDeprecated("files", "use --file flag instead")
+	if err != nil {
+		log.Warn("Unexpected error:", err)
+	}
 
 	runCmd.Flags().StringArrayVar(&runArgs.Files, "file", nil, "run on specified file (repeat for multiple files). takes precedence over --all-files")
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -36,6 +36,11 @@ func newRunCmd(opts *lefthook.Options) *cobra.Command {
 		"run hooks on all files",
 	)
 
+	runCmd.Flags().BoolVar(
+		&runArgs.FilesFromStdin, "files-from-stdin", false,
+		"get files from standard input, null-separated, instead of from CLI parameters --file(s)",
+	)
+
 	runCmd.Flags().StringSliceVar(&runArgs.Files, "files", nil, "[DEPRECATED] run on specified files, comma-separated. takes precedence over --all-files")
 
 	runCmd.Flags().StringArrayVar(&runArgs.Files, "file", nil, "run on specified file (repeat for multiple files). takes precedence over --all-files")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -39,19 +39,28 @@ func newRunCmd(opts *lefthook.Options) *cobra.Command {
 
 	runCmd.Flags().BoolVar(
 		&runArgs.FilesFromStdin, "files-from-stdin", false,
-		"get files from standard input, null-separated, instead of from CLI parameters --file(s)",
+		"get files from standard input, null- or \\n-separated",
 	)
 
-	runCmd.Flags().StringSliceVar(&runArgs.Files, "files", nil, "run on specified files, comma-separated. takes precedence over --all-files")
+	runCmd.Flags().StringSliceVar(
+		&runArgs.Files, "files", nil,
+		"run on specified files, comma-separated",
+	)
+
+	runCmd.Flags().StringArrayVar(
+		&runArgs.Files, "file", nil,
+		"run on specified file (repeat for multiple files). takes precedence over --all-files",
+	)
+
+	runCmd.Flags().StringSliceVar(
+		&runArgs.RunOnlyCommands, "commands", nil,
+		"run only specified commands",
+	)
 
 	err := runCmd.Flags().MarkDeprecated("files", "use --file flag instead")
 	if err != nil {
 		log.Warn("Unexpected error:", err)
 	}
-
-	runCmd.Flags().StringArrayVar(&runArgs.Files, "file", nil, "run on specified file (repeat for multiple files). takes precedence over --all-files")
-
-	runCmd.Flags().StringSliceVar(&runArgs.RunOnlyCommands, "commands", nil, "run only specified commands")
 
 	return &runCmd
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -36,7 +36,9 @@ func newRunCmd(opts *lefthook.Options) *cobra.Command {
 		"run hooks on all files",
 	)
 
-	runCmd.Flags().StringSliceVar(&runArgs.Files, "files", nil, "run on specified files. takes precedence over --all-files")
+	runCmd.Flags().StringSliceVar(&runArgs.Files, "files", nil, "[DEPRECATED] run on specified files, comma-separated. takes precedence over --all-files")
+
+	runCmd.Flags().StringArrayVar(&runArgs.Files, "file", nil, "run on specified file (repeat for multiple files). takes precedence over --all-files")
 
 	runCmd.Flags().StringSliceVar(&runArgs.RunOnlyCommands, "commands", nil, "run only specified commands")
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -134,7 +134,7 @@ and optionally run either on all files (any `{staged_files}` placeholder acts as
 
 ```bash
 $ lefthook run pre-commit --all-files
-$ lefthook run pre-commit --files file1.js,file2.js
+$ lefthook run pre-commit --file file1.js --file file2.js
 ```
 
 (if both are specified, `--all-files` is ignored)

--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -25,10 +25,11 @@ type Command struct {
 	Exclude  string `mapstructure:"exclude"  yaml:",omitempty" json:"exclude,omitempty"  toml:"exclude,omitempty"`
 	Priority int    `mapstructure:"priority" yaml:",omitempty" json:"priority,omitempty" toml:"priority,omitempty"`
 
-	FailText    string `mapstructure:"fail_text"   yaml:"fail_text,omitempty"   json:"fail_text,omitempty"   toml:"fail_text,omitempty"`
-	Interactive bool   `mapstructure:"interactive" yaml:",omitempty"            json:"interactive,omitempty" toml:"interactive,omitempty"`
-	UseStdin    bool   `mapstructure:"use_stdin"   yaml:",omitempty"            json:"use_stdin,omitempty"   toml:"use_stdin,omitempty"`
-	StageFixed  bool   `mapstructure:"stage_fixed" yaml:"stage_fixed,omitempty" json:"stage_fixed,omitempty" toml:"stage_fixed,omitempty"`
+	FailText       string `mapstructure:"fail_text"        yaml:"fail_text,omitempty"   json:"fail_text,omitempty"        toml:"fail_text,omitempty"`
+	Interactive    bool   `mapstructure:"interactive"      yaml:",omitempty"            json:"interactive,omitempty"      toml:"interactive,omitempty"`
+	UseStdin       bool   `mapstructure:"use_stdin"        yaml:",omitempty"            json:"use_stdin,omitempty"        toml:"use_stdin,omitempty"`
+	StageFixed     bool   `mapstructure:"stage_fixed"      yaml:"stage_fixed,omitempty" json:"stage_fixed,omitempty"      toml:"stage_fixed,omitempty"`
+	FilesFromStdin bool   `mapstructure:"files_from_stdin" yaml:",omitempty"            json:"files_from_stdin,omitempty" toml:"files_from_stdin,omitempty"`
 }
 
 func (c Command) Validate() error {

--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -25,11 +25,10 @@ type Command struct {
 	Exclude  string `mapstructure:"exclude"  yaml:",omitempty" json:"exclude,omitempty"  toml:"exclude,omitempty"`
 	Priority int    `mapstructure:"priority" yaml:",omitempty" json:"priority,omitempty" toml:"priority,omitempty"`
 
-	FailText       string `mapstructure:"fail_text"        yaml:"fail_text,omitempty"   json:"fail_text,omitempty"        toml:"fail_text,omitempty"`
-	Interactive    bool   `mapstructure:"interactive"      yaml:",omitempty"            json:"interactive,omitempty"      toml:"interactive,omitempty"`
-	UseStdin       bool   `mapstructure:"use_stdin"        yaml:",omitempty"            json:"use_stdin,omitempty"        toml:"use_stdin,omitempty"`
-	StageFixed     bool   `mapstructure:"stage_fixed"      yaml:"stage_fixed,omitempty" json:"stage_fixed,omitempty"      toml:"stage_fixed,omitempty"`
-	FilesFromStdin bool   `mapstructure:"files_from_stdin" yaml:",omitempty"            json:"files_from_stdin,omitempty" toml:"files_from_stdin,omitempty"`
+	FailText    string `mapstructure:"fail_text"        yaml:"fail_text,omitempty"   json:"fail_text,omitempty"        toml:"fail_text,omitempty"`
+	Interactive bool   `mapstructure:"interactive"      yaml:",omitempty"            json:"interactive,omitempty"      toml:"interactive,omitempty"`
+	UseStdin    bool   `mapstructure:"use_stdin"        yaml:",omitempty"            json:"use_stdin,omitempty"        toml:"use_stdin,omitempty"`
+	StageFixed  bool   `mapstructure:"stage_fixed"      yaml:"stage_fixed,omitempty" json:"stage_fixed,omitempty"      toml:"stage_fixed,omitempty"`
 }
 
 func (c Command) Validate() error {

--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -25,10 +25,10 @@ type Command struct {
 	Exclude  string `mapstructure:"exclude"  yaml:",omitempty" json:"exclude,omitempty"  toml:"exclude,omitempty"`
 	Priority int    `mapstructure:"priority" yaml:",omitempty" json:"priority,omitempty" toml:"priority,omitempty"`
 
-	FailText    string `mapstructure:"fail_text"        yaml:"fail_text,omitempty"   json:"fail_text,omitempty"        toml:"fail_text,omitempty"`
-	Interactive bool   `mapstructure:"interactive"      yaml:",omitempty"            json:"interactive,omitempty"      toml:"interactive,omitempty"`
-	UseStdin    bool   `mapstructure:"use_stdin"        yaml:",omitempty"            json:"use_stdin,omitempty"        toml:"use_stdin,omitempty"`
-	StageFixed  bool   `mapstructure:"stage_fixed"      yaml:"stage_fixed,omitempty" json:"stage_fixed,omitempty"      toml:"stage_fixed,omitempty"`
+	FailText    string `mapstructure:"fail_text"   yaml:"fail_text,omitempty"   json:"fail_text,omitempty"   toml:"fail_text,omitempty"`
+	Interactive bool   `mapstructure:"interactive" yaml:",omitempty"            json:"interactive,omitempty" toml:"interactive,omitempty"`
+	UseStdin    bool   `mapstructure:"use_stdin"   yaml:",omitempty"            json:"use_stdin,omitempty"   toml:"use_stdin,omitempty"`
+	StageFixed  bool   `mapstructure:"stage_fixed" yaml:"stage_fixed,omitempty" json:"stage_fixed,omitempty" toml:"stage_fixed,omitempty"`
 }
 
 func (c Command) Validate() error {

--- a/internal/config/files.go
+++ b/internal/config/files.go
@@ -6,11 +6,11 @@ const (
 	SubFiles       string = "{files}"
 	SubAllFiles    string = "{all_files}"
 	SubStagedFiles string = "{staged_files}"
-	PushFiles      string = "{push_files}"
+	SubPushFiles   string = "{push_files}"
 )
 
 func isRunnerFilesCompatible(runner string) bool {
-	if strings.Contains(runner, SubStagedFiles) && strings.Contains(runner, PushFiles) {
+	if strings.Contains(runner, SubStagedFiles) && strings.Contains(runner, SubPushFiles) {
 		return false
 	}
 	return true

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -25,6 +25,7 @@ const (
 type RunArgs struct {
 	NoTTY           bool
 	AllFiles        bool
+	FilesFromStdin  bool
 	Force           bool
 	Files           []string
 	RunOnlyCommands []string
@@ -124,6 +125,7 @@ Run 'lefthook install' manually.`,
 			SkipSettings:    logSettings,
 			DisableTTY:      cfg.NoTTY || args.NoTTY,
 			AllFiles:        args.AllFiles,
+			FilesFromStdin:  args.FilesFromStdin,
 			Files:           args.Files,
 			Force:           args.Force,
 			RunOnlyCommands: args.RunOnlyCommands,

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -246,6 +246,7 @@ func printSummary(
 	}
 }
 
+// parseFilesFromString parses both `\0`- and `\n`-separated files.
 func parseFilesFromString(paths string) []string {
 	var result []string
 	start := 0

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -115,13 +115,13 @@ Run 'lefthook install' manually.`,
 	if args.FilesFromStdin {
 		paths, err := io.ReadAll(os.Stdin)
 		if err != nil {
-			return fmt.Errorf("error reading standard input: %w", err)
+			return fmt.Errorf("failed to read the files from standard input: %w", err)
 		}
 		args.Files = append(args.Files, parseFilesFromString(string(paths))...)
 	} else if args.AllFiles {
 		files, err := l.repo.AllFiles()
 		if err != nil {
-			return fmt.Errorf("Couldn't get all files: %w", err)
+			return fmt.Errorf("failed to get all files: %w", err)
 		}
 		args.Files = append(args.Files, files...)
 	}

--- a/internal/lefthook/run/prepare_command.go
+++ b/internal/lefthook/run/prepare_command.go
@@ -1,10 +1,8 @@
 package run
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 
@@ -66,35 +64,8 @@ func (r *Runner) prepareCommand(name string, command *config.Command) (*run, err
 	return args, nil
 }
 
-func splitNullTerminatedPaths(s string) []string {
-	var result []string
-	start := 0
-	for i, c := range s {
-		if c == 0 {
-			result = append(result, s[start:i])
-			start = i + 1
-		}
-	}
-	result = append(result, s[start:])
-	return result
-}
-
 func (r *Runner) buildRun(command *config.Command) (*run, error, error) {
 	filesCmd := r.Hook.Files
-	if command.FilesFromStdin || r.FilesFromStdin {
-		scanner := bufio.NewScanner(os.Stdin)
-		scanner.Split(bufio.ScanLines)
-
-		for scanner.Scan() {
-			line := scanner.Text()
-			r.Files = splitNullTerminatedPaths(line)
-		}
-
-		if err := scanner.Err(); err != nil {
-			return nil, fmt.Errorf("error reading standard input: %w", err), nil
-		}
-	}
-
 	if len(command.Files) > 0 {
 		filesCmd = command.Files
 	}

--- a/internal/lefthook/run/prepare_command.go
+++ b/internal/lefthook/run/prepare_command.go
@@ -118,7 +118,7 @@ func (r *Runner) buildRun(command *config.Command) (*run, error, error) {
 
 		files, err := fn()
 		if err != nil {
-			return nil, fmt.Errorf("failed to read file paths from standard input: %w", err), nil
+			return nil, fmt.Errorf("error replacing %s: %w", filesType, err), nil
 		}
 
 		files = filter.Apply(command, files)

--- a/internal/lefthook/run/runner.go
+++ b/internal/lefthook/run/runner.go
@@ -45,8 +45,6 @@ type Options struct {
 	ResultChan      chan Result
 	SkipSettings    log.SkipSettings
 	DisableTTY      bool
-	AllFiles        bool
-	FilesFromStdin  bool
 	Force           bool
 	Files           []string
 	RunOnlyCommands []string

--- a/internal/lefthook/run/runner.go
+++ b/internal/lefthook/run/runner.go
@@ -46,6 +46,7 @@ type Options struct {
 	SkipSettings    log.SkipSettings
 	DisableTTY      bool
 	AllFiles        bool
+	FilesFromStdin  bool
 	Force           bool
 	Files           []string
 	RunOnlyCommands []string

--- a/testdata/files_override.txt
+++ b/testdata/files_override.txt
@@ -1,0 +1,42 @@
+exec git init
+exec lefthook install
+exec git add -A
+
+exec lefthook run echo
+stdout 'a-file\.js'
+
+exec lefthook run echo --all-files
+stdout 'a-file\.js b_file\.go c,file\.rb'
+
+exec lefthook run echo --file a-file.js --file ghost.file
+stdout 'a-file\.js ghost\.file'
+
+stdin b_file.go
+exec lefthook run echo --files-from-stdin
+stdout 'b_file\.go c,file\.rb'
+
+stdin b_file.go
+exec lefthook run echo --files-from-stdin --file ghost.file
+stdout 'ghost\.file b_file\.go c,file\.rb'
+
+-- lefthook.yml --
+skip_output:
+  - meta
+  - execution_info
+  - summary
+
+echo:
+  commands:
+    echo:
+      files: echo a-file.js
+      run: echo "{files}"
+
+-- a-file.js --
+a-file.js
+
+-- b_file.go --
+b_file.go
+c,file.rb
+
+-- c,file.rb --
+c,file.rb


### PR DESCRIPTION
Closes #564.

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

Lefthook is currently not completely ready for repositories with filenames that contain commas.

1. Add `--file` as the successor of `--files`. This option can be repeated for a list of file paths. `--files` is dangerous, e.g., one can create a file `README.md,..` and if it gets supplied to a fixer, who knows what happens.
2. Add `--files-from-stdin`. This option reads file paths from stdin, separated by a null character. This allows for file names with a comma or newline, and is interoperable with Git and Unix tools (e.g., `git ls-files -z`, `git diff --name-only -z`, `find -print0`).

@mrexox Can you test and add automated tests? I specifically advise to test interaction with existing stdin-related features.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
- [x] Add documentation
