### PR TITLE
fix: force remote name origin when using remotes

### DIFF
--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -93,7 +93,7 @@ func (r *Repository) updateRemote(path, ref string) error {
 func (r *Repository) cloneRemote(dest, directoryName, url, ref string) error {
 	log.Debugf("Cloning remote config repository: %v/%v", dest, directoryName)
 
-	cmdClone := []string{"git", "-C", dest, "clone", "--quiet", "--depth", "1"}
+	cmdClone := []string{"git", "-C", dest, "clone", "--quiet", "--origin", "origin", "--depth", "1"}
 	if len(ref) > 0 {
 		cmdClone = append(cmdClone, "--branch", ref)
 	}

--- a/internal/lefthook/install.go
+++ b/internal/lefthook/install.go
@@ -149,7 +149,7 @@ func (l *Lefthook) createHooksIfNeeded(cfg *config.Config, checkHashSum, force b
 		return nil
 	}
 
-	log.Infof(log.Cyan("sync hooks"))
+	log.Infof("%s", log.Cyan("sync hooks"))
 
 	var success bool
 	defer func() {


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/826

**:wrench: Summary**

- [x] Add `--origin origin` for the `git clone` of the remotes. This ignores the `defaultRemoteName` setting.