### PR TITLE
fix(docs): correct typo in 'Scoop for Windows' section

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -89,7 +89,7 @@ Or, with [mint](https://github.com/yonaskolb/Mint):
 mint run csjones/lefthook-plugin
 ```
 
-## <a id="scoop"></a> Scoop for Windowss
+## <a id="scoop"></a> Scoop for Windows
 
 ```sh
 scoop install lefthook


### PR DESCRIPTION
Closes # (issue)

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Fixed a typo in the documentation section for 'Scoop for Windows'.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
