### PR TITLE
chore: setting proper error message for missing lefthook file

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -91,7 +91,7 @@ func readOne(fs afero.Fs, path string, names []string) (*viper.Viper, error) {
 		return v, nil
 	}
 
-	return nil, NotFoundError{fmt.Sprintf("No config files with names %q could not be found in \"%s\"", names, path)}
+	return nil, NotFoundError{fmt.Sprintf("No config files with names %q have been found in \"%s\"", names, path)}
 }
 
 // mergeAll merges configs using the following order.


### PR DESCRIPTION
#### :zap: Summary

While using lefthook I found out the error message being shown was incorrect.
Two negations have been put in the same sentence.

I wanted to help, so here you have it :D

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
