### PR TITLE
fix: commitizen wasn't called properly

### DIFF
--- a/examples/commitlint/lefthook.yml
+++ b/examples/commitlint/lefthook.yml
@@ -3,7 +3,7 @@ prepare-commit-msg:
   commands:
     commitzen:
       interactive: true
-      run: yarn run cz
+      run: yarn run cz --hook # Or npx cz --hook
       env:
         LEFTHOOK: 0
 


### PR DESCRIPTION


<!-- Link to an issue(s) this PR fixes -->

Commitizen wasn't called properly in the given example, and it was causing issues trying to commit twice (I can't believe no one came across this issue) with errors such as:

`fatal: cannot lock ref 'HEAD': is at ee79e382ba5d071408d1093ab56895a9076c7a55 but expected 073a7db08b49ac494c9023c0f4db29d406a12741`

It turns out, it needed the `--hook` parameter as specified in [commitizen docs](https://github.com/commitizen/cz-cli?tab=readme-ov-file#optional-running-commitizen-on-git-commit).

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
- [ ] Add documentation
