### PR TITLE
fix: use lefthook option in ghost hook too

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,2 @@
-[default.extend-words]
-"Pn" = "Pn" # for PnP
+[default.extend-identifiers]
+"PnP" = "PnP"

--- a/internal/lefthook/install.go
+++ b/internal/lefthook/install.go
@@ -236,6 +236,7 @@ func (l *Lefthook) createHooksIfNeeded(cfg *config.Config, checkHashSum, force b
 		Rc:                      cfg.Rc,
 		AssertLefthookInstalled: cfg.AssertLefthookInstalled,
 		Roots:                   roots,
+		LefthookExe:             cfg.Lefthook,
 	}
 	if err = l.addHook(config.GhostHookName, templateArgs); err != nil {
 		return nil


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/443

**:wrench: Summary**

- [x] Fix missing `LefthookExe` for `prepare-commit-msg`