### PR TITLE
feat: allow to define lefthook executable or command

### DIFF
--- a/docs/mdbook/SUMMARY.md
+++ b/docs/mdbook/SUMMARY.md
@@ -29,6 +29,7 @@
   - [`colors`](./configuration/colors.md)
   - [`no_tty`](./configuration/no_tty.md)
   - [`extends`](./configuration/extends.md)
+  - [`lefthook`](./configuration/lefthook.md)
   - [`min_version`](./configuration/min_version.md)
   - [`output`](./configuration/output.md)
   - [`skip_output`](./configuration/skip_output.md)

--- a/docs/mdbook/configuration/README.md
+++ b/docs/mdbook/configuration/README.md
@@ -21,6 +21,7 @@ Lefthook also merges an extra config with the name `lefthook-local`. All support
 - [`colors`](./colors.md)
 - [`no_tty`](./no_tty.md)
 - [`extends`](./extends.md)
+- [`lefthook`](./lefthook.md)
 - [`min_version`](./min_version.md)
 - [`output`](./output.md)
 - [`skip_output`](./skip_output.md)

--- a/docs/mdbook/configuration/lefthook.md
+++ b/docs/mdbook/configuration/lefthook.md
@@ -1,0 +1,62 @@
+## `lefthook`
+
+**Default:** `null`
+
+Provide a full path to lefthook executable or a command to run lefthook. Bourne shell (`sh`) syntax is supported.
+
+> **Important:** This option does not merge from `remotes` or `extends` for security reasons. But it gets merged from lefthook local config if specified.
+
+There are three reasons you may want to specify `lefthook`:
+
+1. You want to force using specific lefthook version from your dependencies (e.g. npm package)
+1. You use OnP loader for your JS/TS project, and your `package.json` with lefthook dependency locates in a subfolder
+1. You want to make sure you use concrete lefthook executable path and want to defined it in `lefthook-local.yml`
+
+### Examples
+
+#### Specify lefthook executable
+
+```yml
+# lefthook.yml
+
+lefthook: /usr/bin/lefthook
+
+pre-commit:
+  jobs:
+    - run: yarn lint
+```
+
+#### Specify a command to run lefthook
+
+```yml
+# lefthook.yml
+
+lefthook: |
+  cd project-with-lefthook
+  pnpm lefthook
+
+pre-commit:
+  jobs:
+    - run: yarn lint
+      root: project-with-lefthook
+```
+
+#### Force using a version from Rubygems
+
+```yml
+# lefthook.yml
+
+lefthook: bundle exec lefthook
+
+pre-commit:
+  jobs:
+    - run: bundle exec rubocop {staged_files}
+```
+
+#### Enable debug logs
+
+```yml
+# lefthook-local.yml
+
+lefthook: lefthook --verbose
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,8 @@ const (
 type Config struct {
 	MinVersion string `json:"min_version,omitempty" jsonschema:"description=Specify a minimum version for the lefthook binary" koanf:"min_version" mapstructure:"min_version,omitempty"`
 
+	Lefthook string `json:"lefthook,omitempty" jsonschema:"description=Lefthook executable path or command" mapstructure:"lefthook,omitempty"`
+
 	SourceDir string `json:"source_dir,omitempty" jsonschema:"default=.lefthook/,description=Change a directory for script files. Directory for script files contains folders with git hook names which contain script files." koanf:"source_dir" mapstructure:"source_dir,omitempty"`
 
 	SourceDirLocal string `json:"source_dir_local,omitempty" jsonschema:"default=.lefthook-local/,description=Change a directory for local script files (not stored in VCS)" koanf:"source_dir_local" mapstructure:"source_dir_local,omitempty"`

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -114,7 +114,7 @@ func LoadKoanf(filesystem afero.Fs, repo *git.Repository) (*koanf.Koanf, *koanf.
 		return nil, nil, err
 	}
 
-	// Don't allow to set `lefthook` field by a remote config
+	// Don't allow to set `lefthook` field from a remote config
 	secondary.Delete("lefthook")
 
 	// Load optional local config (e.g. lefthook-local.yml)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -114,6 +114,9 @@ func LoadKoanf(filesystem afero.Fs, repo *git.Repository) (*koanf.Koanf, *koanf.
 		return nil, nil, err
 	}
 
+	// Don't allow to set `lefthook` field by a remote config
+	secondary.Delete("lefthook")
+
 	// Load optional local config (e.g. lefthook-local.yml)
 	var noLocal bool
 	if err := loadOne(secondary, filesystem, repo.RootPath, localConfigNames); err != nil {

--- a/internal/lefthook/install.go
+++ b/internal/lefthook/install.go
@@ -225,6 +225,7 @@ func (l *Lefthook) createHooksIfNeeded(cfg *config.Config, checkHashSum, force b
 			Rc:                      cfg.Rc,
 			AssertLefthookInstalled: cfg.AssertLefthookInstalled,
 			Roots:                   roots,
+			LefthookExe:             cfg.Lefthook,
 		}
 		if err = l.addHook(hook, templateArgs); err != nil {
 			return fmt.Errorf("could not add the hook: %w", err)

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -18,15 +18,20 @@ call_lefthook()
   if test -n "$LEFTHOOK_BIN"
   then
     "$LEFTHOOK_BIN" "$@"
+  {{ if .LefthookExe -}}
+  elif sh -c "{{ .LefthookExe }} -h" >/dev/null 2>&1
+  then
+    {{ .LefthookExe }} "$@"
+  {{ end -}}
   elif lefthook{{.Extension}} -h >/dev/null 2>&1
   then
     lefthook{{.Extension}} "$@"
-  {{if .Extension -}}
+  {{ if .Extension -}}
   {{/* Check if lefthook.bat exists. Ruby bundler creates such a wrapper */ -}}
   elif lefthook.bat -h >/dev/null 2>&1
   then
     lefthook.bat "$@"
-  {{end -}}
+  {{ end -}}
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')
@@ -57,7 +62,7 @@ call_lefthook()
     elif test -f "$dir/{{.}}/node_modules/lefthook/bin/index.js"
     then
       "$dir/{{.}}/node_modules/lefthook/bin/index.js" "$@"
-    {{end}}
+    {{ end }}
     elif bundle exec lefthook -h >/dev/null 2>&1
     then
       bundle exec lefthook "$@"

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -19,7 +19,7 @@ call_lefthook()
   then
     "$LEFTHOOK_BIN" "$@"
   {{ if .LefthookExe -}}
-  elif sh -c "{{ .LefthookExe }} -h" >/dev/null 2>&1
+  elif test -n "{{ .LefthookExe }}"
   then
     {{ .LefthookExe }} "$@"
   {{ end -}}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"runtime"
+	"strings"
 	"text/template"
 )
 
@@ -15,6 +16,7 @@ var templatesFS embed.FS
 
 type Args struct {
 	Rc                      string
+	LefthookExe             string
 	AssertLefthookInstalled bool
 	Roots                   []string
 }
@@ -22,6 +24,7 @@ type Args struct {
 type hookTmplData struct {
 	HookName                string
 	Extension               string
+	LefthookExe             string
 	Rc                      string
 	Roots                   []string
 	AssertLefthookInstalled bool
@@ -36,6 +39,7 @@ func Hook(hookName string, args Args) []byte {
 		Rc:                      args.Rc,
 		AssertLefthookInstalled: args.AssertLefthookInstalled,
 		Roots:                   args.Roots,
+		LefthookExe:             strings.ReplaceAll(strings.TrimSpace(args.LefthookExe), "\n", ";"),
 	})
 	if err != nil {
 		panic(err)

--- a/schema.json
+++ b/schema.json
@@ -392,11 +392,15 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.01.10.",
+  "$comment": "Last updated on 2025.01.14.",
   "properties": {
     "min_version": {
       "type": "string",
       "description": "Specify a minimum version for the lefthook binary"
+    },
+    "lefthook": {
+      "type": "string",
+      "description": "Lefthook executable path or command"
     },
     "source_dir": {
       "type": "string",

--- a/testdata/lefthook_option.txt
+++ b/testdata/lefthook_option.txt
@@ -1,0 +1,26 @@
+exec git init
+exec lefthook install
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add -A
+exec git commit -m 'must show debug logs'
+stderr 'injected'
+stdout '[lefthook]'
+
+-- lefthook.yml --
+lefthook: |
+  echo 'injected'
+  lefthook -v
+
+output:
+  - execution
+pre-commit:
+  jobs:
+    - run: echo {all_files}
+      glob: "*.txt"
+
+-- file.txt --
+sometext
+
+-- file.js --
+somecode


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/443

**:zap: Summary**

There are two scenarios when you want to specify the lefthook executable or lefthook command:

1. You want to make sure developers in your project use the same lefthook version as installed in your project dependencies (makes sense when installing lefthook via npm, Ruby gems, PyPi)
2. You use PnP loader and have your `package.json` with lefthook dependency in a subdir. Currently there's no way to correctly do `cd subdir; yarn run lefthook`. This option can help with this.

The other special case is: you want to use your own lefthook executable defined in `lefthook-local.yml` (for whatever reason).

- [x] Add `lefthook` field to the top-level config options
- [x] Update hook template. Strip and replace newlines with ';' since the value will be wrapped with `sh -c`
- [x] Add tests
- [x] Add docs

So, examples:

**Some hard-coded binary**

```yml
# lefthook.yml

lefthook: /usr/bin/lefthook

pre-commit:
  jobs:
    - run: echo {staged_files}
```

**Some hidden package**

```yml
# lefthook.yml

lefthook: |
  cd subdir
  yarn run lefthook

pre-commit:
  jobs:
    - run: echo {staged_files}
```

**Force using lefthook gem**

```yml
# lefthook.yml

lefthook: bundle exec lefthook

pre-commit:
  jobs:
    - run: echo {staged_files}
```