### PR TITLE
Option to fully disable LFS hooks

### DIFF
--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -1,3 +1,5 @@
+skip_lfs = true
+
 [pre-commit]
 parallel = true
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -70,6 +70,11 @@ func (run) New(opts *lefthook.Options) *cobra.Command {
 	)
 
 	runCmd.Flags().BoolVar(
+		&runArgs.SkipLFS, "skip-lfs", false,
+		"skip running git lfs",
+	)
+
+	runCmd.Flags().BoolVar(
 		&runArgs.FilesFromStdin, "files-from-stdin", false,
 		"get files from standard input, null-separated",
 	)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	NoTTY                   bool        `mapstructure:"no_tty,omitempty"`
 	AssertLefthookInstalled bool        `mapstructure:"assert_lefthook_installed,omitempty"`
 	Colors                  interface{} `mapstructure:"colors,omitempty"`
+	SkipLFS                 bool        `mapstructure:"skip_lfs,omitempty"`
 
 	// Deprecated: use Remotes
 	Remote  *Remote   `mapstructure:"remote,omitempty"`

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -162,6 +162,7 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 			GitArgs:         gitArgs,
 			LogSettings:     logSettings,
 			DisableTTY:      cfg.NoTTY || args.NoTTY,
+			SkipLFS:         cfg.SkipLFS,
 			Files:           args.Files,
 			Force:           args.Force,
 			RunOnlyCommands: args.RunOnlyCommands,

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -27,6 +27,7 @@ type RunArgs struct {
 	FilesFromStdin  bool
 	Force           bool
 	NoAutoInstall   bool
+	SkipLFS         bool
 	Files           []string
 	RunOnlyCommands []string
 }
@@ -162,7 +163,7 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 			GitArgs:         gitArgs,
 			LogSettings:     logSettings,
 			DisableTTY:      cfg.NoTTY || args.NoTTY,
-			SkipLFS:         cfg.SkipLFS,
+			SkipLFS:         cfg.SkipLFS || args.SkipLFS,
 			Files:           args.Files,
 			Force:           args.Force,
 			RunOnlyCommands: args.RunOnlyCommands,

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -43,6 +43,7 @@ type Options struct {
 	GitArgs         []string
 	LogSettings     log.Settings
 	DisableTTY      bool
+	SkipLFS         bool
 	Force           bool
 	Files           []string
 	RunOnlyCommands []string
@@ -125,6 +126,10 @@ func (r *Runner) RunAll(ctx context.Context, sourceDirs []string) ([]Result, err
 }
 
 func (r *Runner) runLFSHook(ctx context.Context) error {
+	if r.Options.SkipLFS {
+		return nil
+	}
+
 	if !git.IsLFSHook(r.HookName) {
 		return nil
 	}

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -93,6 +93,7 @@ func TestRunAll(t *testing.T) {
 		success, fail    []Result
 		gitCommands      []string
 		force            bool
+		skipLFS          bool
 	}{
 		"empty hook": {
 			hookName: "post-commit",
@@ -716,6 +717,21 @@ func TestRunAll(t *testing.T) {
 				"git diff --name-only HEAD @{push}",
 			},
 		},
+		"with LFS disabled": {
+			hookName: "post-checkout",
+			skipLFS:  true,
+			existingFiles: []string{
+				filepath.Join(root, "README.md"),
+			},
+			hook: &config.Hook{
+				Commands: map[string]*config.Command{
+					"ok": {
+						Run: "success",
+					},
+				},
+			},
+			success: []Result{succeeded("ok")},
+		},
 	} {
 		fs := afero.NewMemMapFs()
 		repo.Fs = fs
@@ -727,6 +743,7 @@ func TestRunAll(t *testing.T) {
 				LogSettings: log.NewSettings(),
 				GitArgs:     tt.args,
 				Force:       tt.force,
+				SkipLFS:     tt.skipLFS,
 			},
 			executor: executor{},
 			cmd:      cmd{},


### PR DESCRIPTION
https://github.com/evilmartians/lefthook/discussions/821

#### :zap: Summary

Git LFS is an opt-in feature that lets people store large files outside a git repository, saving only pointers to them in the git repository itself.

Git does not use LFS by default. One must manually specify files and file patterns using the `.gitattributes` file.

I've found that LFS adds about 2.2 seconds when running lefthook in my employer's large git repo.

<details>
<summary>My small benchmark</summary>

```
❯ /usr/bin/time git lfs post-checkout e6f8d32b e6f8d32b 0
        2.24 real         0.39 user         1.51 sys
❯ /usr/bin/time git lfs post-checkout e6f8d32b e6f8d32b 0
        2.22 real         0.39 user         1.50 sys
❯ /usr/bin/time git lfs post-checkout e6f8d32b e6f8d32b 0
        2.28 real         0.41 user         1.51 sys
❯ /usr/bin/time git lfs post-checkout e6f8d32b e6f8d32b 0
        2.29 real         0.41 user         1.51 sys
❯ /usr/bin/time git lfs post-checkout e6f8d32b e6f8d32b 0
        2.30 real         0.42 user         1.53 sys
```

</details>

Considering the ~500 engineers in my company, and assuming an average of 1 `git checkout` per day (I assume this is a low estimate, but I don't have metrics on this), _**we'd save 6.1 hours of engineering time every month.**_

##### NOTE

I'd personally recommend that we rework this feature—that we change the flag to `enable_lfs` and disable LFS hooks by default. I'm more than happy to do so.

Because LFS is fully opt-in, and because of its poor performance in large repositories, I don't believe it makes sense to enable this feature by default.

##### ALSO NOTE

I disabled LFS for this project as well since it's not needed here (see "chore" commit). I assume you will want me to revert that change! I'm more than happy to 😅.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
