### PR TITLE
feat: add ability to specify job names to run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -94,6 +94,11 @@ func (run) New(opts *lefthook.Options) *cobra.Command {
 		"run only specified commands",
 	)
 
+	runCmd.Flags().StringSliceVar(
+		&runArgs.RunOnlyJobs, "jobs", nil,
+		"run only specified jobs",
+	)
+
 	err := runCmd.Flags().MarkDeprecated("files", "use --file flag instead")
 	if err != nil {
 		log.Warn("Unexpected error:", err)

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -33,6 +33,7 @@ type RunArgs struct {
 	SkipLFS         bool
 	Files           []string
 	RunOnlyCommands []string
+	RunOnlyJobs     []string
 }
 
 func Run(opts *Options, args RunArgs, hookName string, gitArgs []string) error {
@@ -170,6 +171,7 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 			Files:           args.Files,
 			Force:           args.Force,
 			RunOnlyCommands: args.RunOnlyCommands,
+			RunOnlyJobs:     args.RunOnlyJobs,
 			SourceDirs:      sourceDirs,
 		},
 	)

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -41,6 +41,7 @@ type Options struct {
 	Force           bool
 	Files           []string
 	RunOnlyCommands []string
+	RunOnlyJobs     []string
 	SourceDirs      []string
 }
 

--- a/testdata/cli_run_only.txt
+++ b/testdata/cli_run_only.txt
@@ -1,0 +1,34 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add -A
+exec lefthook install
+exec lefthook run hook --jobs a --jobs c --jobs db --commands lint
+stdout '\s*a\s*ca\s*cb\s*db\s*lint\s*'
+
+-- lefthook.yml --
+output:
+  - execution_out
+hook:
+  jobs:
+    - name: a
+      run: echo a
+    - name: b
+      run: echo b
+    - name: c
+      group:
+        jobs:
+          - run: echo ca
+          - run: echo cb
+    - name: d
+      group:
+        jobs:
+          - name: da
+            run: echo da
+          - name: db
+            run: echo db
+  commands:
+    lint:
+      run: echo lint
+    test:
+      run: echo test


### PR DESCRIPTION
Idea from discussion of https://github.com/evilmartians/lefthook/issues/846

**:zap: Summary**

- [x] Add `lefthook run <hook> --jobs job1 job2`
- [x] Add tests