### PR TITLE
fix: replace cmd in jobs

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -537,6 +537,7 @@ func mergeJobsSlice(src, dest []interface{}) []interface{} {
 						destSubJobs = mergeJobsSlice(srcSubJobs, destSubJobs)
 					}
 
+					// Replace possible {cmd} before merging the jobs
 					switch srcRun := srcJob["run"].(type) {
 					case string:
 						switch destRun := destJob["run"].(type) {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -537,6 +537,17 @@ func mergeJobsSlice(src, dest []interface{}) []interface{} {
 						destSubJobs = mergeJobsSlice(srcSubJobs, destSubJobs)
 					}
 
+					switch srcRun := srcJob["run"].(type) {
+					case string:
+						switch destRun := destJob["run"].(type) {
+						case string:
+							newRun := strings.ReplaceAll(srcRun, CMD, destRun)
+							srcJob["run"] = newRun
+						default:
+						}
+					default:
+					}
+
 					maps.Merge(srcJob, destJob)
 
 					if len(destSubJobs) != 0 {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -809,6 +809,36 @@ pre-commit:
 				},
 			},
 		},
+		"with jobs overwrite": {
+			files: map[string]string{
+				"lefthook.yml": `
+pre-commit:
+  jobs:
+    - name: job 1
+      run: echo from job 1
+`,
+				"lefthook-local.yml": `
+pre-commit:
+  jobs:
+    - name: job 1
+      run: wrap {cmd}
+`,
+			},
+			result: &Config{
+				SourceDir:      ".lefthook",
+				SourceDirLocal: ".lefthook-local",
+				Hooks: map[string]*Hook{
+					"pre-commit": {
+						Jobs: []*Job{
+							{
+								Name: "job 1",
+								Run:  "wrap echo from job 1",
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
 		repo := &git.Repository{


### PR DESCRIPTION
**:wrench: Summary**

Support replacing `{cmd}` in Jobs when merging lefthook-local
