### PR TITLE
fix: skip overwriting hooks when fetching data from remotes

### DIFF
--- a/internal/lefthook/install.go
+++ b/internal/lefthook/install.go
@@ -141,7 +141,7 @@ func (l *Lefthook) syncHooks(cfg *config.Config, fetchRemotes bool) (*config.Con
 	}
 
 	// Don't rely on config checksum if remotes were refetched
-	return cfg, l.createHooksIfNeeded(cfg, !remotesSynced, false)
+	return cfg, l.createHooksIfNeeded(cfg, true, false)
 }
 
 func (l *Lefthook) createHooksIfNeeded(cfg *config.Config, checkHashSum, force bool) error {


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/743

**:wrench: Summary**

If the lefthook config hasn't change, no need to overwrite the hooks.