### PR TITLE
fix: skip_lfs config option

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	NoTTY                   bool        `koanf:"no_tty"                    mapstructure:"no_tty,omitempty"`
 	AssertLefthookInstalled bool        `koanf:"assert_lefthook_installed" mapstructure:"assert_lefthook_installed,omitempty"`
 	Colors                  interface{} `mapstructure:"colors,omitempty"`
-	SkipLFS                 bool        `mapstructure:"skip_lfs,omitempty"`
+	SkipLFS                 bool        `koanf:"skip_lfs"                  mapstructure:"skip_lfs,omitempty"`
 
 	// Deprecated: use Remotes
 	Remote  *Remote   `mapstructure:"remote,omitempty"`


### PR DESCRIPTION
#### :zap: Summary

A colleague mentioned to me that the our two-second delay came back. Upon investigation, I noticed that lefthook wasn't reading the config flag anymore.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
