### PR TITLE
fix(jsonschema): add $schema property

### DIFF
--- a/internal/gen/jsonschema.go
+++ b/internal/gen/jsonschema.go
@@ -18,6 +18,7 @@ func main() {
 	r.AdditionalFields = func(t reflect.Type) []reflect.StructField {
 		if t == reflect.TypeOf(config.Config{}) {
 			return reflect.VisibleFields(reflect.TypeOf(struct {
+				Schema               string      ` json:"$schema,omitempty"`
 				PreCommit            *config.Hook `json:"pre-commit,omitempty"`
 				ApplypatchMsg        *config.Hook `json:"applypatch-msg,omitempty"`
 				PreApplypatch        *config.Hook `json:"pre-applypatch,omitempty"`

--- a/internal/gen/jsonschema.go
+++ b/internal/gen/jsonschema.go
@@ -18,7 +18,7 @@ func main() {
 	r.AdditionalFields = func(t reflect.Type) []reflect.StructField {
 		if t == reflect.TypeOf(config.Config{}) {
 			return reflect.VisibleFields(reflect.TypeOf(struct {
-				Schema               string      ` json:"$schema,omitempty"`
+				Schema               string       `json:"$schema,omitempty"`
 				PreCommit            *config.Hook `json:"pre-commit,omitempty"`
 				ApplypatchMsg        *config.Hook `json:"applypatch-msg,omitempty"`
 				PreApplypatch        *config.Hook `json:"pre-applypatch,omitempty"`

--- a/schema.json
+++ b/schema.json
@@ -412,7 +412,7 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.01.21.",
+  "$comment": "Last updated on 2025.01.31.",
   "properties": {
     "min_version": {
       "type": "string",
@@ -503,6 +503,9 @@
     "remote": {
       "$ref": "#/$defs/Remote",
       "description": "Deprecated: use remotes"
+    },
+    "$schema": {
+      "type": "string"
     },
     "pre-commit": {
       "$ref": "#/$defs/Hook"


### PR DESCRIPTION
#### :zap: Summary

In the current jsonschema, specifying `$schema` results in a warning as shown in the following image.

This is because `"additionalProperties": false` and there is no `$schema` in `properties`.

![image](https://github.com/user-attachments/assets/69a6752f-b3b8-42b9-99ff-6bef0053dcac)

To resolve this, the `$schema` property was added.  
This approach has been observed in other projects as well, such as [@biomejs/biome](https://github.com/biomejs/biome/blob/738ad51d654af10d5dd4faf5e8f8bdef5db81f09/packages/%40biomejs/biome/configuration_schema.json#L7-L10).


```diff
    "properties": {
+     "$schema": {
+       "type": "string"
+     },
    },
```

I am not very familiar with Go, so I would appreciate any corrections or suggestions.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
