### PR TITLE
Document the unusual behaviour of ** in glob option

### DIFF
--- a/docs/mdbook/configuration/glob.md
+++ b/docs/mdbook/configuration/glob.md
@@ -31,6 +31,10 @@ pre-commit:
 
 For patterns that you can use see [this](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm) reference. We use [glob](https://github.com/gobwas/glob) library.
 
+***When using `root:`***
+
+Globs are still calculated from the actual root of the git repo, `root` is ignored.
+
 ***Behaviour of `**`***
 
 Note that the behaviour of `**` is different from typical glob implementations, like `ls` or tools like `lint-staged` in that a double-asterisk matches 1+ directories deep, not zero or more directories.

--- a/docs/mdbook/configuration/glob.md
+++ b/docs/mdbook/configuration/glob.md
@@ -31,6 +31,23 @@ pre-commit:
 
 For patterns that you can use see [this](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm) reference. We use [glob](https://github.com/gobwas/glob) library.
 
+***Behaviour of `**`***
+
+Note that the behaviour of `**` is different from typical glob implementations, like `ls` or tools like `lint-staged` in that a double-asterisk matches 1+ directories deep, not zero or more directories.
+If you want to match *both* files at the top level and nested, then rather than:
+
+```yaml
+glob: "src/**/*.js"
+```
+
+You'll need:
+
+```yaml
+glob: "src/*.js"
+```
+
+***Using `glob` without a files template in`run`***
+
 If you've specified `glob` but don't have a files template in [`run`](./run.md) option, lefthook will check `{staged_files}` for `pre-commit` hook and `{push_files}` for `pre-push` hook and apply filtering. If no files left, the command will be skipped.
 
 ```yml

--- a/docs/mdbook/configuration/root.md
+++ b/docs/mdbook/configuration/root.md
@@ -33,3 +33,9 @@ pre-commit:
       glob: "*.{js,ts}"
       run: yarn eslint --fix {staged_files} && git add {staged_files}
 ```
+
+**Notes**
+
+***When using `root:`***
+
+Globs are still calculated from the actual root of the git repo, `root` is ignored.


### PR DESCRIPTION
#### :zap: Summary

I had assumed that glob patterns work like they do with the *nix `ls` command, or in tools like lint-staged. I can imagine people expecting it to behave the same.

It seems that `**` is interpreted as a single asterisk, ie meaning "1+ directories deep", rather than "0 or more directories deep".

Whilst there is a link to the Go glob library used, and that README mentions double asterisks, I was mainly left confused by it:

> Syntax is inspired by [standard wildcards](http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm), except that ** is aka super-asterisk, that do not sensitive for separators.

I don't think this covers the difference I'm bringing up. I also don't know what is meant by "super-asterisk" here - I'd love to know!

More details, including an example are in the commit message.

Thanks for making such an awesome tool!