### PR TITLE
fix: decrease max cmd length for windows

### DIFF
--- a/internal/lefthook/run/prepare_command.go
+++ b/internal/lefthook/run/prepare_command.go
@@ -30,7 +30,7 @@ const (
 	// https://support.microsoft.com/en-us/help/830473/command-prompt-cmd-exe-command-line-string-limitation
 	// https://unix.stackexchange.com/a/120652
 	maxCommandLengthDarwin  = 260000 // 262144
-	maxCommandLengthWindows = 8000   // 8191
+	maxCommandLengthWindows = 7000   // 8191, but see issues#655
 	maxCommandLengthLinux   = 130000 // 131072
 )
 


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/655

**:wrench: Summary**

There were issues with 8000 limit. I assume that decreasing the limit to 7k will fix the issue.