### PR TITLE
fix: correctly parse config options

### DIFF
--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -27,7 +27,7 @@ type Command struct {
 	Priority    int    `json:"priority,omitempty"    mapstructure:"priority"    toml:"priority,omitempty"    yaml:",omitempty"`
 	FailText    string `json:"fail_text,omitempty"   koanf:"fail_text"          mapstructure:"fail_text"     toml:"fail_text,omitempty"   yaml:"fail_text,omitempty"`
 	Interactive bool   `json:"interactive,omitempty" mapstructure:"interactive" toml:"interactive,omitempty" yaml:",omitempty"`
-	UseStdin    bool   `json:"use_stdin,omitempty"   mapstructure:"use_stdin"   toml:"use_stdin,omitempty"   yaml:",omitempty"`
+	UseStdin    bool   `json:"use_stdin,omitempty"   koanf:"use_stdin"          mapstructure:"use_stdin"     toml:"use_stdin,omitempty"   yaml:"use_stdin,omitempty"`
 	StageFixed  bool   `json:"stage_fixed,omitempty" koanf:"stage_fixed"        mapstructure:"stage_fixed"   toml:"stage_fixed,omitempty" yaml:"stage_fixed,omitempty"`
 }
 

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -14,10 +14,10 @@ type Script struct {
 	Env      map[string]string `json:"env,omitempty"      mapstructure:"env"      toml:"env,omitempty"         yaml:",omitempty"`
 	Priority int               `json:"priority,omitempty" mapstructure:"priority" toml:"priority,omitempty"    yaml:",omitempty"`
 
-	FailText    string `json:"fail_text,omitempty"   mapstructure:"fail_text"   toml:"fail_text,omitempty"   yaml:"fail_text,omitempty"`
+	FailText    string `json:"fail_text,omitempty"   koanf:"fail_text"          mapstructure:"fail_text"     toml:"fail_text,omitempty"   yaml:"fail_text,omitempty"`
 	Interactive bool   `json:"interactive,omitempty" mapstructure:"interactive" toml:"interactive,omitempty" yaml:",omitempty"`
-	UseStdin    bool   `json:"use_stdin,omitempty"   mapstructure:"use_stdin"   toml:"use_stdin,omitempty"   yaml:",omitempty"`
-	StageFixed  bool   `json:"stage_fixed,omitempty" mapstructure:"stage_fixed" toml:"stage_fixed,omitempty" yaml:"stage_fixed,omitempty"`
+	UseStdin    bool   `json:"use_stdin,omitempty"   koanf:"use_stdin"          mapstructure:"use_stdin"     toml:"use_stdin,omitempty"   yaml:"use_stdin,omitempty"`
+	StageFixed  bool   `json:"stage_fixed,omitempty" koanf:"stage_fixed"        mapstructure:"stage_fixed"   toml:"stage_fixed,omitempty" yaml:"stage_fixed,omitempty"`
 }
 
 func (s Script) DoSkip(state func() git.State) bool {

--- a/testdata/dump.txt
+++ b/testdata/dump.txt
@@ -34,6 +34,13 @@ pre-commit:
       skip: merge
       glob: "*.js"
       run: yarn test
+  scripts:
+    "my-script.sh":
+      runner: bash
+      use_stdin: true
+      stage_fixed: true
+      env:
+        FOO: bar
 -- lefthook-dumped.yml --
 colors:
   cyan: 14
@@ -54,6 +61,13 @@ pre-commit:
       run: yarn test
       skip: merge
       glob: '*.js'
+  scripts:
+    my-script.sh:
+      runner: bash
+      env:
+        FOO: bar
+      use_stdin: true
+      stage_fixed: true
   follow: true
 -- lefthook-dumped.json --
 {
@@ -83,6 +97,16 @@ pre-commit:
         "glob": "*.js"
       }
     },
+    "scripts": {
+      "my-script.sh": {
+        "runner": "bash",
+        "env": {
+          "FOO": "bar"
+        },
+        "use_stdin": true,
+        "stage_fixed": true
+      }
+    },
     "follow": true
   }
 }
@@ -107,3 +131,12 @@ interactive = true
 run = 'yarn test'
 skip = 'merge'
 glob = '*.js'
+
+[pre-commit.scripts]
+[pre-commit.scripts.'my-script.sh']
+runner = 'bash'
+use_stdin = true
+stage_fixed = true
+
+[pre-commit.scripts.'my-script.sh'.env]
+FOO = 'bar'


### PR DESCRIPTION
Fixes https://github.com/evilmartians/lefthook/issues/893

**:wrench: Summary**

Specify key name for use_stdin option (koanf)

