### PR TITLE
fix: remote issue with worktrees

### DIFF
--- a/internal/config/skip_checker_test.go
+++ b/internal/config/skip_checker_test.go
@@ -11,7 +11,7 @@ import (
 
 type mockCmd struct{}
 
-func (mc mockCmd) WithEnv(string, string) system.Command {
+func (mc mockCmd) WithEnvs(...string) system.Command {
 	return mc
 }
 

--- a/internal/config/skip_checker_test.go
+++ b/internal/config/skip_checker_test.go
@@ -6,9 +6,14 @@ import (
 	"testing"
 
 	"github.com/evilmartians/lefthook/internal/git"
+	"github.com/evilmartians/lefthook/internal/system"
 )
 
 type mockCmd struct{}
+
+func (mc mockCmd) WithEnv(string, string) system.Command {
+	return mc
+}
 
 func (mc mockCmd) Run(cmd []string, _root string, _in io.Reader, _out io.Writer, _errOut io.Writer) error {
 	if len(cmd) == 3 && cmd[2] == "success" {

--- a/internal/git/command_executor.go
+++ b/internal/git/command_executor.go
@@ -21,6 +21,10 @@ func NewExecutor(cmd system.Command) *CommandExecutor {
 	return &CommandExecutor{cmd: cmd}
 }
 
+func (c CommandExecutor) WithEnv(name, value string) CommandExecutor {
+	return CommandExecutor{cmd: c.cmd.WithEnv(name, value), root: c.root}
+}
+
 // Cmd runs plain string command. Trims spaces around output.
 func (c CommandExecutor) Cmd(cmd []string) (string, error) {
 	out, err := c.execute(cmd, c.root)

--- a/internal/git/command_executor.go
+++ b/internal/git/command_executor.go
@@ -21,8 +21,8 @@ func NewExecutor(cmd system.Command) *CommandExecutor {
 	return &CommandExecutor{cmd: cmd}
 }
 
-func (c CommandExecutor) WithEnv(name, value string) CommandExecutor {
-	return CommandExecutor{cmd: c.cmd.WithEnv(name, value), root: c.root}
+func (c CommandExecutor) WithEnvs(envs ...string) CommandExecutor {
+	return CommandExecutor{cmd: c.cmd.WithEnvs(envs...), root: c.root}
 }
 
 // Cmd runs plain string command. Trims spaces around output.

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -65,8 +65,14 @@ func (r *Repository) SyncRemote(url, ref string, force bool) error {
 func (r *Repository) updateRemote(path, ref string) error {
 	log.Debugf("Updating remote config repository: %s", path)
 
+	git := r.Git.WithEnv(
+		"GIT_DIR", filepath.Join(path, ".git"),
+	).WithEnv(
+		"GIT_INDEX_FILE", filepath.Join(path, ".git", "index"),
+	)
+
 	if len(ref) != 0 {
-		_, err := r.Git.Cmd([]string{
+		_, err := git.Cmd([]string{
 			"git", "-C", path, "fetch", "--quiet", "--depth", "1",
 			"origin", ref,
 		})
@@ -74,14 +80,14 @@ func (r *Repository) updateRemote(path, ref string) error {
 			return err
 		}
 
-		_, err = r.Git.Cmd([]string{
+		_, err = git.Cmd([]string{
 			"git", "-C", path, "checkout", "FETCH_HEAD",
 		})
 		if err != nil {
 			return err
 		}
 	} else {
-		_, err := r.Git.Cmd([]string{"git", "-C", path, "pull", "--quiet"})
+		_, err := git.Cmd([]string{"git", "-C", path, "pull", "--quiet"})
 		if err != nil {
 			return err
 		}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -65,9 +65,9 @@ func (r *Repository) SyncRemote(url, ref string, force bool) error {
 func (r *Repository) updateRemote(path, ref string) error {
 	log.Debugf("Updating remote config repository: %s", path)
 
-	git := r.Git.WithEnv(
+	// This is overwriting values for worktrees, otherwise it does not work.
+	git := r.Git.WithEnvs(
 		"GIT_DIR", filepath.Join(path, ".git"),
-	).WithEnv(
 		"GIT_INDEX_FILE", filepath.Join(path, ".git", "index"),
 	)
 

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -14,7 +14,7 @@ type gitCmd struct {
 	cases map[string]string
 }
 
-func (g gitCmd) WithEnv(string, string) system.Command {
+func (g gitCmd) WithEnvs(...string) system.Command {
 	return g
 }
 

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -6,10 +6,16 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/evilmartians/lefthook/internal/system"
 )
 
 type gitCmd struct {
 	cases map[string]string
+}
+
+func (g gitCmd) WithEnv(string, string) system.Command {
+	return g
 }
 
 func (g gitCmd) Run(cmd []string, _root string, _in io.Reader, out io.Writer, _errOut io.Writer) error {

--- a/internal/lefthook/run_test.go
+++ b/internal/lefthook/run_test.go
@@ -10,9 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/evilmartians/lefthook/internal/git"
+	"github.com/evilmartians/lefthook/internal/system"
 )
 
 type gitCmd struct{}
+
+func (g gitCmd) WithEnv(string, string) system.Command {
+	return g
+}
 
 func (g gitCmd) Run([]string, string, io.Reader, io.Writer, io.Writer) error {
 	return nil

--- a/internal/lefthook/run_test.go
+++ b/internal/lefthook/run_test.go
@@ -15,7 +15,7 @@ import (
 
 type gitCmd struct{}
 
-func (g gitCmd) WithEnv(string, string) system.Command {
+func (g gitCmd) WithEnvs(...string) system.Command {
 	return g
 }
 

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evilmartians/lefthook/internal/git"
 	"github.com/evilmartians/lefthook/internal/lefthook/runner/exec"
 	"github.com/evilmartians/lefthook/internal/log"
+	"github.com/evilmartians/lefthook/internal/system"
 )
 
 type (
@@ -41,6 +42,10 @@ func (e executor) Execute(_ctx context.Context, opts exec.Options, _in io.Reader
 
 func (e cmd) RunWithContext(context.Context, []string, string, io.Reader, io.Writer, io.Writer) error {
 	return nil
+}
+
+func (g *gitCmd) WithEnv(string, string) system.Command {
+	return g
 }
 
 func (g *gitCmd) Run(cmd []string, _root string, _in io.Reader, out io.Writer, _errOut io.Writer) error {

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -44,7 +44,7 @@ func (e cmd) RunWithContext(context.Context, []string, string, io.Reader, io.Wri
 	return nil
 }
 
-func (g *gitCmd) WithEnv(string, string) system.Command {
+func (g *gitCmd) WithEnvs(...string) system.Command {
 	return g
 }
 

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -18,7 +18,7 @@ type osCmd struct {
 var Cmd = osCmd{}
 
 type Command interface {
-	WithEnv(string, string) Command
+	WithEnvs(...string) Command
 	Run([]string, string, io.Reader, io.Writer, io.Writer) error
 }
 
@@ -26,12 +26,19 @@ type CommandWithContext interface {
 	RunWithContext(context.Context, []string, string, io.Reader, io.Writer, io.Writer) error
 }
 
-func (c osCmd) WithEnv(name, value string) Command {
-	if c.env == nil {
-		c.env = make([]string, 0, 1)
+func (c osCmd) WithEnvs(envs ...string) Command {
+	if len(envs)%2 != 0 {
+		panic("usage: WithEnvs(name, value, name, value...")
 	}
 
-	c.env = append(c.env, fmt.Sprintf("%s=%s", name, value))
+	if c.env == nil {
+		//nolint:mnd
+		c.env = make([]string, 0, len(envs)/2)
+	}
+
+	for i := 0; i < len(envs); i += 2 {
+		c.env = append(c.env, fmt.Sprintf("%s=%s", envs[i], envs[i+1]))
+	}
 
 	return c
 }

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -3,6 +3,7 @@ package system
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -10,16 +11,33 @@ import (
 	"github.com/evilmartians/lefthook/internal/log"
 )
 
-type osCmd struct{}
+type osCmd struct {
+	env []string
+}
 
 var Cmd = osCmd{}
 
 type Command interface {
+	WithEnv(string, string) Command
 	Run([]string, string, io.Reader, io.Writer, io.Writer) error
 }
 
 type CommandWithContext interface {
 	RunWithContext(context.Context, []string, string, io.Reader, io.Writer, io.Writer) error
+}
+
+func (c osCmd) WithEnv(name, value string) Command {
+	if c.env == nil {
+		c.env = make([]string, 0, 1)
+	}
+
+	c.env = append(c.env, fmt.Sprintf("%s=%s", name, value))
+
+	return c
+}
+
+func (c osCmd) Run(command []string, root string, in io.Reader, out io.Writer, errOut io.Writer) error {
+	return c.RunWithContext(context.Background(), command, root, in, out, errOut)
 }
 
 // Run runs system command with LEFTHOOK=0 in order to prevent calling
@@ -35,20 +53,10 @@ func (c osCmd) RunWithContext(
 	log.Debug("[lefthook] cmd:    ", command)
 
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Env = append(cmd.Env, c.env...)
+	cmd.Env = append(cmd.Env, "LEFTHOOK=0")
 
-	return run(cmd, root, in, out, errOut)
-}
-
-func (c osCmd) Run(command []string, root string, in io.Reader, out io.Writer, errOut io.Writer) error {
-	log.Debug("[lefthook] cmd:    ", command)
-
-	cmd := exec.Command(command[0], command[1:]...)
-
-	return run(cmd, root, in, out, errOut)
-}
-
-func run(cmd *exec.Cmd, root string, in io.Reader, out io.Writer, errOut io.Writer) error {
-	cmd.Env = append(os.Environ(), "LEFTHOOK=0")
 	if len(root) > 0 {
 		cmd.Dir = root
 		log.Debug("[lefthook] dir:    ", root)

--- a/schema.json
+++ b/schema.json
@@ -412,7 +412,7 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.01.31.",
+  "$comment": "Last updated on 2025.02.24.",
   "properties": {
     "min_version": {
       "type": "string",


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/959

**:wrench: Summary**

- [x] Overwrite `GIT_DIR` and `GIT_INDEX_FILE` with remote's paths to make it work with worktrees correctly