### PR TITLE
chore(golangci-lint): enable copyloopvar, intrange, and prealloc

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     - decorder
     - dogsled
     - dupl
@@ -59,6 +60,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - intrange
     - makezero
     - mirror
     - misspell
@@ -67,6 +69,7 @@ linters:
     - noctx
     - nolintlint
     - perfsprint
+    - prealloc
     - predeclared
     - reassign
     - revive


### PR DESCRIPTION


<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

Add some more useful linters. There are no new findings to address at the moment.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
