### PR TITLE
chore: hide remaining wiki links

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1444,6 +1444,6 @@ We have a directory with few examples. You can check it [here](https://github.co
 
 Have a question?
 
-:monocle_face: Check the [wiki](https://github.com/evilmartians/lefthook/wiki)
+<!-- :monocle_face: Check the [wiki](https://github.com/evilmartians/lefthook/wiki) -->
 
-:thinking: Or start a [discussion](https://github.com/evilmartians/lefthook/discussions)
+:thinking: Start a [discussion](https://github.com/evilmartians/lefthook/discussions)

--- a/docs/install.md
+++ b/docs/install.md
@@ -155,6 +155,6 @@ Or take it from [binaries](https://github.com/evilmartians/lefthook/releases) an
 
 Have a question?
 
-:monocle_face: Check the [wiki](https://github.com/evilmartians/lefthook/wiki)
+<!-- :monocle_face: Check the [wiki](https://github.com/evilmartians/lefthook/wiki) -->
 
-:thinking: Or start a [discussion](https://github.com/evilmartians/lefthook/discussions)
+:thinking: Start a [discussion](https://github.com/evilmartians/lefthook/discussions)


### PR DESCRIPTION
Re #608 

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

As per #608 hide the remaining links to the currently disabled Wiki.

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
- [ ] Add documentation
