### PR TITLE
fix: avoid skipping pre commit when deleted files staged

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -23,24 +23,25 @@ const (
 )
 
 var (
-	reHeadBranch     = regexp.MustCompile(`HEAD -> (?P<name>.*)$`)
-	reVersion        = regexp.MustCompile(`\d+\.\d+\.\d+`)
-	cmdPushFilesBase = []string{"git", "diff", "--name-only", "HEAD", "@{push}"}
-	cmdPushFilesHead = []string{"git", "diff", "--name-only", "HEAD"}
-	cmdStagedFiles   = []string{"git", "diff", "--name-only", "--cached", "--diff-filter=ACMR"}
-	cmdStatusShort   = []string{"git", "status", "--short", "--porcelain"}
-	cmdListStash     = []string{"git", "stash", "list"}
-	cmdRootPath      = []string{"git", "rev-parse", "--path-format=absolute", "--show-toplevel"}
-	cmdHooksPath     = []string{"git", "rev-parse", "--path-format=absolute", "--git-path", "hooks"}
-	cmdInfoPath      = []string{"git", "rev-parse", "--path-format=absolute", "--git-path", "info"}
-	cmdGitPath       = []string{"git", "rev-parse", "--path-format=absolute", "--git-dir"}
-	cmdAllFiles      = []string{"git", "ls-files", "--cached"}
-	cmdCreateStash   = []string{"git", "stash", "create"}
-	cmdStageFiles    = []string{"git", "add"}
-	cmdRemotes       = []string{"git", "branch", "--remotes"}
-	cmdHideUnstaged  = []string{"git", "checkout", "--force", "--"}
-	cmdEmptyTreeSHA  = []string{"git", "hash-object", "-t", "tree", "/dev/null"}
-	cmdGitVersion    = []string{"git", "version"}
+	reHeadBranch              = regexp.MustCompile(`HEAD -> (?P<name>.*)$`)
+	reVersion                 = regexp.MustCompile(`\d+\.\d+\.\d+`)
+	cmdPushFilesBase          = []string{"git", "diff", "--name-only", "HEAD", "@{push}"}
+	cmdPushFilesHead          = []string{"git", "diff", "--name-only", "HEAD"}
+	cmdStagedFiles            = []string{"git", "diff", "--name-only", "--cached", "--diff-filter=ACMR"}
+	cmdStagedFilesWithDeleted = []string{"git", "diff", "--name-only", "--cached", "--diff-filter=ACMRD"}
+	cmdStatusShort            = []string{"git", "status", "--short", "--porcelain"}
+	cmdListStash              = []string{"git", "stash", "list"}
+	cmdRootPath               = []string{"git", "rev-parse", "--path-format=absolute", "--show-toplevel"}
+	cmdHooksPath              = []string{"git", "rev-parse", "--path-format=absolute", "--git-path", "hooks"}
+	cmdInfoPath               = []string{"git", "rev-parse", "--path-format=absolute", "--git-path", "info"}
+	cmdGitPath                = []string{"git", "rev-parse", "--path-format=absolute", "--git-dir"}
+	cmdAllFiles               = []string{"git", "ls-files", "--cached"}
+	cmdCreateStash            = []string{"git", "stash", "create"}
+	cmdStageFiles             = []string{"git", "add"}
+	cmdRemotes                = []string{"git", "branch", "--remotes"}
+	cmdHideUnstaged           = []string{"git", "checkout", "--force", "--"}
+	cmdEmptyTreeSHA           = []string{"git", "hash-object", "-t", "tree", "/dev/null"}
+	cmdGitVersion             = []string{"git", "version"}
 )
 
 // Repository represents a git repository.
@@ -117,22 +118,24 @@ func NewRepository(fs afero.Fs, git *CommandExecutor) (*Repository, error) {
 	}, nil
 }
 
-// StagedFiles returns a list of staged files
-// or an error if git command fails.
+// StagedFiles returns a list of staged files which exist on file system.
 func (r *Repository) StagedFiles() ([]string, error) {
-	return r.FilesByCommand(cmdStagedFiles, "")
+	return r.FindExistingFiles(cmdStagedFiles, "")
 }
 
-// StagedFiles returns a list of all files in repository
-// or an error if git command fails.
+// StagedFilesWithDeleted returns a list of staged files with deleted files.
+func (r *Repository) StagedFilesWithDeleted() ([]string, error) {
+	return r.FindAllFiles(cmdStagedFilesWithDeleted, "")
+}
+
+// StagedFiles returns a list of all files in repository.
 func (r *Repository) AllFiles() ([]string, error) {
-	return r.FilesByCommand(cmdAllFiles, "")
+	return r.FindExistingFiles(cmdAllFiles, "")
 }
 
-// PushFiles returns a list of files that are ready to be pushed
-// or an error if git command fails.
+// PushFiles returns a list of files that are ready to be pushed.
 func (r *Repository) PushFiles() ([]string, error) {
-	res, err := r.FilesByCommand(cmdPushFilesBase, "")
+	res, err := r.FindExistingFiles(cmdPushFilesBase, "")
 	if err == nil {
 		return res, nil
 	}
@@ -159,7 +162,7 @@ func (r *Repository) PushFiles() ([]string, error) {
 		r.headBranch = r.emptyTreeSHA
 	}
 
-	return r.FilesByCommand(append(cmdPushFilesHead, r.headBranch), "")
+	return r.FindExistingFiles(append(cmdPushFilesHead, r.headBranch), "")
 }
 
 // PartiallyStagedFiles returns the list of files that have both staged and
@@ -327,22 +330,37 @@ func (r *Repository) AddFiles(files []string) error {
 	return err
 }
 
-// FilesByCommand accepts git command and returns its result as a list of filepaths.
-func (r *Repository) FilesByCommand(command []string, folder string) ([]string, error) {
+// FindAllFiles accepts git command and returns its result as a list of filepaths.
+func (r *Repository) FindAllFiles(command []string, folder string) ([]string, error) {
 	lines, err := r.Git.CmdLinesWithinFolder(command, folder)
 	if err != nil {
 		return nil, err
 	}
 
-	return r.extractFiles(lines)
+	return r.extractFiles(lines, false)
 }
 
-func (r *Repository) extractFiles(lines []string) ([]string, error) {
+// FindExistingFiles accepts git command and returns its result as a list of filepaths.
+func (r *Repository) FindExistingFiles(command []string, folder string) ([]string, error) {
+	lines, err := r.Git.CmdLinesWithinFolder(command, folder)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.extractFiles(lines, true)
+}
+
+func (r *Repository) extractFiles(lines []string, checkExistence bool) ([]string, error) {
 	var files []string
 
 	for _, line := range lines {
 		file := strings.TrimSpace(line)
 		if len(file) == 0 {
+			continue
+		}
+
+		if !checkExistence {
+			files = append(files, file)
 			continue
 		}
 

--- a/internal/lefthook/runner/jobs/build_command.go
+++ b/internal/lefthook/runner/jobs/build_command.go
@@ -56,7 +56,7 @@ func buildCommand(params *Params) (*Job, error) {
 			} else {
 				cmd = []string{"sh", "-c", filesCmd}
 			}
-			return params.Repo.FilesByCommand(cmd, params.Root)
+			return params.Repo.FindExistingFiles(cmd, params.Root)
 		}
 	}
 
@@ -124,7 +124,7 @@ func buildCommand(params *Params) (*Job, error) {
 	}
 
 	if config.HookUsesStagedFiles(params.HookName) {
-		ok, err := canSkipJob(params, filterParams, templates[config.SubStagedFiles], params.Repo.StagedFiles)
+		ok, err := canSkipJob(params, filterParams, templates[config.SubStagedFiles], params.Repo.StagedFilesWithDeleted)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -50,6 +50,7 @@ func (g *gitCmd) Run(cmd []string, _root string, _in io.Reader, out io.Writer, _
 
 	cmdLine := strings.Join(cmd, " ")
 	if cmdLine == "git diff --name-only --cached --diff-filter=ACMR" ||
+		cmdLine == "git diff --name-only --cached --diff-filter=ACMRD" ||
 		cmdLine == "git diff --name-only HEAD @{push}" {
 		root, _ := filepath.Abs("src")
 		_, err := out.Write([]byte(strings.Join([]string{
@@ -622,7 +623,7 @@ func TestRunAll(t *testing.T) {
 					"fail": {
 						Run:        "fail",
 						StageFixed: true,
-						Glob:       "*.sh",
+						Glob:       "*.txt",
 					},
 				},
 			},

--- a/testdata/pre-commit_issue_919.txt
+++ b/testdata/pre-commit_issue_919.txt
@@ -1,0 +1,24 @@
+exec git init
+exec git add -A
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add -A
+exec git commit -m 'first commit'
+rm file.txt
+exec git add -A
+exec lefthook run pre-commit
+stdout '^\s*must be printed\s*$'
+
+-- lefthook.yml --
+output:
+  - execution_out
+pre-commit:
+  jobs:
+    - run: echo 'must be printed'
+    - run: echo 'excluded txt'
+      exclude:
+        - '*.txt'
+    - run: echo 'excluded by' {staged_files}
+
+-- file.txt --
+will be deleted


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/919

**:wrench: Summary**

For `pre-commit` we use `git diff --diff-filter=ACMR` and this avoids checking for deleted files. But sometimes user wants a pre-commit hook to run on any change to the files (even when deleting files). For that cases (when `{staged_files}` template is not used) we should not force skipping the command/job.

- [x] Implement special check for implicit pre-commit skip logic to also count deleted files
- [x] Add a test