### PR TITLE
feat: run --jobs completion

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -36,6 +36,15 @@ func (run) New(opts *lefthook.Options) *cobra.Command {
 		return
 	}
 
+	runHookJobCompletions := func(cmd *cobra.Command, args []string, toComplete string) (ret []string, compDir cobra.ShellCompDirective) {
+		compDir = cobra.ShellCompDirectiveNoFileComp
+		if len(args) == 0 {
+			return
+		}
+		ret = lefthook.ConfigHookJobCompletions(opts, args[0])
+		return
+	}
+
 	runCmd := cobra.Command{
 		Use:               "run hook-name [git args...]",
 		Short:             "Execute group of hooks",
@@ -105,6 +114,8 @@ func (run) New(opts *lefthook.Options) *cobra.Command {
 	}
 
 	_ = runCmd.RegisterFlagCompletionFunc("commands", runHookCommandCompletions)
+
+	_ = runCmd.RegisterFlagCompletionFunc("jobs", runHookJobCompletions)
 
 	return &runCmd
 }

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -285,6 +285,14 @@ func ConfigHookCommandCompletions(opts *Options, hookName string) []string {
 	return lefthook.configHookCommandCompletions(hookName)
 }
 
+func ConfigHookJobCompletions(opts *Options, hookName string) []string {
+	lefthook, err := initialize(opts)
+	if err != nil {
+		return nil
+	}
+	return lefthook.configHookJobCompletions(hookName)
+}
+
 func (l *Lefthook) configHookCommandCompletions(hookName string) []string {
 	cfg, err := config.Load(l.Fs, l.repo)
 	if err != nil {
@@ -298,6 +306,22 @@ func (l *Lefthook) configHookCommandCompletions(hookName string) []string {
 			commands = append(commands, command)
 		}
 		return commands
+	}
+}
+
+func (l *Lefthook) configHookJobCompletions(hookName string) []string {
+	cfg, err := config.Load(l.Fs, l.repo)
+	if err != nil {
+		return nil
+	}
+	if hook, found := cfg.Hooks[hookName]; !found {
+		return nil
+	} else {
+		jobs := make([]string, 0, len(hook.Jobs))
+		for _, job := range hook.Jobs {
+			jobs = append(jobs, job.Name)
+		}
+		return jobs
 	}
 }
 


### PR DESCRIPTION


#### :zap: Summary

<!-- Brief description of what was done -->

Adds `lefthook run foo --jobs <TAB>` completion, like there currently exists for `--commands`.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
