### PR TITLE
feat: add refetch_frequency parameter to settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ Config options:
   - [`git_url`](#git_url)
   - [`ref`](#ref-1)
   - [`refetch`](#refetch)
+  - [`refetch_frequency`](#refetch_frequency)
   - [`configs`](#configs)
 - [`<pre-commit>`](#hook-name) hook name
   - [`files` (global)](#files-global)
@@ -416,6 +417,29 @@ remotes:
   - git_url: https://github.com/evilmartians/lefthook
     refetch: true
 ```
+
+### `refetch_frequency`
+
+**Default:** Not set
+
+Specifies how frequently Lefthook should refetch the remote configuration. This can be set to `always`, `never` or a time duration like `24h`, `30m`, etc.
+
+- When set to `always`, Lefthook will always refetch the remote configuration on each run.
+- When set to a duration (e.g., `24h`), Lefthook will check the last fetch time and refetch the configuration only if the specified amount of time has passed.
+- When set to `never` or not set, Lefthook will not fetch from remote.
+
+**Example**
+
+```yml
+# lefthook.yml
+
+remotes:
+  - git_url: https://github.com/evilmartians/lefthook
+    refetch_frequency: 24h # Refetches once every 24 hours
+```
+
+> [!WARNING]
+> If `refetch` is set to `true`, it overrides any setting in `refetch_frequency`.
 
 ### `configs`
 

--- a/internal/config/remote.go
+++ b/internal/config/remote.go
@@ -4,9 +4,10 @@ type Remote struct {
 	GitURL string `json:"git_url,omitempty" mapstructure:"git_url"       toml:"git_url"       yaml:"git_url"`
 	Ref    string `json:"ref,omitempty"     mapstructure:"ref,omitempty" toml:"ref,omitempty" yaml:",omitempty"`
 	// Deprecated
-	Config  string   `json:"config,omitempty"  mapstructure:"config,omitempty"  toml:"config,omitempty"  yaml:",omitempty"`
-	Configs []string `json:"configs,omitempty" mapstructure:"configs,omitempty" toml:"configs,omitempty" yaml:",omitempty"`
-	Refetch bool     `json:"refetch,omitempty" mapstructure:"refetch,omitempty" toml:"refetch,omitempty" yaml:",omitempty"`
+	Config           string   `json:"config,omitempty"            mapstructure:"config,omitempty"            toml:"config,omitempty"            yaml:",omitempty"`
+	Configs          []string `json:"configs,omitempty"           mapstructure:"configs,omitempty"           toml:"configs,omitempty"           yaml:",omitempty"`
+	Refetch          bool     `json:"refetch,omitempty"           mapstructure:"refetch,omitempty"           toml:"refetch,omitempty"           yaml:",omitempty"`
+	RefetchFrequency string   `json:"refetch_frequency,omitempty" mapstructure:"refetch_frequency,omitempty" toml:"refetch_frequency,omitempty" yaml:",omitempty"`
 }
 
 func (r *Remote) Configured() bool {


### PR DESCRIPTION
#### :zap: Summary

First of all, thanks everyone for the great tool!

The `remote` feature of lefthook allows us at the place where I work to easily share configuration across our hundreds of repositories. Usually, our devs have some dozens of repositories cloned on their machines and work actively in one or two at a time. To ensure that they will have a reasonably recent config when going back to a repo after some time, we configure our remotes with `refetch: true`, but this has the side effect that every time they run lefthook on a currently active repository, either by commiting something or by hand to manually check the output of the QA tools, they trigger a fetch.

To make the experience smother, this PR introduces a new parameter `refetch_frequency` that allows a more fine grained control over the remote refetching by allowing the definition of time periods instead of just a boolean flag. This is a working implementation already, but it defers some decisions that could be made to maybe improve the usability. I didn't want to touch the following points without consulting the core team before, but:
- I think that this parameter superseds the current `refetch`, so maybe it could be marked deprecated;
- I used ParseDuration from go's stdlib in the current implementation, but a more user-friendly format could be used at the cost of a new dependency.

I also apologize in advance for any oddities in the code, I'm not a go programmer, but I can make changes that you see fit to make the PR more fitting.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
- [x] Add documentation
