### PR TITLE
Don't auto-install lefthook if not found

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -108,19 +108,19 @@ func NewRepository(fs afero.Fs, git *CommandExecutor) (*Repository, error) {
 // StagedFiles returns a list of staged files
 // or an error if git command fails.
 func (r *Repository) StagedFiles() ([]string, error) {
-	return r.FilesByCommand(cmdStagedFiles)
+	return r.FilesByCommand(cmdStagedFiles, "")
 }
 
 // StagedFiles returns a list of all files in repository
 // or an error if git command fails.
 func (r *Repository) AllFiles() ([]string, error) {
-	return r.FilesByCommand(cmdAllFiles)
+	return r.FilesByCommand(cmdAllFiles, "")
 }
 
 // PushFiles returns a list of files that are ready to be pushed
 // or an error if git command fails.
 func (r *Repository) PushFiles() ([]string, error) {
-	res, err := r.FilesByCommand(cmdPushFilesBase)
+	res, err := r.FilesByCommand(cmdPushFilesBase, "")
 	if err == nil {
 		return res, nil
 	}
@@ -147,7 +147,7 @@ func (r *Repository) PushFiles() ([]string, error) {
 		r.headBranch = r.emptyTreeSHA
 	}
 
-	return r.FilesByCommand(append(cmdPushFilesHead, r.headBranch))
+	return r.FilesByCommand(append(cmdPushFilesHead, r.headBranch), "")
 }
 
 // PartiallyStagedFiles returns the list of files that have both staged and
@@ -316,8 +316,8 @@ func (r *Repository) AddFiles(files []string) error {
 }
 
 // FilesByCommand accepts git command and returns its result as a list of filepaths.
-func (r *Repository) FilesByCommand(command []string) ([]string, error) {
-	lines, err := r.Git.CmdLines(command)
+func (r *Repository) FilesByCommand(command []string, folder string) ([]string, error) {
+	lines, err := r.Git.CmdLinesWithinFolder(command, folder)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/lefthook/runner/prepare_command.go
+++ b/internal/lefthook/runner/prepare_command.go
@@ -80,7 +80,7 @@ func (r *Runner) buildRun(command *config.Command) (*run, error) {
 			} else {
 				cmd = []string{"sh", "-c", filesCmd}
 			}
-			return r.Repo.FilesByCommand(cmd)
+			return r.Repo.FilesByCommand(cmd, command.Root)
 		}
 	}
 

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -73,9 +73,6 @@ call_lefthook()
     elif command -v mint >/dev/null 2>&1
     then
       mint run csjones/lefthook-plugin "$@"
-    elif command -v npx >/dev/null 2>&1
-    then
-      npx lefthook "$@"
     else
       echo "Can't find lefthook in PATH"
       {{- if .AssertLefthookInstalled}}


### PR DESCRIPTION
Closes # (issue)

<!-- Link to an issue(s) this PR fixes -->
https://github.com/evilmartians/lefthook/discussions/599

#### :zap: Summary

<!-- Brief description of what was done -->

As-is, if lefthook is not found, it will auto-install the latest lefthook from npm. (npx auto-fetches by default)

This isn't great:

1. Security: npm isn't known for being the most secure platform, and if the package was the target of an attack, _all_ lefthook users with node installed would be affected, even those who don't use the lefthook npm package.

2. User friendliness: installing binaries on the user's computer without their permission isn't great, and one of those lefthook binaries (an .exe file) was flagged by an anti-malware package at my organization.

It seems that the intention was to just print a message when lefthook is not found (which I agree with) and it's possible that using npx's fetch-if-not-installed behaviour was just an oversight when implementing this. That said, anyone who has node installed will not get that far, and will be subject to the auto-install behaviour.

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
- [ ] Add documentation
