### PR TITLE
fix: verbose error on versions mismatch

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 )
@@ -49,7 +50,11 @@ func CheckCovered(targetVersion string) error {
 		return err
 	}
 
-	errUncovered := fmt.Errorf("required lefthook version (%s) is higher than current (%s)", targetVersion, version)
+	execPath, err := os.Executable()
+	if err != nil {
+		execPath = "<unknown>"
+	}
+	errUncovered := fmt.Errorf("required lefthook version (%s) is higher than current (%s) at %s", targetVersion, version, execPath)
 
 	switch {
 	case major > tMajor:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strconv"
 )
@@ -17,7 +18,6 @@ var (
 	)
 
 	errIncorrectVersion = errors.New("format of 'min_version' setting is incorrect")
-	errUncovered        = errors.New("required Lefthook version is higher than current")
 )
 
 func Version(verbose bool) string {
@@ -48,6 +48,8 @@ func CheckCovered(targetVersion string) error {
 	if err != nil {
 		return err
 	}
+
+	errUncovered := fmt.Errorf("required lefthook version (%s) is higher than current (%s)", targetVersion, version)
 
 	switch {
 	case major > tMajor:

--- a/testdata/min_version.txt
+++ b/testdata/min_version.txt
@@ -1,6 +1,6 @@
 exec git init
 ! exec lefthook run pre-commit
-stdout 'required Lefthook version is higher than current'
+stdout 'required lefthook version \(13.1.1\) is higher than current'
 
 -- lefthook.yml --
 min_version: 13.1.1


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/718

**:wrench: Summary**

Now when lefthook version mismatches the following error will be printed:

```
Error: required lefthook version (1.6.13) is higher than current (1.6.11) at /Users/me/go/bin/lefthook
```