### PR TITLE
fix: rollback packaging changes

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -75,7 +75,7 @@ call_lefthook()
       mint run csjones/lefthook-plugin "$@"
     elif command -v npx >/dev/null 2>&1
     then
-      npx lefthook-${osArch}-${cpuArch} "$@"
+      npx lefthook "$@"
     else
       echo "Can't find lefthook in PATH"
       {{- if .AssertLefthookInstalled}}

--- a/packaging/npm/lefthook-darwin-arm64/package.json
+++ b/packaging/npm/lefthook-darwin-arm64/package.json
@@ -2,9 +2,6 @@
   "name": "lefthook-darwin-arm64",
   "version": "1.7.3",
   "description": "The macOS ARM 64-bit binary for lefthook, git hooks manager.",
-  "bin": {
-    "lefthook": "bin/lefthook"
-  },
   "preferUnplugged": false,
   "repository": "https://github.com/evilmartians/lefthook",
   "license": "MIT",

--- a/packaging/npm/lefthook-darwin-x64/package.json
+++ b/packaging/npm/lefthook-darwin-x64/package.json
@@ -2,9 +2,6 @@
   "name": "lefthook-darwin-x64",
   "version": "1.7.3",
   "description": "The macOS 64-bit binary for lefthook, git hooks manager.",
-  "bin": {
-    "lefthook": "bin/lefthook"
-  },
   "preferUnplugged": false,
   "repository": "https://github.com/evilmartians/lefthook",
   "license": "MIT",

--- a/packaging/npm/lefthook-freebsd-arm64/package.json
+++ b/packaging/npm/lefthook-freebsd-arm64/package.json
@@ -2,9 +2,6 @@
   "name": "lefthook-freebsd-arm64",
   "version": "1.7.3",
   "description": "The FreeBSD ARM 64-bit binary for lefthook, git hooks manager.",
-  "bin": {
-    "lefthook": "bin/lefthook"
-  },
   "preferUnplugged": false,
   "repository": "https://github.com/evilmartians/lefthook",
   "license": "MIT",

--- a/packaging/npm/lefthook-freebsd-x64/package.json
+++ b/packaging/npm/lefthook-freebsd-x64/package.json
@@ -2,9 +2,6 @@
   "name": "lefthook-freebsd-x64",
   "version": "1.7.3",
   "description": "The FreeBSD 64-bit binary for lefthook, git hooks manager.",
-  "bin": {
-    "lefthook": "bin/lefthook"
-  },
   "preferUnplugged": false,
   "repository": "https://github.com/evilmartians/lefthook",
   "license": "MIT",

--- a/packaging/npm/lefthook-linux-arm64/package.json
+++ b/packaging/npm/lefthook-linux-arm64/package.json
@@ -2,9 +2,6 @@
   "name": "lefthook-linux-arm64",
   "version": "1.7.3",
   "description": "The Linux ARM 64-bit binary for lefthook, git hooks manager.",
-  "bin": {
-    "lefthook": "bin/lefthook"
-  },
   "preferUnplugged": false,
   "repository": "https://github.com/evilmartians/lefthook",
   "license": "MIT",

--- a/packaging/npm/lefthook-linux-x64/package.json
+++ b/packaging/npm/lefthook-linux-x64/package.json
@@ -2,9 +2,6 @@
   "name": "lefthook-linux-x64",
   "version": "1.7.3",
   "description": "The Linux 64-bit binary for lefthook, git hooks manager.",
-  "bin": {
-    "lefthook": "bin/lefthook"
-  },
   "preferUnplugged": false,
   "repository": "https://github.com/evilmartians/lefthook",
   "license": "MIT",

--- a/packaging/npm/lefthook-windows-arm64/package.json
+++ b/packaging/npm/lefthook-windows-arm64/package.json
@@ -2,9 +2,6 @@
   "name": "lefthook-windows-arm64",
   "version": "1.7.3",
   "description": "The Windows ARM 64-bit binary for lefthook, git hooks manager.",
-  "bin": {
-    "lefthook": "bin/lefthook"
-  },
   "preferUnplugged": false,
   "repository": "https://github.com/evilmartians/lefthook",
   "license": "MIT",

--- a/packaging/npm/lefthook-windows-x64/package.json
+++ b/packaging/npm/lefthook-windows-x64/package.json
@@ -2,9 +2,6 @@
   "name": "lefthook-windows-x64",
   "version": "1.7.3",
   "description": "The Windows 64-bit binary for lefthook, git hooks manager.",
-  "bin": {
-    "lefthook": "bin/lefthook"
-  },
   "preferUnplugged": false,
   "repository": "https://github.com/evilmartians/lefthook",
   "license": "MIT",


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/775

**:wrench: Summary**

Looks like optional dependencies (os-arch packages) conflict with the original `lefthook`. This was the only significant change that probably broke the behavior of `npx lefthook`.