### PR TITLE
feat(config): look up from .config subdir by default, too

### DIFF
--- a/docs/mdbook/configuration/README.md
+++ b/docs/mdbook/configuration/README.md
@@ -13,6 +13,8 @@ Lefthook supports the following file names for the main config:
 
 If there are more than 1 file in the project, only one will be used, and you'll never know which one. So, please, use one format in a project.
 
+Filenames without the leading dot will also be looked up from the [`.config` subdirectory](https://github.com/pi0/config-dir).
+
 Lefthook also merges an extra config with the name `lefthook-local`. All supported formats can be applied to this `-local` config. If you name your main config with the leading dot, like `.lefthook.json`, the `-local` config also must be named with the leading dot: `.lefthook-local.json`.
 
 ## Options

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -30,8 +30,8 @@ const (
 
 var (
 	hookKeyRegexp    = regexp.MustCompile(`^(?P<hookName>[^.]+)\.(scripts|commands|jobs)`)
-	localConfigNames = []string{"lefthook-local", ".lefthook-local"}
-	mainConfigNames  = []string{"lefthook", ".lefthook"}
+	localConfigNames = []string{"lefthook-local", ".lefthook-local", filepath.Join(".config", "lefthook-local")}
+	mainConfigNames  = []string{"lefthook", ".lefthook", filepath.Join(".config", "lefthook")}
 	extensions       = []string{
 		".yml",
 		".yaml",


### PR DESCRIPTION
Closes # (issue)

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

<!-- Brief description of what was done -->

Look up configs from `.config` subdirs too, to help unclutter project top level dirs, https://github.com/pi0/config-dir (and other similar proposals)

pi0/config-dir support discussion item: https://github.com/pi0/config-dir/discussions/6#discussioncomment-11881023

This is a draft for discussion purposes, to be still done at least
- [ ] tests
- [ ] the `.config/lefthook` and `.config/lefthook-local` source dirs should work out of the box, too
- [ ] decide how relative paths should work and make sure they do that way, e.g. should they always be from the "top level dir" no matter if the config is in `.config`, or relative to that dir (I think I'd propose the former)
- [ ] remove with `uninstall`

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [x] Add documentation
