### PR TITLE
chore: refactor commands interfaces

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,7 +61,7 @@ changelog:
     - '^spec:'
     - '^tmp:'
     - '^context:'
-    - '^\d\.\d\.\d:'
+    - '^\d+\.\d+\.\d+:'
 
 snapcrafts:
   -

--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -47,7 +47,7 @@ func (c Command) Validate() error {
 }
 
 func (c Command) DoSkip(gitState git.State) bool {
-	skipChecker := NewSkipChecker(system.Executor{})
+	skipChecker := NewSkipChecker(system.Cmd)
 	return skipChecker.check(gitState, c.Skip, c.Only)
 }
 

--- a/internal/config/command_executor.go
+++ b/internal/config/command_executor.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"io"
 	"runtime"
 
@@ -26,7 +25,7 @@ func (c *commandExecutor) execute(commandLine string) bool {
 		args = []string{"sh", "-c", commandLine}
 	}
 
-	err := c.cmd.Run(context.Background(), args, "", system.NullReader, io.Discard)
+	err := c.cmd.Run(args, "", system.NullReader, io.Discard)
 
 	return err == nil
 }

--- a/internal/config/command_executor.go
+++ b/internal/config/command_executor.go
@@ -1,21 +1,20 @@
 package config
 
 import (
+	"context"
+	"io"
 	"runtime"
-)
 
-// Executor is a general execution interface for implicit commands.
-type Executor interface {
-	Execute(args []string, root string) (string, error)
-}
+	"github.com/evilmartians/lefthook/internal/system"
+)
 
 // commandExecutor implements execution of a skip checks passed in a `run` option.
 type commandExecutor struct {
-	exec Executor
+	cmd system.Command
 }
 
 // cmd runs plain string command in a subshell returning the success of it.
-func (c *commandExecutor) cmd(commandLine string) bool {
+func (c *commandExecutor) execute(commandLine string) bool {
 	if commandLine == "" {
 		return false
 	}
@@ -27,7 +26,7 @@ func (c *commandExecutor) cmd(commandLine string) bool {
 		args = []string{"sh", "-c", commandLine}
 	}
 
-	_, err := c.exec.Execute(args, "")
+	err := c.cmd.Run(context.Background(), args, "", system.NullReader, io.Discard)
 
 	return err == nil
 }

--- a/internal/config/hook.go
+++ b/internal/config/hook.go
@@ -44,7 +44,7 @@ func (h *Hook) Validate() error {
 }
 
 func (h *Hook) DoSkip(gitState git.State) bool {
-	skipChecker := NewSkipChecker(system.Executor{})
+	skipChecker := NewSkipChecker(system.Cmd)
 	return skipChecker.check(gitState, h.Skip, h.Only)
 }
 

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -30,7 +30,7 @@ type scriptRunnerReplace struct {
 }
 
 func (s Script) DoSkip(gitState git.State) bool {
-	skipChecker := NewSkipChecker(system.Executor{})
+	skipChecker := NewSkipChecker(system.Cmd)
 	return skipChecker.check(gitState, s.Skip, s.Only)
 }
 

--- a/internal/config/skip_checker.go
+++ b/internal/config/skip_checker.go
@@ -5,14 +5,15 @@ import (
 
 	"github.com/evilmartians/lefthook/internal/git"
 	"github.com/evilmartians/lefthook/internal/log"
+	"github.com/evilmartians/lefthook/internal/system"
 )
 
 type skipChecker struct {
 	exec *commandExecutor
 }
 
-func NewSkipChecker(executor Executor) *skipChecker {
-	return &skipChecker{&commandExecutor{executor}}
+func NewSkipChecker(cmd system.Command) *skipChecker {
+	return &skipChecker{&commandExecutor{cmd}}
 }
 
 // check returns the result of applying a skip/only setting which can be a branch, git state, shell command, etc.
@@ -84,7 +85,7 @@ func (sc *skipChecker) matchesCommands(typedState map[string]interface{}) bool {
 		return false
 	}
 
-	result := sc.exec.cmd(commandLine)
+	result := sc.exec.execute(commandLine)
 
 	log.Debugf("[lefthook] skip/only cmd: %s, result: %t", commandLine, result)
 

--- a/internal/config/skip_checker_test.go
+++ b/internal/config/skip_checker_test.go
@@ -1,24 +1,26 @@
 package config
 
 import (
+	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/evilmartians/lefthook/internal/git"
 )
 
-type mockExecutor struct{}
+type mockCmd struct{}
 
-func (mc mockExecutor) Execute(args []string, _root string) (string, error) {
-	if len(args) == 3 && args[2] == "success" {
-		return "", nil
+func (mc mockCmd) Run(_ctx context.Context, cmd []string, _root string, _in io.Reader, _out io.Writer) error {
+	if len(cmd) == 3 && cmd[2] == "success" {
+		return nil
 	} else {
-		return "", errors.New("failure")
+		return errors.New("failure")
 	}
 }
 
 func TestDoSkip(t *testing.T) {
-	skipChecker := NewSkipChecker(mockExecutor{})
+	skipChecker := NewSkipChecker(mockCmd{})
 
 	for _, tt := range [...]struct {
 		name       string

--- a/internal/config/skip_checker_test.go
+++ b/internal/config/skip_checker_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"errors"
 	"io"
 	"testing"
@@ -11,7 +10,7 @@ import (
 
 type mockCmd struct{}
 
-func (mc mockCmd) Run(_ctx context.Context, cmd []string, _root string, _in io.Reader, _out io.Writer) error {
+func (mc mockCmd) Run(cmd []string, _root string, _in io.Reader, _out io.Writer) error {
 	if len(cmd) == 3 && cmd[2] == "success" {
 		return nil
 	} else {

--- a/internal/git/command_executor.go
+++ b/internal/git/command_executor.go
@@ -1,33 +1,30 @@
 package git
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
 
+	"github.com/evilmartians/lefthook/internal/log"
 	"github.com/evilmartians/lefthook/internal/system"
 )
 
-// Executor is a general execution interface for implicit commands.
-// Added here mostly for mockable tests.
-type Executor interface {
-	Execute(args []string, root string) (string, error)
-}
-
 // CommandExecutor provides some methods that take some effect on execution and/or result data.
 type CommandExecutor struct {
-	exec Executor
+	cmd  system.Command
 	root string
 }
 
 // NewExecutor returns an object that executes given commands in the OS.
-func NewExecutor(exec Executor) *CommandExecutor {
-	return &CommandExecutor{exec: exec}
+func NewExecutor(cmd system.Command) *CommandExecutor {
+	return &CommandExecutor{cmd: cmd}
 }
 
 // Cmd runs plain string command. Trims spaces around output.
-func (c CommandExecutor) Cmd(args []string) (string, error) {
-	out, err := c.exec.Execute(args, c.root)
+func (c CommandExecutor) Cmd(cmd []string) (string, error) {
+	out, err := c.execute(cmd, c.root)
 	if err != nil {
 		return "", err
 	}
@@ -55,7 +52,7 @@ func (c CommandExecutor) BatchedCmd(cmd []string, args []string) (string, error)
 
 // CmdLines runs plain string command, returns its output split by newline.
 func (c CommandExecutor) CmdLines(cmd []string) ([]string, error) {
-	out, err := c.exec.Execute(cmd, c.root)
+	out, err := c.execute(cmd, c.root)
 	if err != nil {
 		return nil, err
 	}
@@ -66,12 +63,22 @@ func (c CommandExecutor) CmdLines(cmd []string) ([]string, error) {
 // CmdLines runs plain string command, returns its output split by newline.
 func (c CommandExecutor) CmdLinesWithinFolder(cmd []string, folder string) ([]string, error) {
 	root := filepath.Join(c.root, folder)
-	out, err := c.exec.Execute(cmd, root)
+	out, err := c.execute(cmd, root)
 	if err != nil {
 		return nil, err
 	}
 
 	return strings.Split(strings.TrimSpace(out), "\n"), nil
+}
+
+func (c CommandExecutor) execute(cmd []string, root string) (string, error) {
+	out := bytes.NewBuffer(make([]byte, 0))
+	err := c.cmd.Run(context.Background(), cmd, root, system.NullReader, out)
+	strOut := out.String()
+
+	log.Debug("[lefthook] out: ", strOut)
+
+	return strOut, err
 }
 
 func batchByLength(s []string, length int) [][]string {

--- a/internal/git/command_executor.go
+++ b/internal/git/command_executor.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -73,7 +72,7 @@ func (c CommandExecutor) CmdLinesWithinFolder(cmd []string, folder string) ([]st
 
 func (c CommandExecutor) execute(cmd []string, root string) (string, error) {
 	out := bytes.NewBuffer(make([]byte, 0))
-	err := c.cmd.Run(context.Background(), cmd, root, system.NullReader, out)
+	err := c.cmd.Run(cmd, root, system.NullReader, out)
 	strOut := out.String()
 
 	log.Debug("[lefthook] out: ", strOut)

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -1,23 +1,30 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 )
 
-type GitMock struct {
+type gitCmd struct {
 	cases map[string]string
 }
 
-func (g GitMock) Execute(cmd []string, _root string) (string, error) {
+func (g gitCmd) Run(_ctx context.Context, cmd []string, _root string, _in io.Reader, out io.Writer) error {
 	res, ok := g.cases[(strings.Join(cmd, " "))]
 	if !ok {
-		return "", errors.New("doesn't exist")
+		return errors.New("doesn't exist")
 	}
 
-	return strings.TrimSpace(res), nil
+	_, err := out.Write([]byte(strings.TrimSpace(res)))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func TestPartiallyStagedFiles(t *testing.T) {
@@ -37,7 +44,7 @@ MM staged but changed
 		t.Run(fmt.Sprintf("%d: %s", i, tt.name), func(t *testing.T) {
 			repository := &Repository{
 				Git: &CommandExecutor{
-					exec: GitMock{
+					cmd: gitCmd{
 						cases: map[string]string{
 							"git status --short --porcelain": tt.gitOut,
 						},

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -13,7 +12,7 @@ type gitCmd struct {
 	cases map[string]string
 }
 
-func (g gitCmd) Run(_ctx context.Context, cmd []string, _root string, _in io.Reader, out io.Writer) error {
+func (g gitCmd) Run(cmd []string, _root string, _in io.Reader, out io.Writer) error {
 	res, ok := g.cases[(strings.Join(cmd, " "))]
 	if !ok {
 		return errors.New("doesn't exist")

--- a/internal/lefthook/lefthook.go
+++ b/internal/lefthook/lefthook.go
@@ -51,7 +51,7 @@ func initialize(opts *Options) (*Lefthook, error) {
 
 	log.SetColors(!opts.NoColors)
 
-	repo, err := git.NewRepository(opts.Fs, git.NewExecutor(system.Executor{}))
+	repo, err := git.NewRepository(opts.Fs, git.NewExecutor(system.Cmd))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/lefthook/run_test.go
+++ b/internal/lefthook/run_test.go
@@ -1,7 +1,9 @@
 package lefthook
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -11,10 +13,10 @@ import (
 	"github.com/evilmartians/lefthook/internal/git"
 )
 
-type GitMock struct{}
+type gitCmd struct{}
 
-func (g GitMock) Execute(_cmd []string, root string) (string, error) {
-	return "", nil
+func (g gitCmd) Run(context.Context, []string, string, io.Reader, io.Writer) error {
+	return nil
 }
 
 func TestRun(t *testing.T) {
@@ -157,7 +159,7 @@ post-commit:
 				Options: &Options{Fs: fs},
 				repo: &git.Repository{
 					Fs:        fs,
-					Git:       git.NewExecutor(GitMock{}),
+					Git:       git.NewExecutor(gitCmd{}),
 					HooksPath: hooksPath,
 					RootPath:  root,
 					GitPath:   gitPath,

--- a/internal/lefthook/run_test.go
+++ b/internal/lefthook/run_test.go
@@ -1,7 +1,6 @@
 package lefthook
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -15,7 +14,7 @@ import (
 
 type gitCmd struct{}
 
-func (g gitCmd) Run(context.Context, []string, string, io.Reader, io.Writer) error {
+func (g gitCmd) Run([]string, string, io.Reader, io.Writer) error {
 	return nil
 }
 

--- a/internal/lefthook/runner/exec/execute_unix.go
+++ b/internal/lefthook/runner/exec/execute_unix.go
@@ -68,15 +68,15 @@ func (e CommandExecutor) Execute(ctx context.Context, opts Options, in io.Reader
 	return nil
 }
 
-func (e CommandExecutor) RawExecute(ctx context.Context, command []string, in io.Reader, out io.Writer) error {
-	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+// func (e CommandExecutor) RawExecute(ctx context.Context, command []string, in io.Reader, out io.Writer) error {
+// 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 
-	cmd.Stdin = in
-	cmd.Stdout = out
-	cmd.Stderr = os.Stderr
+// 	cmd.Stdin = in
+// 	cmd.Stdout = out
+// 	cmd.Stderr = os.Stderr
 
-	return cmd.Run()
-}
+// 	return cmd.Run()
+// }
 
 func (e CommandExecutor) execute(ctx context.Context, cmdstr string, args *executeArgs) error {
 	command := exec.CommandContext(ctx, "sh", "-c", cmdstr)

--- a/internal/lefthook/runner/exec/execute_unix.go
+++ b/internal/lefthook/runner/exec/execute_unix.go
@@ -68,16 +68,6 @@ func (e CommandExecutor) Execute(ctx context.Context, opts Options, in io.Reader
 	return nil
 }
 
-// func (e CommandExecutor) RawExecute(ctx context.Context, command []string, in io.Reader, out io.Writer) error {
-// 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
-
-// 	cmd.Stdin = in
-// 	cmd.Stdout = out
-// 	cmd.Stderr = os.Stderr
-
-// 	return cmd.Run()
-// }
-
 func (e CommandExecutor) execute(ctx context.Context, cmdstr string, args *executeArgs) error {
 	command := exec.CommandContext(ctx, "sh", "-c", cmdstr)
 	command.Dir = args.root

--- a/internal/lefthook/runner/exec/execute_windows.go
+++ b/internal/lefthook/runner/exec/execute_windows.go
@@ -59,15 +59,15 @@ func (e CommandExecutor) Execute(ctx context.Context, opts Options, in io.Reader
 	return nil
 }
 
-func (e CommandExecutor) RawExecute(ctx context.Context, command []string, in io.Reader, out io.Writer) error {
-	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+// func (e CommandExecutor) RawExecute(ctx context.Context, command []string, in io.Reader, out io.Writer) error {
+// 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 
-	cmd.Stdin = in
-	cmd.Stdout = out
-	cmd.Stderr = os.Stderr
+// 	cmd.Stdin = in
+// 	cmd.Stdout = out
+// 	cmd.Stderr = os.Stderr
 
-	return cmd.Run()
-}
+// 	return cmd.Run()
+// }
 
 func (e CommandExecutor) execute(cmdstr string, args *executeArgs) error {
 	cmdargs := strings.Split(cmdstr, " ")

--- a/internal/lefthook/runner/exec/execute_windows.go
+++ b/internal/lefthook/runner/exec/execute_windows.go
@@ -59,16 +59,6 @@ func (e CommandExecutor) Execute(ctx context.Context, opts Options, in io.Reader
 	return nil
 }
 
-// func (e CommandExecutor) RawExecute(ctx context.Context, command []string, in io.Reader, out io.Writer) error {
-// 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
-
-// 	cmd.Stdin = in
-// 	cmd.Stdout = out
-// 	cmd.Stderr = os.Stderr
-
-// 	return cmd.Run()
-// }
-
 func (e CommandExecutor) execute(cmdstr string, args *executeArgs) error {
 	cmdargs := strings.Split(cmdstr, " ")
 	command := exec.Command(cmdargs[0])

--- a/internal/lefthook/runner/exec/executor.go
+++ b/internal/lefthook/runner/exec/executor.go
@@ -17,5 +17,4 @@ type Options struct {
 // It is used here for testing purpose mostly.
 type Executor interface {
 	Execute(ctx context.Context, opts Options, in io.Reader, out io.Writer) error
-	RawExecute(ctx context.Context, command []string, in io.Reader, out io.Writer) error
 }

--- a/internal/lefthook/runner/exec/executor.go
+++ b/internal/lefthook/runner/exec/executor.go
@@ -16,5 +16,5 @@ type Options struct {
 // Executor provides an interface for command execution.
 // It is used here for testing purpose mostly.
 type Executor interface {
-	Execute(ctx context.Context, opts Options, in io.Reader, out io.Writer) error
+	Execute(context.Context, Options, io.Reader, io.Writer) error
 }

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/evilmartians/lefthook/internal/lefthook/runner/exec"
 	"github.com/evilmartians/lefthook/internal/lefthook/runner/filters"
 	"github.com/evilmartians/lefthook/internal/log"
+	"github.com/evilmartians/lefthook/internal/system"
 )
 
 const (
@@ -55,6 +56,7 @@ type Runner struct {
 	partiallyStagedFiles []string
 	failed               atomic.Bool
 	executor             exec.Executor
+	cmd                  system.Command
 }
 
 func New(opts Options) *Runner {
@@ -65,6 +67,7 @@ func New(opts Options) *Runner {
 		// and scripts access the same Git data STDIN is cached via cachedReader.
 		stdin:    NewCachedReader(os.Stdin),
 		executor: exec.CommandExecutor{},
+		cmd:      system.Cmd,
 	}
 }
 
@@ -143,12 +146,13 @@ func (r *Runner) runLFSHook(ctx context.Context) error {
 			"[git-lfs] executing hook: git lfs %s %s", r.HookName, strings.Join(r.GitArgs, " "),
 		)
 		out := bytes.NewBuffer(make([]byte, 0))
-		err := r.executor.RawExecute(
+		err := r.cmd.Run(
 			ctx,
 			append(
 				[]string{"git", "lfs", r.HookName},
 				r.GitArgs...,
 			),
+			"",
 			r.stdin,
 			out,
 		)
@@ -497,7 +501,7 @@ func (r *Runner) run(ctx context.Context, opts exec.Options, follow bool) bool {
 	defer log.UnsetName(opts.Name)
 
 	// If the command does not explicitly `use_stdin` no input will be provided.
-	var in io.Reader = NewNullReader()
+	var in io.Reader = system.NullReader
 	if opts.UseStdin {
 		in = r.stdin
 	}

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -56,7 +56,7 @@ type Runner struct {
 	partiallyStagedFiles []string
 	failed               atomic.Bool
 	executor             exec.Executor
-	cmd                  system.Command
+	cmd                  system.CommandWithContext
 }
 
 func New(opts Options) *Runner {
@@ -146,7 +146,7 @@ func (r *Runner) runLFSHook(ctx context.Context) error {
 			"[git-lfs] executing hook: git lfs %s %s", r.HookName, strings.Join(r.GitArgs, " "),
 		)
 		out := bytes.NewBuffer(make([]byte, 0))
-		err := r.cmd.Run(
+		err := r.cmd.RunWithContext(
 			ctx,
 			append(
 				[]string{"git", "lfs", r.HookName},

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -22,6 +22,10 @@ import (
 type (
 	executor struct{}
 	cmd      struct{}
+	gitCmd   struct {
+		mux      sync.Mutex
+		commands []string
+	}
 )
 
 func (e executor) Execute(_ctx context.Context, opts exec.Options, _in io.Reader, _out io.Writer) (err error) {
@@ -34,16 +38,11 @@ func (e executor) Execute(_ctx context.Context, opts exec.Options, _in io.Reader
 	return
 }
 
-func (e cmd) Run(context.Context, []string, string, io.Reader, io.Writer) error {
+func (e cmd) RunWithContext(context.Context, []string, string, io.Reader, io.Writer) error {
 	return nil
 }
 
-type gitCmd struct {
-	mux      sync.Mutex
-	commands []string
-}
-
-func (g *gitCmd) Run(_ctx context.Context, cmd []string, _root string, _in io.Reader, out io.Writer) error {
+func (g *gitCmd) Run(cmd []string, _root string, _in io.Reader, out io.Writer) error {
 	g.mux.Lock()
 	g.commands = append(g.commands, strings.Join(cmd, " "))
 	g.mux.Unlock()

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -19,9 +19,12 @@ import (
 	"github.com/evilmartians/lefthook/internal/log"
 )
 
-type TestExecutor struct{}
+type (
+	executor struct{}
+	cmd      struct{}
+)
 
-func (e TestExecutor) Execute(_ctx context.Context, opts exec.Options, _in io.Reader, _out io.Writer) (err error) {
+func (e executor) Execute(_ctx context.Context, opts exec.Options, _in io.Reader, _out io.Writer) (err error) {
 	if strings.HasPrefix(opts.Commands[0], "success") {
 		err = nil
 	} else {
@@ -31,16 +34,16 @@ func (e TestExecutor) Execute(_ctx context.Context, opts exec.Options, _in io.Re
 	return
 }
 
-func (e TestExecutor) RawExecute(_ctx context.Context, _command []string, _in io.Reader, _out io.Writer) error {
+func (e cmd) Run(context.Context, []string, string, io.Reader, io.Writer) error {
 	return nil
 }
 
-type GitMock struct {
+type gitCmd struct {
 	mux      sync.Mutex
 	commands []string
 }
 
-func (g *GitMock) Execute(cmd []string, _root string) (string, error) {
+func (g *gitCmd) Run(_ctx context.Context, cmd []string, _root string, _in io.Reader, out io.Writer) error {
 	g.mux.Lock()
 	g.commands = append(g.commands, strings.Join(cmd, " "))
 	g.mux.Unlock()
@@ -49,16 +52,19 @@ func (g *GitMock) Execute(cmd []string, _root string) (string, error) {
 	if cmdLine == "git diff --name-only --cached --diff-filter=ACMR" ||
 		cmdLine == "git diff --name-only HEAD @{push}" {
 		root, _ := filepath.Abs("src")
-		return strings.Join([]string{
+		_, err := out.Write([]byte(strings.Join([]string{
 			filepath.Join(root, "scripts", "script.sh"),
 			filepath.Join(root, "README.md"),
-		}, "\n"), nil
+		}, "\n")))
+		if err != nil {
+			return err
+		}
 	}
 
-	return "", nil
+	return nil
 }
 
-func (g *GitMock) reset() {
+func (g *gitCmd) reset() {
 	g.mux.Lock()
 	g.commands = []string{}
 	g.mux.Unlock()
@@ -70,7 +76,7 @@ func TestRunAll(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 
-	gitExec := &GitMock{}
+	gitExec := &gitCmd{}
 	gitPath := filepath.Join(root, ".git")
 	repo := &git.Repository{
 		Git:       git.NewExecutor(gitExec),
@@ -736,7 +742,6 @@ func TestRunAll(t *testing.T) {
 	} {
 		fs := afero.NewMemMapFs()
 		repo.Fs = fs
-		executor := TestExecutor{}
 		runner := &Runner{
 			Options: Options{
 				Repo:        repo,
@@ -746,7 +751,8 @@ func TestRunAll(t *testing.T) {
 				GitArgs:     tt.args,
 				Force:       tt.force,
 			},
-			executor: executor,
+			executor: executor{},
+			cmd:      cmd{},
 		}
 		gitExec.reset()
 

--- a/internal/system/null_reader.go
+++ b/internal/system/null_reader.go
@@ -1,13 +1,11 @@
-package runner
+package system
 
 import "io"
 
 // nullReader always returns `io.EOF`.
 type nullReader struct{}
 
-func NewNullReader() io.Reader {
-	return nullReader{}
-}
+var NullReader = nullReader{}
 
 // Implements io.Reader interface.
 func (nullReader) Read(b []byte) (int, error) {

--- a/internal/system/null_reader_test.go
+++ b/internal/system/null_reader_test.go
@@ -1,4 +1,4 @@
-package runner
+package system
 
 import (
 	"bytes"
@@ -7,9 +7,7 @@ import (
 )
 
 func TestNullReader(t *testing.T) {
-	nullReader := NewNullReader()
-
-	res, err := io.ReadAll(nullReader)
+	res, err := io.ReadAll(NullReader)
 	if err != nil {
 		t.Errorf("unexpected err: %s", err)
 	}

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -15,15 +15,32 @@ type osCmd struct{}
 var Cmd = osCmd{}
 
 type Command interface {
-	Run(context.Context, []string, string, io.Reader, io.Writer) error
+	Run([]string, string, io.Reader, io.Writer) error
+}
+
+type CommandWithContext interface {
+	RunWithContext(context.Context, []string, string, io.Reader, io.Writer) error
 }
 
 // Run runs system command with LEFTHOOK=0 in order to prevent calling
 // subsequent lefthook hooks.
-func (c osCmd) Run(ctx context.Context, command []string, root string, in io.Reader, out io.Writer) error {
+func (c osCmd) RunWithContext(ctx context.Context, command []string, root string, in io.Reader, out io.Writer) error {
 	log.Debug("[lefthook] cmd: ", command)
 
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+
+	return run(cmd, root, in, out)
+}
+
+func (c osCmd) Run(command []string, root string, in io.Reader, out io.Writer) error {
+	log.Debug("[lefthook] cmd: ", command)
+
+	cmd := exec.Command(command[0], command[1:]...)
+
+	return run(cmd, root, in, out)
+}
+
+func run(cmd *exec.Cmd, root string, in io.Reader, out io.Writer) error {
 	cmd.Env = append(os.Environ(), "LEFTHOOK=0")
 	if len(root) > 0 {
 		cmd.Dir = root

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -1,33 +1,41 @@
-// system package contains OS-specific implementations.
+// system package contains wrappers for OS interactions.
 package system
 
 import (
+	"context"
+	"io"
 	"os"
 	"os/exec"
 
 	"github.com/evilmartians/lefthook/internal/log"
 )
 
-type Executor struct{}
+type osCmd struct{}
 
-// Execute executes git command with LEFTHOOK=0 in order
-// to prevent calling subsequent lefthook hooks.
-func (e Executor) Execute(args []string, root string) (string, error) {
-	log.Debug("[lefthook] cmd: ", args)
+var Cmd = osCmd{}
 
-	cmd := exec.Command(args[0], args[1:]...)
+type Command interface {
+	Run(context.Context, []string, string, io.Reader, io.Writer) error
+}
+
+// Run runs system command with LEFTHOOK=0 in order to prevent calling
+// subsequent lefthook hooks.
+func (c osCmd) Run(ctx context.Context, command []string, root string, in io.Reader, out io.Writer) error {
+	log.Debug("[lefthook] cmd: ", command)
+
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 	cmd.Env = append(os.Environ(), "LEFTHOOK=0")
 	if len(root) > 0 {
 		cmd.Dir = root
+		log.Debug("[lefthook] dir: ", root)
 	}
 
-	out, err := cmd.CombinedOutput()
-	log.Debug("[lefthook] dir: ", root)
+	cmd.Stdin = in
+	cmd.Stdout = out
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
 	log.Debug("[lefthook] err: ", err)
-	log.Debug("[lefthook] out: ", string(out))
-	if err != nil {
-		return "", err
-	}
 
-	return string(out), nil
+	return err
 }


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/730

**:broom: Summary**

`exec.Executor` interface does not need duplicated `RawExecute`, this code is moved to `system` package.

Also refactored some naming.
