### PR TITLE
fix: fetch remotes only for non ghost hooks

### DIFF
--- a/internal/lefthook/install.go
+++ b/internal/lefthook/install.go
@@ -114,18 +114,20 @@ func (l *Lefthook) createConfig(path string) error {
 	return nil
 }
 
-func (l *Lefthook) syncHooks(cfg *config.Config) (*config.Config, error) {
+func (l *Lefthook) syncHooks(cfg *config.Config, fetchRemotes bool) (*config.Config, error) {
 	var remotesSynced bool
 	var err error
 
-	for _, remote := range cfg.Remotes {
-		if remote.Configured() && remote.Refetch {
-			if err = l.repo.SyncRemote(remote.GitURL, remote.Ref, false); err != nil {
-				log.Warnf("Couldn't sync from %s. Will continue anyway: %s", remote.GitURL, err)
-				continue
-			}
+	if fetchRemotes {
+		for _, remote := range cfg.Remotes {
+			if remote.Configured() && remote.Refetch {
+				if err = l.repo.SyncRemote(remote.GitURL, remote.Ref, false); err != nil {
+					log.Warnf("Couldn't sync from %s. Will continue anyway: %s", remote.GitURL, err)
+					continue
+				}
 
-			remotesSynced = true
+				remotesSynced = true
+			}
 		}
 	}
 

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -102,7 +102,7 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 		newCfg, err := l.syncHooks(cfg, !isGhostHook)
 		if err != nil {
 			log.Warnf(
-				`⚠️  There was a problem with synchronizing git hooks. Run 'lefthook install' manually. Error: %s`, err,
+				"⚠️  There was a problem with synchronizing git hooks. Run 'lefthook install' manually.\n   Error: %s", err,
 			)
 		} else {
 			cfg = newCfg

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -73,7 +73,9 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 	// prepare-commit-msg hook is used for seamless synchronization of hooks with config.
 	// See: internal/lefthook/install.go
 	_, ok := cfg.Hooks[hookName]
+	var isGhostHook bool
 	if hookName == config.GhostHookName && !ok && !verbose {
+		isGhostHook = true
 		log.SetLevel(log.WarnLevel)
 	}
 
@@ -97,11 +99,10 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 
 	if !args.NoAutoInstall {
 		// This line controls updating the git hook if config has changed
-		newCfg, err := l.syncHooks(cfg)
+		newCfg, err := l.syncHooks(cfg, !isGhostHook)
 		if err != nil {
-			log.Warn(
-				`⚠️  There was a problem with synchronizing git hooks.
-Run 'lefthook install' manually.`,
+			log.Warnf(
+				`⚠️  There was a problem with synchronizing git hooks. Run 'lefthook install' manually. Error: %s`, err,
 			)
 		} else {
 			cfg = newCfg

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -148,6 +148,7 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 			sourceDirs = append(
 				sourceDirs,
 				filepath.Join(
+					l.repo.RootPath,
 					l.repo.RemoteFolder(remote.GitURL, remote.Ref),
 					cfg.SourceDir,
 				),


### PR DESCRIPTION
Related to https://github.com/evilmartians/lefthook/issues/743

**:wrench: Summary**

- [x] Do not refetch queries if being run in `prepare-commit-msg` and it is not present in a config
- [x] Print error that caused the issue when syncing the hooks