### PR TITLE
Add new output instead skip_output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,7 +163,45 @@ If you want to specify a minimum version for lefthook binary (e.g. if you need s
 min_version: 1.1.3
 ```
 
+### `output`
+
+You can manage verbosity using the `output` config. You can specify what to print in your output by setting these values, which you need to have
+
+Possible values are `meta,summary,success,failure,execution,execution_out,execution_info,skips`.
+By default, all output values are enabled
+
+You can also disable all output with setting `output: false`. In this case only errors will be printed.
+
+This config quiets all outputs except for errors.
+
+`output` is enabled if there is no `skip_output` and `LEFTHOOK_QUIET`.
+
+**Example**
+
+```yml
+# lefthook.yml
+
+output:
+  - meta           # Print lefthook version
+  - summary        # Print summary block (successful and failed steps)
+  - empty_summary  # Print summary heading when there are no steps to run
+  - success        # Print successful steps
+  - failure        # Print failed steps printing
+  - execution      # Print any execution logs (but prints if the execution failed)
+  - execution_out  # Print execution output (but still prints failed commands output)
+  - execution_info # Print `EXECUTE > ...` logging
+  - skips          # Print "skip" (i.e. no files matched)
+```
+
+You can also *extend* this list with an environment variable `LEFTHOOK_OUTPUT`:
+
+```bash
+LEFTHOOK_OUTPUT="meta,success,summary" lefthook run pre-commit
+```
+
 ### `skip_output`
+
+> **Deprecated:** This feature is deprecated and might be removed in future versions. Please, use `[output]` instead for managing verbosity.
 
 You can manage the verbosity using the `skip_output` config. You can set whether lefthook should print some parts of its output.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	SourceDirLocal          string      `mapstructure:"source_dir_local"`
 	Rc                      string      `mapstructure:"rc,omitempty"`
 	SkipOutput              interface{} `mapstructure:"skip_output,omitempty"`
+	Output                  interface{} `mapstructure:"output,omitempty"`
 	Extends                 []string    `mapstructure:"extends,omitempty"`
 	NoTTY                   bool        `mapstructure:"no_tty,omitempty"`
 	AssertLefthookInstalled bool        `mapstructure:"assert_lefthook_installed,omitempty"`

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -76,17 +76,19 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 		log.SetLevel(log.WarnLevel)
 	}
 
-	newTags := os.Getenv(envOutput)
-	tags := os.Getenv(envSkipOutput)
+	outputLogTags := os.Getenv(envOutput)
+	outputSkipTags := os.Getenv(envSkipOutput)
 
-	var logSettings log.SettingsInterface
+	var logSettings log.Settings
 
-	if tags == "" && cfg.SkipOutput == nil {
+	if outputSkipTags == "" && cfg.SkipOutput == nil {
 		logSettings = log.NewSettings()
-		logSettings.ApplySettings(newTags, cfg.Output)
+		logSettings.ApplySettings(outputLogTags, cfg.Output)
 	} else {
+		log.Warn("skip_output is deprecated, please use output option")
+
 		logSettings = log.NewSkipSettings() //nolint:staticcheck //SA1019: for temporary backward compatibility
-		logSettings.ApplySettings(tags, cfg.SkipOutput)
+		logSettings.ApplySettings(outputSkipTags, cfg.SkipOutput)
 	}
 
 	if !logSettings.SkipMeta() {
@@ -201,7 +203,7 @@ Run 'lefthook install' manually.`,
 func printSummary(
 	duration time.Duration,
 	results []run.Result,
-	logSettings log.SettingsInterface,
+	logSettings log.Settings,
 ) {
 	summaryPrint := log.Separate
 

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -91,7 +91,7 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 		logSettings.ApplySettings(outputSkipTags, cfg.SkipOutput)
 	}
 
-	if !logSettings.SkipMeta() {
+	if logSettings.LogMeta() {
 		log.Box(
 			log.Cyan("🥊 lefthook ")+log.Gray(fmt.Sprintf("v%s", version.Version(false))),
 			log.Gray("hook: ")+log.Bold(hookName),
@@ -187,7 +187,7 @@ Run 'lefthook install' manually.`,
 		return errors.New("Interrupted")
 	}
 
-	if !logSettings.SkipSummary() {
+	if logSettings.LogSummary() {
 		printSummary(time.Since(startTime), results, logSettings)
 	}
 
@@ -207,12 +207,12 @@ func printSummary(
 ) {
 	summaryPrint := log.Separate
 
-	if logSettings.SkipExecution() || (logSettings.SkipExecutionInfo() && logSettings.SkipExecutionOutput()) {
+	if !logSettings.LogExecution() || !(logSettings.LogExecutionInfo() && logSettings.LogExecutionOutput()) {
 		summaryPrint = func(s string) { log.Info(s) }
 	}
 
 	if len(results) == 0 {
-		if !logSettings.SkipEmptySummary() {
+		if logSettings.LogEmptySummary() {
 			summaryPrint(
 				fmt.Sprintf(
 					"%s %s %s",
@@ -229,7 +229,7 @@ func printSummary(
 		log.Cyan("summary: ") + log.Gray(fmt.Sprintf("(done in %.2f seconds)", duration.Seconds())),
 	)
 
-	if !logSettings.SkipSuccess() {
+	if logSettings.LogSuccess() {
 		for _, result := range results {
 			if result.Status != run.StatusOk {
 				continue
@@ -239,7 +239,7 @@ func printSummary(
 		}
 	}
 
-	if !logSettings.SkipFailure() {
+	if logSettings.LogFailure() {
 		for _, result := range results {
 			if result.Status != run.StatusErr {
 				continue

--- a/internal/lefthook/run/runner.go
+++ b/internal/lefthook/run/runner.go
@@ -43,7 +43,7 @@ type Options struct {
 	HookName        string
 	GitArgs         []string
 	ResultChan      chan Result
-	SkipSettings    log.SettingsInterface
+	SkipSettings    log.Settings
 	DisableTTY      bool
 	Force           bool
 	Files           []string

--- a/internal/lefthook/run/runner.go
+++ b/internal/lefthook/run/runner.go
@@ -43,7 +43,7 @@ type Options struct {
 	HookName        string
 	GitArgs         []string
 	ResultChan      chan Result
-	SkipSettings    log.SkipSettings
+	SkipSettings    log.SettingsInterface
 	DisableTTY      bool
 	Force           bool
 	Files           []string

--- a/internal/lefthook/run/runner.go
+++ b/internal/lefthook/run/runner.go
@@ -426,14 +426,14 @@ func (r *Runner) run(ctx context.Context, opts exec.Options, follow bool) bool {
 	log.SetName(opts.Name)
 	defer log.UnsetName(opts.Name)
 
-	if (follow || opts.Interactive) && !r.SkipSettings.SkipExecution() {
+	if (follow || opts.Interactive) && r.SkipSettings.LogExecution() {
 		r.logExecute(opts.Name, nil, nil)
 
 		var out io.Writer
-		if r.SkipSettings.SkipExecutionOutput() {
-			out = io.Discard
-		} else {
+		if r.SkipSettings.LogExecutionOutput() {
 			out = os.Stdout
+		} else {
+			out = io.Discard
 		}
 
 		err := r.executor.Execute(ctx, opts, out)
@@ -478,7 +478,7 @@ func intersect(a, b []string) bool {
 }
 
 func (r *Runner) logSkip(name, reason string) {
-	if r.SkipSettings.SkipSkips() {
+	if !r.SkipSettings.LogSkips() {
 		return
 	}
 
@@ -493,14 +493,14 @@ func (r *Runner) logSkip(name, reason string) {
 }
 
 func (r *Runner) logExecute(name string, err error, out io.Reader) {
-	if err == nil && r.SkipSettings.SkipExecution() {
+	if err == nil && !r.SkipSettings.LogExecution() {
 		return
 	}
 
 	var execLog string
 	var color lipgloss.TerminalColor
 	switch {
-	case r.SkipSettings.SkipExecutionInfo():
+	case !r.SkipSettings.LogExecutionInfo():
 		execLog = ""
 	case err != nil:
 		execLog = log.Red(fmt.Sprintf("%s ❯ ", name))
@@ -518,7 +518,7 @@ func (r *Runner) logExecute(name string, err error, out io.Reader) {
 		log.Info()
 	}
 
-	if err == nil && r.SkipSettings.SkipExecutionOutput() {
+	if err == nil && !r.SkipSettings.LogExecutionOutput() {
 		return
 	}
 

--- a/internal/lefthook/run/runner_test.go
+++ b/internal/lefthook/run/runner_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evilmartians/lefthook/internal/config"
 	"github.com/evilmartians/lefthook/internal/git"
 	"github.com/evilmartians/lefthook/internal/lefthook/run/exec"
+	"github.com/evilmartians/lefthook/internal/log"
 )
 
 type TestExecutor struct{}
@@ -749,12 +750,13 @@ func TestRunAll(t *testing.T) {
 		executor := TestExecutor{}
 		runner := &Runner{
 			Options: Options{
-				Repo:       repo,
-				Hook:       tt.hook,
-				HookName:   tt.hookName,
-				GitArgs:    tt.args,
-				ResultChan: resultChan,
-				Force:      tt.force,
+				Repo:         repo,
+				Hook:         tt.hook,
+				HookName:     tt.hookName,
+				SkipSettings: log.NewSettings(),
+				GitArgs:      tt.args,
+				ResultChan:   resultChan,
+				Force:        tt.force,
 			},
 			executor: executor,
 		}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -60,6 +60,19 @@ const (
 	spinnerText        = " waiting"
 )
 
+type SettingsInterface interface {
+	ApplySettings(tags string, skipOutput interface{})
+	SkipSuccess() bool
+	SkipFailure() bool
+	SkipSummary() bool
+	SkipMeta() bool
+	SkipExecution() bool
+	SkipExecutionOutput() bool
+	SkipExecutionInfo() bool
+	SkipSkips() bool
+	SkipEmptySummary() bool
+}
+
 type StyleLogger struct {
 	style lipgloss.Style
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -60,19 +60,6 @@ const (
 	spinnerText        = " waiting"
 )
 
-type SettingsInterface interface {
-	ApplySettings(tags string, skipOutput interface{})
-	SkipSuccess() bool
-	SkipFailure() bool
-	SkipSummary() bool
-	SkipMeta() bool
-	SkipExecution() bool
-	SkipExecutionOutput() bool
-	SkipExecutionInfo() bool
-	SkipSkips() bool
-	SkipEmptySummary() bool
-}
-
 type StyleLogger struct {
 	style lipgloss.Style
 }

--- a/internal/log/settings.go
+++ b/internal/log/settings.go
@@ -19,15 +19,15 @@ const (
 
 type Settings interface {
 	ApplySettings(tags string, skipOutput interface{})
-	SkipSuccess() bool
-	SkipFailure() bool
-	SkipSummary() bool
-	SkipMeta() bool
-	SkipExecution() bool
-	SkipExecutionOutput() bool
-	SkipExecutionInfo() bool
-	SkipSkips() bool
-	SkipEmptySummary() bool
+	LogSuccess() bool
+	LogFailure() bool
+	LogSummary() bool
+	LogMeta() bool
+	LogExecution() bool
+	LogExecutionOutput() bool
+	LogExecutionInfo() bool
+	LogSkips() bool
+	LogEmptySummary() bool
 }
 
 type OutputSettings int16
@@ -49,6 +49,10 @@ func (s *OutputSettings) ApplySettings(tags string, output interface{}) {
 	}
 
 	if options, ok := output.([]interface{}); ok {
+		if len(options) == 0 {
+			s.enableAll(true)
+			return
+		}
 		for _, option := range options {
 			if optStr, ok := option.(string); ok {
 				s.applySetting(optStr)
@@ -90,7 +94,7 @@ func (s *OutputSettings) enableAll(val bool) {
 	if val {
 		*s = enableAll // Enable all params
 	} else {
-		*s |= skipFailure // Disable all params
+		*s |= failure // Disable all params
 	}
 }
 
@@ -99,39 +103,38 @@ func (s OutputSettings) isEnable(option int16) bool {
 	return int16(s)&option != 0
 }
 
-// Using `SkipX` to maintain backward compatibility.
-func (s OutputSettings) SkipSuccess() bool {
-	return !s.isEnable(success)
+func (s OutputSettings) LogSuccess() bool {
+	return s.isEnable(success)
 }
 
-func (s OutputSettings) SkipFailure() bool {
-	return !s.isEnable(failure)
+func (s OutputSettings) LogFailure() bool {
+	return s.isEnable(failure)
 }
 
-func (s OutputSettings) SkipSummary() bool {
-	return !s.isEnable(summary)
+func (s OutputSettings) LogSummary() bool {
+	return s.isEnable(summary)
 }
 
-func (s OutputSettings) SkipMeta() bool {
-	return !s.isEnable(meta)
+func (s OutputSettings) LogMeta() bool {
+	return s.isEnable(meta)
 }
 
-func (s OutputSettings) SkipExecution() bool {
-	return !s.isEnable(execution)
+func (s OutputSettings) LogExecution() bool {
+	return s.isEnable(execution)
 }
 
-func (s OutputSettings) SkipExecutionOutput() bool {
-	return !s.isEnable(executionOutput)
+func (s OutputSettings) LogExecutionOutput() bool {
+	return s.isEnable(executionOutput)
 }
 
-func (s OutputSettings) SkipExecutionInfo() bool {
-	return !s.isEnable(executionInfo)
+func (s OutputSettings) LogExecutionInfo() bool {
+	return s.isEnable(executionInfo)
 }
 
-func (s OutputSettings) SkipSkips() bool {
-	return !s.isEnable(skips)
+func (s OutputSettings) LogSkips() bool {
+	return s.isEnable(skips)
 }
 
-func (s OutputSettings) SkipEmptySummary() bool {
-	return !s.isEnable(emptySummary)
+func (s OutputSettings) LogEmptySummary() bool {
+	return s.isEnable(emptySummary)
 }

--- a/internal/log/settings.go
+++ b/internal/log/settings.go
@@ -1,0 +1,124 @@
+package log
+
+import (
+	"strings"
+)
+
+const (
+	meta = 1 << iota
+	success
+	failure
+	summary
+	skips
+	execution
+	executionOutput
+	executionInfo
+	emptySummary
+	enableAll = ^0 // Set all bits as 1
+)
+
+type Settings int16
+
+func NewSettings() SettingsInterface {
+	var s Settings
+	return &s
+}
+
+func (s *Settings) ApplySettings(tags string, output interface{}) {
+	if tags == "" && (output == nil || output == "") {
+		s.enableAll(true)
+		return
+	}
+
+	if val, ok := output.(bool); ok {
+		s.enableAll(val)
+		return
+	}
+
+	if options, ok := output.([]interface{}); ok {
+		for _, option := range options {
+			if optStr, ok := option.(string); ok {
+				s.applySetting(optStr)
+			}
+		}
+	}
+
+	if tags != "" {
+		for _, tag := range strings.Split(tags, ",") {
+			s.applySetting(tag)
+		}
+	}
+}
+
+func (s *Settings) applySetting(setting string) {
+	switch setting {
+	case "meta":
+		*s |= meta
+	case "success":
+		*s |= success
+	case "failure":
+		*s |= failure
+	case "summary":
+		*s |= summary
+	case "skips":
+		*s |= skips
+	case "execution":
+		*s |= execution
+	case "execution_out":
+		*s |= executionOutput
+	case "execution_info":
+		*s |= executionInfo
+	case "empty_summary":
+		*s |= emptySummary
+	}
+}
+
+func (s *Settings) enableAll(val bool) {
+	if val {
+		*s = enableAll // Enable all params
+	} else {
+		*s |= skipFailure // Disable all params
+	}
+}
+
+// Checks the state of params.
+func (s Settings) isEnable(option int16) bool {
+	return int16(s)&option != 0
+}
+
+// Using `SkipX` to maintain backward compatibility.
+func (s Settings) SkipSuccess() bool {
+	return !s.isEnable(success)
+}
+
+func (s Settings) SkipFailure() bool {
+	return !s.isEnable(failure)
+}
+
+func (s Settings) SkipSummary() bool {
+	return !s.isEnable(summary)
+}
+
+func (s Settings) SkipMeta() bool {
+	return !s.isEnable(meta)
+}
+
+func (s Settings) SkipExecution() bool {
+	return !s.isEnable(execution)
+}
+
+func (s Settings) SkipExecutionOutput() bool {
+	return !s.isEnable(executionOutput)
+}
+
+func (s Settings) SkipExecutionInfo() bool {
+	return !s.isEnable(executionInfo)
+}
+
+func (s Settings) SkipSkips() bool {
+	return !s.isEnable(skips)
+}
+
+func (s Settings) SkipEmptySummary() bool {
+	return !s.isEnable(emptySummary)
+}

--- a/internal/log/settings.go
+++ b/internal/log/settings.go
@@ -17,14 +17,27 @@ const (
 	enableAll = ^0 // Set all bits as 1
 )
 
-type Settings int16
+type Settings interface {
+	ApplySettings(tags string, skipOutput interface{})
+	SkipSuccess() bool
+	SkipFailure() bool
+	SkipSummary() bool
+	SkipMeta() bool
+	SkipExecution() bool
+	SkipExecutionOutput() bool
+	SkipExecutionInfo() bool
+	SkipSkips() bool
+	SkipEmptySummary() bool
+}
 
-func NewSettings() SettingsInterface {
-	var s Settings
+type OutputSettings int16
+
+func NewSettings() Settings {
+	var s OutputSettings
 	return &s
 }
 
-func (s *Settings) ApplySettings(tags string, output interface{}) {
+func (s *OutputSettings) ApplySettings(tags string, output interface{}) {
 	if tags == "" && (output == nil || output == "") {
 		s.enableAll(true)
 		return
@@ -50,7 +63,7 @@ func (s *Settings) ApplySettings(tags string, output interface{}) {
 	}
 }
 
-func (s *Settings) applySetting(setting string) {
+func (s *OutputSettings) applySetting(setting string) {
 	switch setting {
 	case "meta":
 		*s |= meta
@@ -73,7 +86,7 @@ func (s *Settings) applySetting(setting string) {
 	}
 }
 
-func (s *Settings) enableAll(val bool) {
+func (s *OutputSettings) enableAll(val bool) {
 	if val {
 		*s = enableAll // Enable all params
 	} else {
@@ -82,43 +95,43 @@ func (s *Settings) enableAll(val bool) {
 }
 
 // Checks the state of params.
-func (s Settings) isEnable(option int16) bool {
+func (s OutputSettings) isEnable(option int16) bool {
 	return int16(s)&option != 0
 }
 
 // Using `SkipX` to maintain backward compatibility.
-func (s Settings) SkipSuccess() bool {
+func (s OutputSettings) SkipSuccess() bool {
 	return !s.isEnable(success)
 }
 
-func (s Settings) SkipFailure() bool {
+func (s OutputSettings) SkipFailure() bool {
 	return !s.isEnable(failure)
 }
 
-func (s Settings) SkipSummary() bool {
+func (s OutputSettings) SkipSummary() bool {
 	return !s.isEnable(summary)
 }
 
-func (s Settings) SkipMeta() bool {
+func (s OutputSettings) SkipMeta() bool {
 	return !s.isEnable(meta)
 }
 
-func (s Settings) SkipExecution() bool {
+func (s OutputSettings) SkipExecution() bool {
 	return !s.isEnable(execution)
 }
 
-func (s Settings) SkipExecutionOutput() bool {
+func (s OutputSettings) SkipExecutionOutput() bool {
 	return !s.isEnable(executionOutput)
 }
 
-func (s Settings) SkipExecutionInfo() bool {
+func (s OutputSettings) SkipExecutionInfo() bool {
 	return !s.isEnable(executionInfo)
 }
 
-func (s Settings) SkipSkips() bool {
+func (s OutputSettings) SkipSkips() bool {
 	return !s.isEnable(skips)
 }
 
-func (s Settings) SkipEmptySummary() bool {
+func (s OutputSettings) SkipEmptySummary() bool {
 	return !s.isEnable(emptySummary)
 }

--- a/internal/log/settings_test.go
+++ b/internal/log/settings_test.go
@@ -30,30 +30,15 @@ func TestSetting(t *testing.T) {
 			tags:     "",
 			settings: false,
 			results: map[string]bool{
-				"meta":           true,
-				"summary":        true,
-				"success":        true,
-				"failure":        false,
-				"skips":          true,
-				"execution":      true,
-				"execution_out":  true,
-				"execution_info": true,
-				"empty_summary":  true,
+				"failure": true,
 			},
 		},
 		{
 			tags:     "",
 			settings: []interface{}{"failure", "execution"},
 			results: map[string]bool{
-				"meta":           true,
-				"summary":        true,
-				"success":        true,
-				"failure":        false,
-				"skips":          true,
-				"execution":      false,
-				"execution_out":  true,
-				"execution_info": true,
-				"empty_summary":  true,
+				"failure":   true,
+				"execution": true,
 			},
 		},
 		{
@@ -70,45 +55,41 @@ func TestSetting(t *testing.T) {
 				"empty_summary",
 			},
 			results: map[string]bool{
-				"meta":           false,
-				"summary":        false,
-				"success":        false,
-				"failure":        false,
-				"skips":          false,
-				"execution":      false,
-				"execution_out":  false,
-				"execution_info": false,
-				"empty_summary":  false,
+				"meta":           true,
+				"summary":        true,
+				"success":        true,
+				"failure":        true,
+				"skips":          true,
+				"execution":      true,
+				"execution_out":  true,
+				"execution_info": true,
+				"empty_summary":  true,
 			},
 		},
 		{
 			tags:     "",
 			settings: true,
 			results: map[string]bool{
-				"meta":           false,
-				"summary":        false,
-				"success":        false,
-				"failure":        false,
-				"skips":          false,
-				"execution":      false,
-				"execution_out":  false,
-				"execution_info": false,
-				"empty_summary":  false,
+				"meta":           true,
+				"summary":        true,
+				"success":        true,
+				"failure":        true,
+				"skips":          true,
+				"execution":      true,
+				"execution_out":  true,
+				"execution_info": true,
+				"empty_summary":  true,
 			},
 		},
 		{
 			tags:     "meta,summary,success,skips,empty_summary",
 			settings: nil,
 			results: map[string]bool{
-				"meta":           false,
-				"summary":        false,
-				"success":        false,
-				"failure":        true,
-				"skips":          false,
-				"execution":      true,
-				"execution_out":  true,
-				"execution_info": true,
-				"empty_summary":  false,
+				"meta":          true,
+				"summary":       true,
+				"success":       true,
+				"skips":         true,
+				"empty_summary": true,
 			},
 		},
 	} { //nolint:dupl // In next versions the `skip_settings_test` will be removed
@@ -117,40 +98,40 @@ func TestSetting(t *testing.T) {
 
 			(&settings).ApplySettings(tt.tags, tt.settings)
 
-			if settings.SkipMeta() != tt.results["meta"] {
-				t.Errorf("expected SkipMeta to be %v", tt.results["meta"])
+			if settings.LogMeta() != tt.results["meta"] {
+				t.Errorf("expected LogMeta to be %v", tt.results["meta"])
 			}
 
-			if settings.SkipSuccess() != tt.results["success"] {
-				t.Errorf("expected SkipSuccess to be %v", tt.results["success"])
+			if settings.LogSuccess() != tt.results["success"] {
+				t.Errorf("expected LogSuccess to be %v", tt.results["success"])
 			}
 
-			if settings.SkipFailure() != tt.results["failure"] {
-				t.Errorf("expected SkipFailure to be %v", tt.results["failure"])
+			if settings.LogFailure() != tt.results["failure"] {
+				t.Errorf("expected LogFailure to be %v", tt.results["failure"])
 			}
 
-			if settings.SkipSummary() != tt.results["summary"] {
-				t.Errorf("expected SkipSummary to be %v", tt.results["summary"])
+			if settings.LogSummary() != tt.results["summary"] {
+				t.Errorf("expected LogSummary to be %v", tt.results["summary"])
 			}
 
-			if settings.SkipExecution() != tt.results["execution"] {
-				t.Errorf("expected SkipExecution to be %v", tt.results["execution"])
+			if settings.LogExecution() != tt.results["execution"] {
+				t.Errorf("expected LogExecution to be %v", tt.results["execution"])
 			}
 
-			if settings.SkipExecutionOutput() != tt.results["execution_out"] {
-				t.Errorf("expected SkipExecutionOutput to be %v", tt.results["execution_out"])
+			if settings.LogExecutionOutput() != tt.results["execution_out"] {
+				t.Errorf("expected LogExecutionOutput to be %v", tt.results["execution_out"])
 			}
 
-			if settings.SkipExecutionInfo() != tt.results["execution_info"] {
-				t.Errorf("expected SkipExecutionInfo to be %v", tt.results["execution_info"])
+			if settings.LogExecutionInfo() != tt.results["execution_info"] {
+				t.Errorf("expected LogExecutionInfo to be %v", tt.results["execution_info"])
 			}
 
-			if settings.SkipEmptySummary() != tt.results["empty_summary"] {
-				t.Errorf("expected SkipEmptySummary to be %v", tt.results["empty_summary"])
+			if settings.LogEmptySummary() != tt.results["empty_summary"] {
+				t.Errorf("expected LogEmptySummary to be %v", tt.results["empty_summary"])
 			}
 
-			if settings.SkipSkips() != tt.results["skips"] {
-				t.Errorf("expected SkipSkips to be %v", tt.results["skip"])
+			if settings.LogSkips() != tt.results["skips"] {
+				t.Errorf("expected LogSkips to be %v", tt.results["skip"])
 			}
 		})
 	}

--- a/internal/log/settings_test.go
+++ b/internal/log/settings_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestSkipSetting(t *testing.T) {
+func TestSetting(t *testing.T) {
 	for i, tt := range [...]struct {
 		tags     string
 		settings interface{}
@@ -14,19 +14,46 @@ func TestSkipSetting(t *testing.T) {
 		{
 			tags:     "",
 			settings: []interface{}{},
-			results:  map[string]bool{},
+			results: map[string]bool{
+				"meta":           true,
+				"summary":        true,
+				"success":        true,
+				"failure":        true,
+				"skips":          true,
+				"execution":      true,
+				"execution_out":  true,
+				"execution_info": true,
+				"empty_summary":  true,
+			},
 		},
 		{
 			tags:     "",
 			settings: false,
-			results:  map[string]bool{},
+			results: map[string]bool{
+				"meta":           true,
+				"summary":        true,
+				"success":        true,
+				"failure":        false,
+				"skips":          true,
+				"execution":      true,
+				"execution_out":  true,
+				"execution_info": true,
+				"empty_summary":  true,
+			},
 		},
 		{
 			tags:     "",
 			settings: []interface{}{"failure", "execution"},
 			results: map[string]bool{
-				"failure":   true,
-				"execution": true,
+				"meta":           true,
+				"summary":        true,
+				"success":        true,
+				"failure":        false,
+				"skips":          true,
+				"execution":      false,
+				"execution_out":  true,
+				"execution_info": true,
+				"empty_summary":  true,
 			},
 		},
 		{
@@ -43,50 +70,50 @@ func TestSkipSetting(t *testing.T) {
 				"empty_summary",
 			},
 			results: map[string]bool{
-				"meta":           true,
-				"summary":        true,
-				"success":        true,
-				"failure":        true,
-				"skips":          true,
-				"execution":      true,
-				"execution_out":  true,
-				"execution_info": true,
-				"empty_summary":  true,
+				"meta":           false,
+				"summary":        false,
+				"success":        false,
+				"failure":        false,
+				"skips":          false,
+				"execution":      false,
+				"execution_out":  false,
+				"execution_info": false,
+				"empty_summary":  false,
 			},
 		},
 		{
 			tags:     "",
 			settings: true,
 			results: map[string]bool{
-				"meta":           true,
-				"summary":        true,
-				"success":        true,
+				"meta":           false,
+				"summary":        false,
+				"success":        false,
 				"failure":        false,
-				"skips":          true,
-				"execution":      true,
-				"execution_out":  true,
-				"execution_info": true,
-				"empty_summary":  true,
+				"skips":          false,
+				"execution":      false,
+				"execution_out":  false,
+				"execution_info": false,
+				"empty_summary":  false,
 			},
 		},
 		{
 			tags:     "meta,summary,success,skips,empty_summary",
 			settings: nil,
 			results: map[string]bool{
-				"meta":           true,
-				"summary":        true,
-				"success":        true,
-				"failure":        false,
-				"skips":          true,
-				"execution":      false,
-				"execution_out":  false,
-				"execution_info": false,
-				"empty_summary":  true,
+				"meta":           false,
+				"summary":        false,
+				"success":        false,
+				"failure":        true,
+				"skips":          false,
+				"execution":      true,
+				"execution_out":  true,
+				"execution_info": true,
+				"empty_summary":  false,
 			},
 		},
 	} { //nolint:dupl // In next versions the `skip_settings_test` will be removed
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			var settings SkipSettings
+			var settings Settings
 
 			(&settings).ApplySettings(tt.tags, tt.settings)
 

--- a/internal/log/settings_test.go
+++ b/internal/log/settings_test.go
@@ -113,7 +113,7 @@ func TestSetting(t *testing.T) {
 		},
 	} { //nolint:dupl // In next versions the `skip_settings_test` will be removed
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			var settings Settings
+			var settings OutputSettings
 
 			(&settings).ApplySettings(tt.tags, tt.settings)
 

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -21,7 +21,7 @@ const (
 type SkipSettings int16
 
 // Deprecated: Use NewSettings instead.
-func NewSkipSettings() SettingsInterface {
+func NewSkipSettings() Settings {
 	var s SkipSettings
 	return &s
 }

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -74,40 +74,40 @@ func (s *SkipSettings) skipAll(val bool) {
 	}
 }
 
-func (s SkipSettings) SkipSuccess() bool {
-	return s.doSkip(skipSuccess)
+func (s SkipSettings) LogSuccess() bool {
+	return !s.doSkip(skipSuccess)
 }
 
-func (s SkipSettings) SkipFailure() bool {
-	return s.doSkip(skipFailure)
+func (s SkipSettings) LogFailure() bool {
+	return !s.doSkip(skipFailure)
 }
 
-func (s SkipSettings) SkipSummary() bool {
-	return s.doSkip(skipSummary)
+func (s SkipSettings) LogSummary() bool {
+	return !s.doSkip(skipSummary)
 }
 
-func (s SkipSettings) SkipMeta() bool {
-	return s.doSkip(skipMeta)
+func (s SkipSettings) LogMeta() bool {
+	return !s.doSkip(skipMeta)
 }
 
-func (s SkipSettings) SkipExecution() bool {
-	return s.doSkip(skipExecution)
+func (s SkipSettings) LogExecution() bool {
+	return !s.doSkip(skipExecution)
 }
 
-func (s SkipSettings) SkipExecutionOutput() bool {
-	return s.doSkip(skipExecutionOutput)
+func (s SkipSettings) LogExecutionOutput() bool {
+	return !s.doSkip(skipExecutionOutput)
 }
 
-func (s SkipSettings) SkipExecutionInfo() bool {
-	return s.doSkip(skipExecutionInfo)
+func (s SkipSettings) LogExecutionInfo() bool {
+	return !s.doSkip(skipExecutionInfo)
 }
 
-func (s SkipSettings) SkipSkips() bool {
-	return s.doSkip(skipSkips)
+func (s SkipSettings) LogSkips() bool {
+	return !s.doSkip(skipSkips)
 }
 
-func (s SkipSettings) SkipEmptySummary() bool {
-	return s.doSkip(skipEmptySummary)
+func (s SkipSettings) LogEmptySummary() bool {
+	return !s.doSkip(skipEmptySummary)
 }
 
 func (s SkipSettings) doSkip(option int16) bool {

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -17,12 +17,19 @@ const (
 	skipAll = (1 << iota) - 1
 )
 
+// Deprecated: Use Settings instead.
 type SkipSettings int16
+
+// Deprecated: Use NewSettings instead.
+func NewSkipSettings() SettingsInterface {
+	var s SkipSettings
+	return &s
+}
 
 func (s *SkipSettings) ApplySettings(tags string, skipOutput interface{}) {
 	switch typedSkipOutput := skipOutput.(type) {
 	case bool:
-		s.SkipAll(typedSkipOutput)
+		s.skipAll(typedSkipOutput)
 	case []interface{}:
 		for _, skipOption := range typedSkipOutput {
 			s.applySetting(skipOption.(string))
@@ -59,7 +66,7 @@ func (s *SkipSettings) applySetting(setting string) {
 	}
 }
 
-func (s *SkipSettings) SkipAll(val bool) {
+func (s *SkipSettings) skipAll(val bool) {
 	if val {
 		*s = skipAll &^ skipFailure
 	} else {

--- a/internal/log/skip_settings_test.go
+++ b/internal/log/skip_settings_test.go
@@ -14,19 +14,46 @@ func TestSkipSetting(t *testing.T) {
 		{
 			tags:     "",
 			settings: []interface{}{},
-			results:  map[string]bool{},
+			results: map[string]bool{
+				"meta":           true,
+				"summary":        true,
+				"success":        true,
+				"failure":        true,
+				"skips":          true,
+				"execution":      true,
+				"execution_out":  true,
+				"execution_info": true,
+				"empty_summary":  true,
+			},
 		},
 		{
 			tags:     "",
 			settings: false,
-			results:  map[string]bool{},
+			results: map[string]bool{
+				"meta":           true,
+				"summary":        true,
+				"success":        true,
+				"failure":        true,
+				"skips":          true,
+				"execution":      true,
+				"execution_out":  true,
+				"execution_info": true,
+				"empty_summary":  true,
+			},
 		},
 		{
 			tags:     "",
 			settings: []interface{}{"failure", "execution"},
 			results: map[string]bool{
-				"failure":   true,
-				"execution": true,
+				"meta":           true,
+				"summary":        true,
+				"success":        true,
+				"failure":        false,
+				"skips":          true,
+				"execution":      false,
+				"execution_out":  true,
+				"execution_info": true,
+				"empty_summary":  true,
 			},
 		},
 		{
@@ -42,46 +69,23 @@ func TestSkipSetting(t *testing.T) {
 				"execution_info",
 				"empty_summary",
 			},
-			results: map[string]bool{
-				"meta":           true,
-				"summary":        true,
-				"success":        true,
-				"failure":        true,
-				"skips":          true,
-				"execution":      true,
-				"execution_out":  true,
-				"execution_info": true,
-				"empty_summary":  true,
-			},
+			results: map[string]bool{},
 		},
 		{
 			tags:     "",
 			settings: true,
 			results: map[string]bool{
-				"meta":           true,
-				"summary":        true,
-				"success":        true,
-				"failure":        false,
-				"skips":          true,
-				"execution":      true,
-				"execution_out":  true,
-				"execution_info": true,
-				"empty_summary":  true,
+				"failure": true,
 			},
 		},
 		{
 			tags:     "meta,summary,success,skips,empty_summary",
 			settings: nil,
 			results: map[string]bool{
-				"meta":           true,
-				"summary":        true,
-				"success":        true,
-				"failure":        false,
-				"skips":          true,
-				"execution":      false,
-				"execution_out":  false,
-				"execution_info": false,
-				"empty_summary":  true,
+				"failure":        true,
+				"execution":      true,
+				"execution_out":  true,
+				"execution_info": true,
 			},
 		},
 	} { //nolint:dupl // In next versions the `skip_settings_test` will be removed
@@ -90,40 +94,40 @@ func TestSkipSetting(t *testing.T) {
 
 			(&settings).ApplySettings(tt.tags, tt.settings)
 
-			if settings.SkipMeta() != tt.results["meta"] {
-				t.Errorf("expected SkipMeta to be %v", tt.results["meta"])
+			if settings.LogMeta() != tt.results["meta"] {
+				t.Errorf("expected LogMeta to be %v", tt.results["meta"])
 			}
 
-			if settings.SkipSuccess() != tt.results["success"] {
-				t.Errorf("expected SkipSuccess to be %v", tt.results["success"])
+			if settings.LogSuccess() != tt.results["success"] {
+				t.Errorf("expected LogSuccess to be %v", tt.results["success"])
 			}
 
-			if settings.SkipFailure() != tt.results["failure"] {
-				t.Errorf("expected SkipFailure to be %v", tt.results["failure"])
+			if settings.LogFailure() != tt.results["failure"] {
+				t.Errorf("expected LogFailure to be %v", tt.results["failure"])
 			}
 
-			if settings.SkipSummary() != tt.results["summary"] {
-				t.Errorf("expected SkipSummary to be %v", tt.results["summary"])
+			if settings.LogSummary() != tt.results["summary"] {
+				t.Errorf("expected LogSummary to be %v", tt.results["summary"])
 			}
 
-			if settings.SkipExecution() != tt.results["execution"] {
-				t.Errorf("expected SkipExecution to be %v", tt.results["execution"])
+			if settings.LogExecution() != tt.results["execution"] {
+				t.Errorf("expected LogExecution to be %v", tt.results["execution"])
 			}
 
-			if settings.SkipExecutionOutput() != tt.results["execution_out"] {
-				t.Errorf("expected SkipExecutionOutput to be %v", tt.results["execution_out"])
+			if settings.LogExecutionOutput() != tt.results["execution_out"] {
+				t.Errorf("expected LogExecutionOutput to be %v", tt.results["execution_out"])
 			}
 
-			if settings.SkipExecutionInfo() != tt.results["execution_info"] {
-				t.Errorf("expected SkipExecutionInfo to be %v", tt.results["execution_info"])
+			if settings.LogExecutionInfo() != tt.results["execution_info"] {
+				t.Errorf("expected LogExecutionInfo to be %v", tt.results["execution_info"])
 			}
 
-			if settings.SkipEmptySummary() != tt.results["empty_summary"] {
-				t.Errorf("expected SkipEmptySummary to be %v", tt.results["empty_summary"])
+			if settings.LogEmptySummary() != tt.results["empty_summary"] {
+				t.Errorf("expected LogEmptySummary to be %v", tt.results["empty_summary"])
 			}
 
-			if settings.SkipSkips() != tt.results["skips"] {
-				t.Errorf("expected SkipSkips to be %v", tt.results["skip"])
+			if settings.LogSkips() != tt.results["skips"] {
+				t.Errorf("expected LogSkips to be %v", tt.results["skip"])
 			}
 		})
 	}


### PR DESCRIPTION
Closes #592 

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Deprecate the `skip_output` and add `output` as a whitelist of output values
I saved the `skip_output` logic for further removal in the next versions

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
- [x] Add documentation
