### PR TITLE
Fix typo for command names in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -931,7 +931,7 @@ pre-commit:
   commands:
     lint:
       run: yarn lint
-    text:
+    test:
       run: yarn test
 ```
 
@@ -946,7 +946,7 @@ pre-commit:
   commands:
     lint:
       run: yarn lint
-    text:
+    test:
       run: yarn test
 ```
 
@@ -961,7 +961,7 @@ pre-commit:
   commands:
     lint:
       run: yarn lint
-    text:
+    test:
       run: yarn test
 ```
 


### PR DESCRIPTION
I just fixed the typo in the configuration.md. 