### PR TITLE
fix: fix printing when using `output` log setting

### DIFF
--- a/internal/lefthook/run/runner.go
+++ b/internal/lefthook/run/runner.go
@@ -43,7 +43,7 @@ type Options struct {
 	HookName        string
 	GitArgs         []string
 	ResultChan      chan Result
-	SkipSettings    log.Settings
+	LogSettings     log.Settings
 	DisableTTY      bool
 	Force           bool
 	Files           []string
@@ -426,11 +426,11 @@ func (r *Runner) run(ctx context.Context, opts exec.Options, follow bool) bool {
 	log.SetName(opts.Name)
 	defer log.UnsetName(opts.Name)
 
-	if (follow || opts.Interactive) && r.SkipSettings.LogExecution() {
+	if (follow || opts.Interactive) && r.LogSettings.LogExecution() {
 		r.logExecute(opts.Name, nil, nil)
 
 		var out io.Writer
-		if r.SkipSettings.LogExecutionOutput() {
+		if r.LogSettings.LogExecutionOutput() {
 			out = os.Stdout
 		} else {
 			out = io.Discard
@@ -478,7 +478,7 @@ func intersect(a, b []string) bool {
 }
 
 func (r *Runner) logSkip(name, reason string) {
-	if !r.SkipSettings.LogSkips() {
+	if !r.LogSettings.LogSkips() {
 		return
 	}
 
@@ -493,14 +493,14 @@ func (r *Runner) logSkip(name, reason string) {
 }
 
 func (r *Runner) logExecute(name string, err error, out io.Reader) {
-	if err == nil && !r.SkipSettings.LogExecution() {
+	if err == nil && !r.LogSettings.LogExecution() {
 		return
 	}
 
 	var execLog string
 	var color lipgloss.TerminalColor
 	switch {
-	case !r.SkipSettings.LogExecutionInfo():
+	case !r.LogSettings.LogExecutionInfo():
 		execLog = ""
 	case err != nil:
 		execLog = log.Red(fmt.Sprintf("%s ❯ ", name))
@@ -518,7 +518,7 @@ func (r *Runner) logExecute(name string, err error, out io.Reader) {
 		log.Info()
 	}
 
-	if err == nil && !r.SkipSettings.LogExecutionOutput() {
+	if err == nil && !r.LogSettings.LogExecutionOutput() {
 		return
 	}
 

--- a/internal/lefthook/run/runner_test.go
+++ b/internal/lefthook/run/runner_test.go
@@ -750,13 +750,13 @@ func TestRunAll(t *testing.T) {
 		executor := TestExecutor{}
 		runner := &Runner{
 			Options: Options{
-				Repo:         repo,
-				Hook:         tt.hook,
-				HookName:     tt.hookName,
-				SkipSettings: log.NewSettings(),
-				GitArgs:      tt.args,
-				ResultChan:   resultChan,
-				Force:        tt.force,
+				Repo:        repo,
+				Hook:        tt.hook,
+				HookName:    tt.hookName,
+				LogSettings: log.NewSettings(),
+				GitArgs:     tt.args,
+				ResultChan:  resultChan,
+				Force:       tt.force,
 			},
 			executor: executor,
 		}

--- a/internal/log/settings.go
+++ b/internal/log/settings.go
@@ -104,11 +104,11 @@ func (s OutputSettings) isEnable(option int16) bool {
 }
 
 func (s OutputSettings) LogSuccess() bool {
-	return s.isEnable(success)
+	return s.isEnable(success) || s.isEnable(summary)
 }
 
 func (s OutputSettings) LogFailure() bool {
-	return s.isEnable(failure)
+	return s.isEnable(failure) || s.isEnable(summary)
 }
 
 func (s OutputSettings) LogSummary() bool {
@@ -120,15 +120,15 @@ func (s OutputSettings) LogMeta() bool {
 }
 
 func (s OutputSettings) LogExecution() bool {
-	return s.isEnable(execution)
+	return s.isEnable(execution) || s.isEnable(executionOutput) || s.isEnable(executionInfo)
 }
 
 func (s OutputSettings) LogExecutionOutput() bool {
-	return s.isEnable(executionOutput)
+	return s.isEnable(execution) || s.isEnable(executionOutput)
 }
 
 func (s OutputSettings) LogExecutionInfo() bool {
-	return s.isEnable(executionInfo)
+	return s.isEnable(execution) || s.isEnable(executionInfo)
 }
 
 func (s OutputSettings) LogSkips() bool {

--- a/internal/log/settings_test.go
+++ b/internal/log/settings_test.go
@@ -35,10 +35,46 @@ func TestSetting(t *testing.T) {
 		},
 		{
 			tags:     "",
+			settings: []interface{}{"success"},
+			results: map[string]bool{
+				"success": true,
+			},
+		},
+		{
+			tags:     "",
+			settings: []interface{}{"summary"},
+			results: map[string]bool{
+				"summary": true,
+				"success": true,
+				"failure": true,
+			},
+		},
+		{
+			tags:     "",
 			settings: []interface{}{"failure", "execution"},
 			results: map[string]bool{
-				"failure":   true,
-				"execution": true,
+				"failure":        true,
+				"execution":      true,
+				"execution_info": true,
+				"execution_out":  true,
+			},
+		},
+		{
+			tags:     "",
+			settings: []interface{}{"failure", "execution_out"},
+			results: map[string]bool{
+				"failure":       true,
+				"execution":     true,
+				"execution_out": true,
+			},
+		},
+		{
+			tags:     "",
+			settings: []interface{}{"failure", "execution_info"},
+			results: map[string]bool{
+				"failure":        true,
+				"execution":      true,
+				"execution_info": true,
 			},
 		},
 		{
@@ -82,12 +118,13 @@ func TestSetting(t *testing.T) {
 			},
 		},
 		{
-			tags:     "meta,summary,success,skips,empty_summary",
+			tags:     "meta,summary,skips,empty_summary",
 			settings: nil,
 			results: map[string]bool{
 				"meta":          true,
 				"summary":       true,
 				"success":       true,
+				"failure":       true,
 				"skips":         true,
 				"empty_summary": true,
 			},


### PR DESCRIPTION
**:wrench: Summary**

The mechanism for *allow* settings differs from *skip* approach. This PR fixes this for summary and output logs
