### PR TITLE
Fixed the use of '.Extension' in hook.tmpl

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -45,9 +45,9 @@ call_lefthook()
       "$dir/node_modules/lefthook/bin/index.js" "$@"
     {{ $extension := .Extension }}
     {{- range .Roots -}}
-    elif test -f "$dir/{{.}}/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook{{.Extension}}"
+    elif test -f "$dir/{{.}}/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook{{$extension}}"
     then
-      "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook{{.Extension}}" "$@"
+      "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook{{$extension}}" "$@"
     elif test -f "$dir/{{.}}/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook{{$extension}}"
     then
       "$dir/{{.}}/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook{{$extension}}" "$@"


### PR DESCRIPTION
Fixes #766

#### :zap: Summary

After using `range` `.Extension` cant be accessed on the resulting string. Two places where missed where this leads to a problem. They were replaced in this PR.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests (needed?)
- [ ] Add documentation (needed?)
