### PR TITLE
fix: files from stdin only null separated

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -60,7 +60,7 @@ func newRunCmd(opts *lefthook.Options) *cobra.Command {
 
 	runCmd.Flags().BoolVar(
 		&runArgs.FilesFromStdin, "files-from-stdin", false,
-		"get files from standard input, null- or \\n-separated",
+		"get files from standard input, null-separated",
 	)
 
 	runCmd.Flags().StringSliceVar(

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -294,12 +294,12 @@ func (l *Lefthook) configHookCommandCompletions(hookName string) []string {
 	}
 }
 
-// parseFilesFromString parses both `\0`- and `\n`-separated files.
+// parseFilesFromString parses both `\0`-separated files.
 func parseFilesFromString(paths string) []string {
 	var result []string
 	start := 0
 	for i, c := range paths {
-		if c == 0 || c == '\n' {
+		if c == 0 {
 			result = append(result, paths[start:i])
 			start = i + 1
 		}

--- a/testdata/files_override.txt
+++ b/testdata/files_override.txt
@@ -11,14 +11,6 @@ stdout 'a-file\.js b_file\.go c,file\.rb'
 exec lefthook run echo --file a-file.js --file ghost.file
 stdout 'a-file\.js ghost\.file'
 
-stdin b_file.go
-exec lefthook run echo --files-from-stdin
-stdout 'b_file\.go c,file\.rb'
-
-stdin b_file.go
-exec lefthook run echo --files-from-stdin --file ghost.file
-stdout 'ghost\.file b_file\.go c,file\.rb'
-
 -- lefthook.yml --
 skip_output:
   - meta
@@ -36,7 +28,6 @@ a-file.js
 
 -- b_file.go --
 b_file.go
-c,file.rb
 
 -- c,file.rb --
 c,file.rb


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/564

**:wrench: Summary**

Keep only null separation logic
