### PR TITLE
fix: respect roots in commands for npm packages

### DIFF
--- a/internal/lefthook/add.go
+++ b/internal/lefthook/add.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/evilmartians/lefthook/internal/config"
+	"github.com/evilmartians/lefthook/internal/templates"
 )
 
 const defaultDirMode = 0o755
@@ -39,7 +40,7 @@ func (l *Lefthook) Add(args *AddArgs) error {
 		return err
 	}
 
-	err = l.addHook(args.Hook, "", false)
+	err = l.addHook(args.Hook, templates.Args{})
 	if err != nil {
 		return err
 	}

--- a/internal/lefthook/lefthook.go
+++ b/internal/lefthook/lefthook.go
@@ -117,9 +117,9 @@ func (l *Lefthook) cleanHook(hook string, force bool) error {
 }
 
 // Creates a hook file using hook template.
-func (l *Lefthook) addHook(hook, rc string, assertLefthookInstalled bool) error {
+func (l *Lefthook) addHook(hook string, args templates.Args) error {
 	hookPath := filepath.Join(l.repo.HooksPath, hook)
 	return afero.WriteFile(
-		l.Fs, hookPath, templates.Hook(hook, rc, assertLefthookInstalled), hookFileMode,
+		l.Fs, hookPath, templates.Hook(hook, args), hookFileMode,
 	)
 }

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -34,7 +34,7 @@ call_lefthook()
   then
     "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
   {{ $extension := .Extension }}
-  {{- range .Roots}}
+  {{- range .Roots -}}
   elif test -f "$dir/{{.}}/node_modules/lefthook/bin/index.js"
   then
     "$dir/{{.}}/node_modules/lefthook/bin/index.js" "$@"

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -33,6 +33,18 @@ call_lefthook()
   elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
   then
     "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
+  {{ $extension := .Extension }}
+  {{- range .Roots}}
+  elif test -f "$dir/{{.}}/node_modules/lefthook/bin/index.js"
+  then
+    "$dir/{{.}}/node_modules/lefthook/bin/index.js" "$@"
+  elif test -f "$dir/{{.}}/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}"
+  then
+    "$dir/{{.}}/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}" "$@"
+  elif test -f "$dir/{{.}}/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}"
+  then
+    "$dir/{{.}}/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}" "$@"
+  {{end}}
   elif bundle exec lefthook -h >/dev/null 2>&1
   then
     bundle exec lefthook "$@"

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -13,21 +13,29 @@ const checksumFormat = "%s %d\n"
 //go:embed *
 var templatesFS embed.FS
 
+type Args struct {
+	Rc                      string
+	AssertLefthookInstalled bool
+	Roots                   []string
+}
+
 type hookTmplData struct {
 	HookName                string
 	Extension               string
 	Rc                      string
+	Roots                   []string
 	AssertLefthookInstalled bool
 }
 
-func Hook(hookName, rc string, assertLefthookInstalled bool) []byte {
+func Hook(hookName string, args Args) []byte {
 	buf := &bytes.Buffer{}
 	t := template.Must(template.ParseFS(templatesFS, "hook.tmpl"))
 	err := t.Execute(buf, hookTmplData{
 		HookName:                hookName,
 		Extension:               getExtension(),
-		Rc:                      rc,
-		AssertLefthookInstalled: assertLefthookInstalled,
+		Rc:                      args.Rc,
+		AssertLefthookInstalled: args.AssertLefthookInstalled,
+		Roots:                   args.Roots,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/610 https://github.com/evilmartians/lefthook/issues/510

**:wrench: Summary**

- [x] Take `root` values from all commands and use them in the hook template to search for lefthook executable.