### PR TITLE
chore: remove go patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/evilmartians/lefthook
 
-go 1.22.2
+go 1.22
+
+toolchain go1.22.2
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/discussions/725

**:broom: Summary**

Keep the toolchain separate