### PR TITLE
feat: expand Swift integration with Mint support

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -73,10 +73,18 @@ python3 -m pip install --user lefthook
 
 ## <a id="swift"></a> Swift
 
-You can find the Swift wrapper plugin [here](https://github.com/csjones/lefthook-plugin). To utilize lefthook, include the plugin in the dependencies section of your `Package.swift`:
+You can find the Swift wrapper plugin [here](https://github.com/csjones/lefthook-plugin). 
+
+Utilize lefthook in your Swift project using Swift Package Manager:
 
 ```swift
 .package(url: "https://github.com/csjones/lefthook-plugin.git", exact: "1.6.12"),
+```
+
+Or, with [mint](https://github.com/yonaskolb/Mint):
+
+```bash
+mint run csjones/lefthook-plugin
 ```
 
 ## <a id="scoop"></a> Scoop for Windowss

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -64,6 +64,9 @@ call_lefthook()
   elif swift package plugin lefthook >/dev/null 2>&1
   then
     swift package --disable-sandbox plugin lefthook "$@"
+  elif command -v mint >/dev/null 2>&1
+  then
+    mint run csjones/lefthook-plugin "$@"
   elif command -v npx >/dev/null 2>&1
   then
     npx lefthook "$@"


### PR DESCRIPTION
Building on top of [previous PR that added Swift support](https://github.com/evilmartians/lefthook/pull/556). 

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

The `csjones/lefthook-plugin` Swift project has recently [added mint package manager support](https://github.com/csjones/lefthook-plugin/pull/4). To advertise this functionality, I wanted to mention this new feature in the lefthook docs. 

For my edits in this PR, I used the [previous PR that added Swift support](https://github.com/evilmartians/lefthook/pull/556) as a reference. I have not tested `internal/templates/hook.tmpl`, if it's even possible to do so. 

Thanks! 

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [X] Add documentation
