### PR TITLE
ci: parallelize publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - run: python -m pip install --upgrade pip twine wheel setuptools
-
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
@@ -56,40 +50,84 @@ jobs:
           name: dist
           path: dist.tar
 
-  publish-packages:
+  publish-npm:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - run: git fetch --force --tags
 
-      - name: Fetch all tags
-        run: git fetch --force --tags
-
-      - name: Download build binaries
-        uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4
         with:
           name: dist
       - run: tar -xvf dist.tar
 
-      - name: Publish to NPM, Rubygems and PyPI
+      - name: Publish to NPM
         env:
           NPM_API_KEY: ${{ secrets.NPM_API_KEY }}
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-          PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
         run: |
           cat << EOF > ~/.npmrc
           //registry.npmjs.org/:_authToken=${NPM_API_KEY}
           EOF
           chmod 0600 ~/.npmrc
+          cd packaging/
+          ruby pack.rb prepare
+          ruby pack.rb publish_npm
+
+  publish-gem:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+      - run: tar -xvf dist.tar
+
+      - name: Publish to Rubygems
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
           mkdir -p ~/.gem/
           cat << EOF > ~/.gem/credentials
           ---
           :rubygems_api_key: ${RUBYGEMS_API_KEY}
           EOF
           chmod 0600 ~/.gem/credentials
+          cd packaging/
+          ruby pack.rb prepare
+          ruby pack.rb publish_gem
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+      - run: tar -xvf dist.tar
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip twine wheel setuptools
+
+      - name: Publish to PyPI
+        env:
+          PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
+        run: |
           cat << EOF > ~/.pypirc
           [distutils]
             index-servers =
@@ -103,7 +141,7 @@ jobs:
           chmod 0600 ~/.pypirc
           cd packaging/
           ruby pack.rb prepare
-          ruby pack.rb publish
+          ruby pack.rb publish_pypi
 
   publish-homebrew:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  goreleaser:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -49,6 +49,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
 
+      - name: Preserve artifacts permissions with tar
+        run: tar -cvf dist.tar dist/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist.tar
+
+  publish-packages:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --force --tags
+
+      - name: Download build binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+      - run: tar -xvf dist.tar
+
       - name: Publish to NPM, Rubygems and PyPI
         env:
           NPM_API_KEY: ${{ secrets.NPM_API_KEY }}
@@ -80,12 +105,20 @@ jobs:
           ruby pack.rb prepare
           ruby pack.rb publish
 
+  publish-homebrew:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Update Homebrew formula
         uses: dawidd6/action-homebrew-bump-formula@v3
         with:
           formula: lefthook
           token: ${{secrets.HOMEBREW_TOKEN}}
 
+  publish-winget:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Publish to Winget
         uses: vedantmgoyal2009/winget-releaser@v2
         with:

--- a/packaging/pack.rb
+++ b/packaging/pack.rb
@@ -122,11 +122,12 @@ module Pack
   end
 
   def publish
-    puts "Publishing to PyPI..."
-    cd(File.join(__dir__, "pypi"))
-    system("python setup.py sdist bdist_wheel", exception: true)
-    system("python -m twine upload --verbose --repository lefthook dist/*", exception: true)
+    publish_pypi
+    publish_npm
+    publish_gem
+  end
 
+  def publish_npm
     puts "Publishing lefthook npm..."
     cd(File.join(__dir__, "npm"))
     Dir["lefthook*"].each do |package|
@@ -143,13 +144,20 @@ module Pack
     puts "Publishing @evilmartians/lefthook-installer npm..."
     cd(File.join(__dir__, "npm-installer"))
     system("npm publish --access public", exception: true)
+  end
 
+  def publish_gem
     puts "Publishing to Rubygems..."
     cd(File.join(__dir__, "rubygems"))
     system("rake build", exception: true)
     system("gem push pkg/*.gem", exception: true)
+  end
 
-    puts "done"
+  def publish_pypi
+    puts "Publishing to PyPI..."
+    cd(File.join(__dir__, "pypi"))
+    system("python setup.py sdist bdist_wheel", exception: true)
+    system("python -m twine upload --verbose --repository lefthook dist/*", exception: true)
   end
 
   def replace_in_file(filepath, regexp, value)


### PR DESCRIPTION
**:zap: Summary**

Homebrew and Winget repos can be updated in parallel. Still need `build` to finish just to make sure the program is buildable.

Publishing of packages also moved to parallel jobs.
