### PR TITLE
fix: add `--porcelain` to `git status --short`

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -24,7 +24,7 @@ var (
 	cmdPushFilesBase = []string{"git", "diff", "--name-only", "HEAD", "@{push}"}
 	cmdPushFilesHead = []string{"git", "diff", "--name-only", "HEAD"}
 	cmdStagedFiles   = []string{"git", "diff", "--name-only", "--cached", "--diff-filter=ACMR"}
-	cmdStatusShort   = []string{"git", "status", "--short"}
+	cmdStatusShort   = []string{"git", "status", "--short", "--porcelain"}
 	cmdListStash     = []string{"git", "stash", "list"}
 	cmdRootPath      = []string{"git", "rev-parse", "--show-toplevel"}
 	cmdHooksPath     = []string{"git", "rev-parse", "--git-path", "hooks"}

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -39,7 +39,7 @@ MM staged but changed
 				Git: &CommandExecutor{
 					exec: GitMock{
 						cases: map[string]string{
-							"git status --short": tt.gitOut,
+							"git status --short --porcelain": tt.gitOut,
 						},
 					},
 				},


### PR DESCRIPTION
#### :zap: Summary

I faced an error like below (with LEFTHOOK_VERBOSE=true) when I partially added a file by `git add -p` and then executed `git commit`:

```
...
│ [lefthook] cmd: [git status --short]
│ [lefthook] dir: /path/to/my/repo
│ [lefthook] err: <nil>
│ [lefthook] out: MM xxx.yaml

│ [lefthook] saving partially staged files
│ [lefthook] cmd: [git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output .git/info/lefthook-unstaged.patch -- 2mMM xxx.yaml]
│ [lefthook] dir: /path/to/my/repo
│ [lefthook] err: <nil>
│ [lefthook] out:
│ [lefthook] cmd: [git stash create]
│ [lefthook] dir: /path/to/my/repo
│ [lefthook] err: <nil>
│ [lefthook] out: ...

│ [lefthook] cmd: [git stash store --quiet --message lefthook auto backup ...]
│ [lefthook] dir: /path/to/my/repo
│ [lefthook] err: <nil>
│ [lefthook] out:
│ [lefthook] cmd: [git checkout --force -- 2mMM xxx.yaml]
│ [lefthook] dir: /path/to/my/repo
│ [lefthook] err: exit status 1
│ [lefthook] out: error: pathspec '2mM?[m?[31mM?[m xxx.yaml' did not match any file(s) known to git

Couldn't hide unstaged files: error in batch 0: exit status 1
...
```

As a result, the whole file has been committed unexpectedly.

Given that, this PR fixes the issue by adding `--porcelain`, an option that makes the output machine-readable, to `git status` command.
With this fix, I see now `lefthook` properly hides partially staged files as below:

```
│ [lefthook] cmd: [git status --short --porcelain]
│ [lefthook] dir: /path/to/my/repo
│ [lefthook] err: <nil>
│ [lefthook] out: MM xxx.yaml

│ [lefthook] saving partially staged files
│ [lefthook] cmd: [git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output .git/info/lefthook-unstaged.patch -- xxx.yaml]
│ [lefthook] dir: /path/to/my/repo
│ [lefthook] err: <nil>
│ [lefthook] out:
│ [lefthook] cmd: [git stash create]
│ [lefthook] dir: /path/to/my/repo
│ [lefthook] err: <nil>
│ [lefthook] out: ...

│ [lefthook] cmd: [git stash store --quiet --message lefthook auto backup ...]
│ [lefthook] dir: /path/to/my/repo
│ [lefthook] err: <nil>
│ [lefthook] out:
│ [lefthook] cmd: [git checkout --force -- xxx.yaml]
│ [lefthook] dir: /path/to/my/repo
│ [lefthook] err: <nil>
│ [lefthook] out:
│ [lefthook] hide partially staged files: [xxx.yaml]
```

<!-- Brief description of what was done -->

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
