### PR TITLE
docs: add community aur package mention

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -152,10 +152,15 @@ See all instructions: https://cloudsmith.io/~evilmartians/repos/lefthook/setup/#
 
 ## <a id="arch"></a> AUR for Arch
 
-You can install lefthook [package](https://aur.archlinux.org/packages/lefthook) from AUR.
+Official [AUR package](https://aur.archlinux.org/packages/lefthook) (compiles from sources)
+Community [AUR package](https://aur.archlinux.org/packages/lefthook-bin) (delivers pre-compiled binaries)
 
 ```sh
+# To compile from sources
 yay -S lefthook
+
+# To install only executable
+yay -S lefthook-bin
 ```
 
 ## <a id="else"></a> Manuall installation with prebuilt executable

--- a/docs/mdbook/installation/arch.md
+++ b/docs/mdbook/installation/arch.md
@@ -1,7 +1,12 @@
 ## AUR for Arch
 
-[AUR package](https://aur.archlinux.org/packages/lefthook)
+Official [AUR package](https://aur.archlinux.org/packages/lefthook) (compiles from sources)
+Community [AUR package](https://aur.archlinux.org/packages/lefthook-bin) (delivers pre-compiled binaries)
 
 ```sh
+# To compile from sources
 yay -S lefthook
+
+# To install only executable
+yay -S lefthook-bin
 ```


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/906

**:zap: Summary**

Add a mention of a community-driven lefthook-bin AUR package.