### PR TITLE
fix: calculate hashsum of the full config

### DIFF
--- a/internal/lefthook/dump.go
+++ b/internal/lefthook/dump.go
@@ -1,6 +1,8 @@
 package lefthook
 
 import (
+	"os"
+
 	"github.com/evilmartians/lefthook/internal/config"
 	"github.com/evilmartians/lefthook/internal/log"
 )
@@ -45,7 +47,7 @@ func Dump(opts *Options, args DumpArgs) {
 		format = config.TOMLFormat
 	}
 
-	if err := cfg.Dump(format); err != nil {
+	if err := cfg.Dump(format, os.Stdout); err != nil {
 		log.Errorf("couldn't dump config: %s\n", err)
 		return
 	}

--- a/internal/lefthook/install_test.go
+++ b/internal/lefthook/install_test.go
@@ -326,7 +326,7 @@ post-commit:
     notify:
       run: echo 'Done!'
 `,
-			checksum: "8b2c9fc6b3391b3cf020b97ab7037c61 1555894310\n",
+			checksum: "939f59e3f706df65f379a9ff5ce0119b 1555894310\n",
 			wantExist: []string{
 				configPath,
 				infoPath(config.ChecksumFileName),


### PR DESCRIPTION
**:wrench: Summary**

Instead of calculating the hashsum only for `lefthook.yml`, calculate the hashsum for the whole loaded config. If something changes – reinstall the hooks.