### PR TITLE
Run LFS hooks after checking if hooks are skipped

### DIFF
--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -90,13 +90,13 @@ type executable interface {
 func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) ([]Result, error) {
 	results := make([]Result, 0, len(r.Hook.Commands)+len(r.Hook.Scripts))
 
-	if err := r.runLFSHook(ctx); err != nil {
-		return results, err
-	}
-
 	if r.Hook.DoSkip(r.Repo.State()) {
 		r.logSkip(r.HookName, "hook setting")
 		return results, nil
+	}
+
+	if err := r.runLFSHook(ctx); err != nil {
+		return results, err
 	}
 
 	if !r.DisableTTY && !r.Hook.Follow {


### PR DESCRIPTION
#### :zap: Summary

I noticed that the `skip: true` configuration I added to `post-checkout` was running LFS code. I also noticed that setting the environment variable `LEFTHOOK=0` did not run any LFS code.

This PR moves `r.Hook.DoSkip` closer to the top of `RunAll`, basically running less code when asked to skip.

I didn't really know how to test this! `runner_test.go` doesn't seem to test any LFS behavior. I'm pretty new to Go, so I'm unlikely to be able to heavily modify tests.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
