### PR TITLE
Fix lefthook capturing stdin from terminal even if when non-interactive and not using stdin

### DIFF
--- a/internal/lefthook/run/exec/execute_unix.go
+++ b/internal/lefthook/run/exec/execute_unix.go
@@ -102,8 +102,6 @@ func (e CommandExecutor) execute(ctx context.Context, cmdstr string, args *execu
 
 		defer func() { _ = p.Close() }()
 
-		go func() { _, _ = io.Copy(p, args.in) }()
-
 		_, _ = io.Copy(args.out, p)
 	}
 


### PR DESCRIPTION



Closes  https://github.com/evilmartians/lefthook/issues/588

#### :zap: Summary

If I'm reading the code, this `args.in` should be a nullReader when non-interactive and not using stdin. For some reason though, it ends up capturing stdin. That is, any typing you do while lefthook is running goes to lefthook, instead of the shell invoking it.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
