### PR TITLE
fix: when forced install redownload remotes

### DIFF
--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -31,7 +31,7 @@ func (r *Repository) RemotesFolder() string {
 // SyncRemote clones or pulls the latest changes for a git repository that was
 // specified as a remote config repository. If successful, the path to the root
 // of the repository will be returned.
-func (r *Repository) SyncRemote(url, ref string) error {
+func (r *Repository) SyncRemote(url, ref string, force bool) error {
 	remotesPath := r.RemotesFolder()
 
 	err := r.Fs.MkdirAll(remotesPath, remotesFolderMode)
@@ -42,9 +42,16 @@ func (r *Repository) SyncRemote(url, ref string) error {
 	directoryName := remoteDirectoryName(url, ref)
 	remotePath := filepath.Join(remotesPath, directoryName)
 
-	_, err = r.Fs.Stat(remotePath)
-	if err == nil {
-		return r.updateRemote(remotePath, ref)
+	if force {
+		err = r.Fs.RemoveAll(remotePath)
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err = r.Fs.Stat(remotePath)
+		if err == nil {
+			return r.updateRemote(remotePath, ref)
+		}
 	}
 
 	return r.cloneRemote(remotesPath, directoryName, url, ref)

--- a/internal/lefthook/install.go
+++ b/internal/lefthook/install.go
@@ -52,7 +52,7 @@ func (l *Lefthook) Install(force bool) error {
 
 	for _, remote := range cfg.Remotes {
 		if remote.Configured() {
-			if err := l.repo.SyncRemote(remote.GitURL, remote.Ref); err != nil {
+			if err := l.repo.SyncRemote(remote.GitURL, remote.Ref, force); err != nil {
 				log.Warnf("Couldn't sync remotes. Will continue without them: %s", err)
 			} else {
 				// Reread the config file with synced remotes


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/680

**:wrench: Summary**

When `install` called with force flag like `lefthook install -f` – drop the folders containing remotes and re-download them.