### PR TITLE
fix: use direct lefthook package

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -75,7 +75,7 @@ call_lefthook()
       mint run csjones/lefthook-plugin "$@"
     elif command -v npx >/dev/null 2>&1
     then
-      npx lefthook "$@"
+    npx lefthook-${osArch}-${cpuArch} "$@"
     else
       echo "Can't find lefthook in PATH"
       {{- if .AssertLefthookInstalled}}

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -75,7 +75,7 @@ call_lefthook()
       mint run csjones/lefthook-plugin "$@"
     elif command -v npx >/dev/null 2>&1
     then
-    npx lefthook-${osArch}-${cpuArch} "$@"
+      npx lefthook-${osArch}-${cpuArch} "$@"
     else
       echo "Can't find lefthook in PATH"
       {{- if .AssertLefthookInstalled}}


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/773

**:wrench: Summary**

Instead of relying on `lefthook` package use direct `lefthook-{os}-{arch}` since we know the OS and the Arch.