### PR TITLE
perf: delay git and uname commands in hook scripts until needed

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -15,10 +15,6 @@ fi
 
 call_lefthook()
 {
-  dir="$(git rev-parse --show-toplevel)"
-  osArch=$(uname | tr '[:upper:]' '[:lower:]')
-  cpuArch=$(uname -m | sed 's/aarch64/arm64/')
-
   if test -n "$LEFTHOOK_BIN"
   then
     "$LEFTHOOK_BIN" "$@"
@@ -31,53 +27,60 @@ call_lefthook()
   then
     lefthook.bat "$@"
   {{end -}}
-  elif test -f "$dir/node_modules/lefthook/bin/index.js"
-  then
-    "$dir/node_modules/lefthook/bin/index.js" "$@"
-  elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
-  then
-    "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
-  elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
-  then
-    "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
-  {{ $extension := .Extension }}
-  {{- range .Roots -}}
-  elif test -f "$dir/{{.}}/node_modules/lefthook/bin/index.js"
-  then
-    "$dir/{{.}}/node_modules/lefthook/bin/index.js" "$@"
-  elif test -f "$dir/{{.}}/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}"
-  then
-    "$dir/{{.}}/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}" "$@"
-  elif test -f "$dir/{{.}}/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}"
-  then
-    "$dir/{{.}}/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}" "$@"
-  {{end}}
-  elif bundle exec lefthook -h >/dev/null 2>&1
-  then
-    bundle exec lefthook "$@"
-  elif yarn lefthook -h >/dev/null 2>&1
-  then
-    yarn lefthook "$@"
-  elif pnpm lefthook -h >/dev/null 2>&1
-  then
-    pnpm lefthook "$@"
-  elif swift package plugin lefthook >/dev/null 2>&1
-  then
-    swift package --disable-sandbox plugin lefthook "$@"
-  elif command -v mint >/dev/null 2>&1
-  then
-    mint run csjones/lefthook-plugin "$@"
-  elif command -v npx >/dev/null 2>&1
-  then
-    npx lefthook "$@"
   else
-    echo "Can't find lefthook in PATH"
-    {{- if .AssertLefthookInstalled}}
-    echo "ERROR: Operation is aborted due to lefthook settings."
-    echo "Make sure lefthook is available in your environment and re-try."
-    echo "To skip these checks use --no-verify git argument or set LEFTHOOK=0 env variable."
-    exit 1
-    {{- end}}
+    dir="$(git rev-parse --show-toplevel)"
+    if test -f "$dir/node_modules/lefthook/bin/index.js"
+    then
+      "$dir/node_modules/lefthook/bin/index.js" "$@"
+    else
+      osArch=$(uname | tr '[:upper:]' '[:lower:]')
+      cpuArch=$(uname -m | sed 's/aarch64/arm64/')
+      if test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
+      then
+        "$dir/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
+      elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}"
+      then
+        "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{.Extension}}" "$@"
+      {{ $extension := .Extension }}
+      {{- range .Roots -}}
+      elif test -f "$dir/{{.}}/node_modules/lefthook/bin/index.js"
+      then
+        "$dir/{{.}}/node_modules/lefthook/bin/index.js" "$@"
+      elif test -f "$dir/{{.}}/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}"
+      then
+        "$dir/{{.}}/node_modules/@evilmartians/lefthook/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}" "$@"
+      elif test -f "$dir/{{.}}/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}"
+      then
+        "$dir/{{.}}/node_modules/@evilmartians/lefthook-installer/bin/lefthook_${osArch}_${cpuArch}/lefthook{{$extension}}" "$@"
+      {{end}}
+      elif bundle exec lefthook -h >/dev/null 2>&1
+      then
+        bundle exec lefthook "$@"
+      elif yarn lefthook -h >/dev/null 2>&1
+      then
+        yarn lefthook "$@"
+      elif pnpm lefthook -h >/dev/null 2>&1
+      then
+        pnpm lefthook "$@"
+      elif swift package plugin lefthook >/dev/null 2>&1
+      then
+        swift package --disable-sandbox plugin lefthook "$@"
+      elif command -v mint >/dev/null 2>&1
+      then
+        mint run csjones/lefthook-plugin "$@"
+      elif command -v npx >/dev/null 2>&1
+      then
+        npx lefthook "$@"
+      else
+        echo "Can't find lefthook in PATH"
+        {{- if .AssertLefthookInstalled}}
+        echo "ERROR: Operation is aborted due to lefthook settings."
+        echo "Make sure lefthook is available in your environment and re-try."
+        echo "To skip these checks use --no-verify git argument or set LEFTHOOK=0 env variable."
+        exit 1
+        {{- end}}
+      fi
+    fi
   fi
 }
 


### PR DESCRIPTION
Closes # (issue)

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

Avoid running git and uname commands in scripts until their output is actually needed.

I suggest reviewing without showing whitespace changes due to changes in indentation.

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
- [ ] Add documentation
