### PR TITLE
Fix missing sub directory

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -47,7 +47,7 @@ call_lefthook()
     {{- range .Roots -}}
     elif test -f "$dir/{{.}}/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook{{$extension}}"
     then
-      "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook{{$extension}}" "$@"
+      "$dir/{{.}}/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook{{$extension}}" "$@"
     elif test -f "$dir/{{.}}/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook{{$extension}}"
     then
       "$dir/{{.}}/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook{{$extension}}" "$@"


### PR DESCRIPTION
Having issues after upgrading:

The application resides in a sub directory, but lefthook tires to execute the binary in the project root:
```
.git/hooks/pre-commit: 37: /home/$PROJECT/node_modules/lefthook-linux-x64/bin/lefthook: not found
# actual location:
# /home/$PROJECT/ftonend/node_modules/lefthook-linux-x64/bin/lefthook
```

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
- [ ] Add documentation

I think it was a copy&paste error.  Feel free to just close this PR if it's bogus.
