### PR TITLE
fix: LFS pre-push requires Stdin

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1431,6 +1431,10 @@ When you try to commit `git commit -m "bad commit text"` script `template_checke
 > **Note**
 >
 > With many commands or scripts having `use_stdin: true`, only one will receive the data. The others will have nothing. If you need to pass the data from stdin to every command or script, please, submit a [feature request](https://github.com/evilmartians/lefthook/issues/new?assignees=&labels=feature+request&projects=&template=feature_request.md).
+>
+> The LFS `pre-push` hook needs the data provided by Git through Stdin. As such, no other `pre-push` command or script should use this flag when the repository uses LFS.
+>
+> When run, lefthook will error and stop execution if multiple commands or scripts have this flag enabled.
 
 Pass the stdin from the OS to the command/script.
 

--- a/internal/git/lfs.go
+++ b/internal/git/lfs.go
@@ -16,6 +16,10 @@ var lfsHooks = [...]string{
 	"pre-push",
 }
 
+var lfsHookConsumeStdin = [...]string{
+	"pre-push",
+}
+
 // IsLFSAvailable returns 'true' if git-lfs is installed.
 func IsLFSAvailable() bool {
 	_, err := exec.LookPath("git-lfs")
@@ -26,6 +30,18 @@ func IsLFSAvailable() bool {
 // IsLFSHook returns whether the hookName is supported by Git LFS.
 func IsLFSHook(hookName string) bool {
 	for _, lfsHookName := range lfsHooks {
+		if lfsHookName == hookName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// DoesLFSHookConsumeStdin returns whether the LFS hookName will consume Stdin
+// meaning it won't be available to following commands
+func DoesLFSHookConsumeStdin(hookName string) bool {
+	for _, lfsHookName := range lfsHookConsumeStdin {
 		if lfsHookName == hookName {
 			return true
 		}

--- a/internal/git/lfs.go
+++ b/internal/git/lfs.go
@@ -39,7 +39,7 @@ func IsLFSHook(hookName string) bool {
 }
 
 // DoesLFSHookConsumeStdin returns whether the LFS hookName will consume Stdin
-// meaning it won't be available to following commands
+// meaning it won't be available to following commands.
 func DoesLFSHookConsumeStdin(hookName string) bool {
 	for _, lfsHookName := range lfsHookConsumeStdin {
 		if lfsHookName == hookName {

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -169,7 +169,11 @@ Run 'lefthook install' manually.`,
 	)
 
 	startTime := time.Now()
-	results := r.RunAll(ctx, sourceDirs)
+	results, err := r.RunAll(ctx, sourceDirs)
+
+	if err != nil {
+		return err
+	}
 
 	if ctx.Err() != nil {
 		return errors.New("Interrupted")

--- a/internal/lefthook/runner/exec/execute_unix.go
+++ b/internal/lefthook/runner/exec/execute_unix.go
@@ -72,11 +72,15 @@ func (e CommandExecutor) Execute(ctx context.Context, opts Options, out io.Write
 	return nil
 }
 
-func (e CommandExecutor) RawExecute(ctx context.Context, command []string, out io.Writer) error {
+func (e CommandExecutor) RawExecute(ctx context.Context, command []string, out io.Writer, forwardStdin bool) error {
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 
 	cmd.Stdout = out
 	cmd.Stderr = os.Stderr
+
+	if forwardStdin {
+		cmd.Stdin = os.Stdin
+	}
 
 	return cmd.Run()
 }

--- a/internal/lefthook/runner/exec/execute_windows.go
+++ b/internal/lefthook/runner/exec/execute_windows.go
@@ -63,11 +63,15 @@ func (e CommandExecutor) Execute(ctx context.Context, opts Options, out io.Write
 	return nil
 }
 
-func (e CommandExecutor) RawExecute(ctx context.Context, command []string, out io.Writer) error {
+func (e CommandExecutor) RawExecute(ctx context.Context, command []string, out io.Writer, forwardStdin bool) error {
 	cmd := exec.Command(command[0], command[1:]...)
 
 	cmd.Stdout = out
 	cmd.Stderr = os.Stderr
+
+	if forwardStdin {
+		cmd.Stdin = os.Stdin
+	}
 
 	return cmd.Run()
 }

--- a/internal/lefthook/runner/exec/executor.go
+++ b/internal/lefthook/runner/exec/executor.go
@@ -17,5 +17,5 @@ type Options struct {
 // It is used here for testing purpose mostly.
 type Executor interface {
 	Execute(ctx context.Context, opts Options, out io.Writer) error
-	RawExecute(ctx context.Context, command []string, out io.Writer) error
+	RawExecute(ctx context.Context, command []string, out io.Writer, forwardStdin bool) error
 }

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -82,7 +82,8 @@ type executable interface {
 func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) ([]Result, error) {
 	results := make([]Result, 0, len(r.Hook.Commands)+len(r.Hook.Scripts))
 
-	if err := r.runLFSHook(ctx); err != nil {
+	ranLFS, err := r.runLFSHook(ctx)
+	if err != nil {
 		log.Error(err)
 		return results, err
 	}
@@ -90,6 +91,11 @@ func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) ([]Result, err
 	if r.Hook.DoSkip(r.Repo.State()) {
 		r.logSkip(r.HookName, "hook setting")
 		return results, nil
+	}
+
+	// Sanity check before running hooks
+	if err := r.sanityCheck(ranLFS); err != nil {
+		return results, err
 	}
 
 	if !r.DisableTTY && !r.Hook.Follow {
@@ -117,9 +123,10 @@ func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) ([]Result, err
 	return results, nil
 }
 
-func (r *Runner) runLFSHook(ctx context.Context) error {
+// returns whether it ran a LFS hook
+func (r *Runner) runLFSHook(ctx context.Context) (bool, error) {
 	if !git.IsLFSHook(r.HookName) {
-		return nil
+		return false, nil
 	}
 
 	lfsRequiredFile := filepath.Join(r.Repo.RootPath, git.LFSRequiredFile)
@@ -127,11 +134,11 @@ func (r *Runner) runLFSHook(ctx context.Context) error {
 
 	requiredExists, err := afero.Exists(r.Repo.Fs, lfsRequiredFile)
 	if err != nil {
-		return err
+		return false, err
 	}
 	configExists, err := afero.Exists(r.Repo.Fs, lfsConfigFile)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if git.IsLFSAvailable() {
@@ -162,10 +169,10 @@ func (r *Runner) runLFSHook(ctx context.Context) error {
 
 		if err != nil && (requiredExists || configExists) {
 			log.Warnf("git-lfs command failed: %s\n", output)
-			return err
+			return true, err
 		}
 
-		return nil
+		return true, nil
 	}
 
 	if requiredExists || configExists {
@@ -176,7 +183,38 @@ func (r *Runner) runLFSHook(ctx context.Context) error {
 				"  - %s\n",
 			lfsRequiredFile, lfsConfigFile,
 		)
-		return errors.New("git-lfs is required")
+		return false, errors.New("git-lfs is required")
+	}
+
+	return false, nil
+}
+
+func (r *Runner) sanityCheck(ranLFS bool) error {
+	// More than one hook can't use Stdin
+	StdinConsumed := ranLFS && git.DoesLFSHookConsumeStdin(r.HookName)
+	for commandName, command := range r.Hook.Commands {
+		if command.UseStdin {
+			if StdinConsumed {
+				log.Errorf(
+					"command %s wants to use Stdin which was consumed by a previously.",
+					commandName,
+				)
+				return errors.New("More than one command or script wants to use Stdin")
+			}
+			StdinConsumed = true
+		}
+	}
+	for scriptName, script := range r.Hook.Scripts {
+		if script.UseStdin {
+			if StdinConsumed {
+				log.Errorf(
+					"script %s wants to use Stdin which was consumed by a previously.",
+					scriptName,
+				)
+				return errors.New("More than one command or script wants to use Stdin")
+			}
+			StdinConsumed = true
+		}
 	}
 
 	return nil

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -123,7 +123,7 @@ func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) ([]Result, err
 	return results, nil
 }
 
-// returns whether it ran a LFS hook
+// returns whether it ran a LFS hook.
 func (r *Runner) runLFSHook(ctx context.Context) (bool, error) {
 	if !git.IsLFSHook(r.HookName) {
 		return false, nil
@@ -153,6 +153,7 @@ func (r *Runner) runLFSHook(ctx context.Context) (bool, error) {
 				r.GitArgs...,
 			),
 			out,
+			git.DoesLFSHookConsumeStdin(r.HookName),
 		)
 
 		output := strings.Trim(out.String(), "\n")

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -84,6 +84,7 @@ func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) ([]Result, err
 
 	if err := r.runLFSHook(ctx); err != nil {
 		log.Error(err)
+		return results, err
 	}
 
 	if r.Hook.DoSkip(r.Repo.State()) {

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -79,7 +79,7 @@ type executable interface {
 
 // RunAll runs scripts and commands.
 // LFS hook is executed at first if needed.
-func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) []Result {
+func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) ([]Result, error) {
 	results := make([]Result, 0, len(r.Hook.Commands)+len(r.Hook.Scripts))
 
 	if err := r.runLFSHook(ctx); err != nil {
@@ -88,7 +88,7 @@ func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) []Result {
 
 	if r.Hook.DoSkip(r.Repo.State()) {
 		r.logSkip(r.HookName, "hook setting")
-		return results
+		return results, nil
 	}
 
 	if !r.DisableTTY && !r.Hook.Follow {
@@ -113,7 +113,7 @@ func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) []Result {
 
 	r.postHook()
 
-	return results
+	return results, nil
 }
 
 func (r *Runner) runLFSHook(ctx context.Context) error {

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -87,6 +87,7 @@ func TestRunAll(t *testing.T) {
 		existingFiles          []string
 		hook                   *config.Hook
 		success, fail          []Result
+		err                    error
 		gitCommands            []string
 		force                  bool
 	}{
@@ -766,7 +767,10 @@ func TestRunAll(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("%d: %s", i, tt.name), func(t *testing.T) {
-			results := runner.RunAll(context.Background(), tt.sourceDirs)
+			results, err := runner.RunAll(context.Background(), tt.sourceDirs)
+			if err != tt.err {
+				t.Errorf("error is not matching\nNeed: %v\n Was: %v", tt.err, err)
+			}
 
 			var success, fail []Result
 			for _, result := range results {

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -31,7 +31,7 @@ func (e TestExecutor) Execute(_ctx context.Context, opts exec.Options, _out io.W
 	return
 }
 
-func (e TestExecutor) RawExecute(_ctx context.Context, _command []string, _out io.Writer) error {
+func (e TestExecutor) RawExecute(_ctx context.Context, _command []string, _out io.Writer, forwardStdin bool) error {
 	return nil
 }
 


### PR DESCRIPTION
DRAFT: Opening as draft. I'll self-review tomorrow and look if I can add tests or update doc

Partial workaround fix for #511

#### :zap: Summary

`git lfs pre-push` hook read information on what will be pushed to remote to determine what LFS object it needs to upload.
Until now, Stdin from Git was not forwarded to it, causing it to never uploading LFS objects, which is a big issue as these objects can be lost due to pruning.

There is another change that check if multiple commands have the `use_stdin` option to true, as, at the moment, Stdin will be consumed by the first command executed, and others will be left hanging.

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
- [ ] Add documentation
