### PR TITLE
fix: enable interactive scripts

### DIFF
--- a/internal/lefthook/runner/exec/execute_unix.go
+++ b/internal/lefthook/runner/exec/execute_unix.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/mattn/go-isatty"
-	"github.com/mattn/go-tty"
 
 	"github.com/evilmartians/lefthook/internal/log"
 )
@@ -35,10 +34,10 @@ func (e CommandExecutor) Execute(ctx context.Context, opts Options, out io.Write
 		in = os.Stdin
 	}
 	if opts.Interactive && !isatty.IsTerminal(os.Stdin.Fd()) {
-		tty, err := tty.Open()
+		tty, err := os.Open("/dev/tty")
 		if err == nil {
 			defer tty.Close()
-			in = tty.Input()
+			in = tty
 		} else {
 			log.Errorf("Couldn't enable TTY input: %s\n", err)
 		}


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/discussions/709

**:wrench: Summary**

`tty.Open` does not work with interactive bash scripts. I am about to dig into this issue but changing this to `os.Open("/dev/tty")` since it fixes the issue.