### PR TITLE
fix: use lefthook package with npx

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -44,7 +44,7 @@ call_lefthook()
     pnpm lefthook "$@"
   elif command -v npx >/dev/null 2>&1
   then
-    npx @evilmartians/lefthook "$@"
+    npx lefthook "$@"
   elif swift package plugin lefthook >/dev/null 2>&1
   then
     swift package --disable-sandbox plugin lefthook "$@"


### PR DESCRIPTION
**:wrench: Summary**

`@evilmartians/lefthook` embeds all binaries and it is not optimal to download such a big package when only one binary is used. 
Change `@evilmartians/lefthook` to `lefthook` npm package for `npx` call.
