### PR TITLE
chore: skip printing deprecation warning

### DIFF
--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -85,7 +85,8 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 		logSettings = log.NewSettings()
 		logSettings.ApplySettings(outputLogTags, cfg.Output)
 	} else {
-		log.Warn("skip_output is deprecated, please use output option")
+		// Deprecate skip_output in the future. Leaving as is to reduce noise in output.
+		// log.Warn("skip_output is deprecated, please use output option")
 
 		logSettings = log.NewSkipSettings() //nolint:staticcheck //SA1019: for temporary backward compatibility
 		logSettings.ApplySettings(outputSkipTags, cfg.SkipOutput)

--- a/internal/log/skip_settings.go
+++ b/internal/log/skip_settings.go
@@ -68,18 +68,18 @@ func (s *SkipSettings) applySetting(setting string) {
 
 func (s *SkipSettings) skipAll(val bool) {
 	if val {
-		*s = skipAll &^ skipFailure
+		*s = skipAll &^ skipFailure &^ skipSummary
 	} else {
 		*s = 0
 	}
 }
 
 func (s SkipSettings) LogSuccess() bool {
-	return !s.doSkip(skipSuccess)
+	return !s.doSkip(skipSuccess) && !s.doSkip(skipSummary)
 }
 
 func (s SkipSettings) LogFailure() bool {
-	return !s.doSkip(skipFailure)
+	return !s.doSkip(skipFailure) && !s.doSkip(skipSummary)
 }
 
 func (s SkipSettings) LogSummary() bool {

--- a/internal/log/skip_settings_test.go
+++ b/internal/log/skip_settings_test.go
@@ -61,8 +61,6 @@ func TestSkipSetting(t *testing.T) {
 			settings: []interface{}{
 				"meta",
 				"summary",
-				"success",
-				"failure",
 				"skips",
 				"execution",
 				"execution_out",
@@ -75,6 +73,7 @@ func TestSkipSetting(t *testing.T) {
 			tags:     "",
 			settings: true,
 			results: map[string]bool{
+				"summary": true,
 				"failure": true,
 			},
 		},
@@ -82,6 +81,16 @@ func TestSkipSetting(t *testing.T) {
 			tags:     "meta,summary,success,skips,empty_summary",
 			settings: nil,
 			results: map[string]bool{
+				"execution":      true,
+				"execution_out":  true,
+				"execution_info": true,
+			},
+		},
+		{
+			tags:     "meta,success,skips,empty_summary",
+			settings: nil,
+			results: map[string]bool{
+				"summary":        true,
 				"failure":        true,
 				"execution":      true,
 				"execution_out":  true,


### PR DESCRIPTION
**:broom: Summary**

Fix skip_settings related to summary, success and failure logging. Skipping summary skips failure and success.
