### PR TITLE
Configurable path to lefthook to run during git hook

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,6 +18,7 @@ Then use git as usually, you don't need to reinstall lefthook when you change th
   - [`LEFTHOOK_EXCLUDE`](#lefthook_exclude)
   - [`LEFTHOOK_QUIET`](#lefthook_quiet)
   - [`LEFTHOOK_VERBOSE`](#lefthook_verbose)
+  - [`LEFTHOOK_PATH`](#lefthook_path)
 - [Features and tips](#features-and-tips)
   - [Disable lefthook in CI](#disable-lefthook-in-ci)
   - [Local config](#local-config)
@@ -191,6 +192,15 @@ SUMMARY: (done in 0.01 seconds)
 ### `LEFTHOOK_VERBOSE`
 
 Set `LEFTHOOK_VERBOSE=1` or `LEFTHOOK_VERBOSE=true` to enable verbose printing.
+
+### `LEFTHOOK_PATH`
+
+Set `LEFTHOOK_PATH` to a location where lefthook is installed to use that instead of trying to detect it on the path or your package manager.
+
+Useful for cases when:
+
+- lefthook is installed multiple ways, and you want to be explicit about which one is used (example: installed through homebrew, but also is in Gemfile but you are using a ruby version manager like rbenv that prepends it to the path)
+- debugging and/or developing lefthook
 
 ## Features and tips
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ Then use git as usually, you don't need to reinstall lefthook when you change th
   - [`LEFTHOOK_EXCLUDE`](#lefthook_exclude)
   - [`LEFTHOOK_QUIET`](#lefthook_quiet)
   - [`LEFTHOOK_VERBOSE`](#lefthook_verbose)
-  - [`LEFTHOOK_PATH`](#lefthook_path)
+  - [`LEFTHOOK_BIN`](#lefthook_bin)
 - [Features and tips](#features-and-tips)
   - [Disable lefthook in CI](#disable-lefthook-in-ci)
   - [Local config](#local-config)
@@ -193,9 +193,9 @@ SUMMARY: (done in 0.01 seconds)
 
 Set `LEFTHOOK_VERBOSE=1` or `LEFTHOOK_VERBOSE=true` to enable verbose printing.
 
-### `LEFTHOOK_PATH`
+### `LEFTHOOK_BIN`
 
-Set `LEFTHOOK_PATH` to a location where lefthook is installed to use that instead of trying to detect it on the path or your package manager.
+Set `LEFTHOOK_BIN` to a location where lefthook is installed to use that instead of trying to detect from the it the PATH or from a package manager.
 
 Useful for cases when:
 

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -19,9 +19,9 @@ call_lefthook()
   osArch=$(uname | tr '[:upper:]' '[:lower:]')
   cpuArch=$(uname -m | sed 's/aarch64/arm64/')
 
-  if test -n "$LEFTHOOK_PATH"
+  if test -n "$LEFTHOOK_BIN"
   then
-    "$LEFTHOOK_PATH" "$@"
+    "$LEFTHOOK_BIN" "$@"
   elif lefthook{{.Extension}} -h >/dev/null 2>&1
   then
     lefthook{{.Extension}} "$@"

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ "$LEFTHOOK_VERBOSE" = "1" -o "$LEFTHOOK_VERBOSE" = "true" ]; then
+  set -x
+fi
+
 if [ "$LEFTHOOK" = "0" ]; then
   exit 0
 fi

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -19,7 +19,10 @@ call_lefthook()
   osArch=$(uname | tr '[:upper:]' '[:lower:]')
   cpuArch=$(uname -m | sed 's/aarch64/arm64/')
 
-  if lefthook{{.Extension}} -h >/dev/null 2>&1
+  if test -n "$LEFTHOOK_PATH"
+  then
+    "$LEFTHOOK_PATH" "$@"
+  elif lefthook{{.Extension}} -h >/dev/null 2>&1
   then
     lefthook{{.Extension}} "$@"
   {{if .Extension -}}


### PR DESCRIPTION
#### :zap: Summary

This adds `LEFTHOOK_PATH` to the `.git/hook` templates. It's used first before 

This is something that would have been helpful while working on https://github.com/evilmartians/lefthook/issues/588 and I was testing against a locally built 

While I was here, I added `set -x` when `LEFTHOOK_VERBOSE` is on. This is another thing that would have been useful, and I also used it to help validate LEFTHOOK_PATH working 😁  Let me know if I should split it out separately.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [x] Add documentation
