### PR TITLE
fix: try ignoring empty patch files on pre commit hook

### DIFF
--- a/internal/lefthook/run/runner.go
+++ b/internal/lefthook/run/runner.go
@@ -220,7 +220,7 @@ func (r *Runner) postHook() {
 	}
 
 	if err := r.Repo.RestoreUnstaged(); err != nil {
-		log.Warnf("Couldn't restore hidden unstaged files: %s\n", err)
+		log.Warnf("Couldn't restore unstaged files: %s\n", err)
 		return
 	}
 


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/627
Relates to https://github.com/evilmartians/lefthook/issues/542

**:wrench: Summary**

Check patch file size before trying to apply it. Remove the patch if it's empty and skip applying it.