### PR TITLE
fix: worktrees remote issue

### DIFF
--- a/internal/config/skip_checker_test.go
+++ b/internal/config/skip_checker_test.go
@@ -11,7 +11,7 @@ import (
 
 type mockCmd struct{}
 
-func (mc mockCmd) WithEnvs(...string) system.Command {
+func (mc mockCmd) WithoutEnvs() system.Command {
 	return mc
 }
 

--- a/internal/git/command_executor.go
+++ b/internal/git/command_executor.go
@@ -21,8 +21,8 @@ func NewExecutor(cmd system.Command) *CommandExecutor {
 	return &CommandExecutor{cmd: cmd}
 }
 
-func (c CommandExecutor) WithEnvs(envs ...string) CommandExecutor {
-	return CommandExecutor{cmd: c.cmd.WithEnvs(envs...), root: c.root}
+func (c CommandExecutor) WithoutEnvs() CommandExecutor {
+	return CommandExecutor{cmd: c.cmd.WithoutEnvs(), root: c.root}
 }
 
 // Cmd runs plain string command. Trims spaces around output.

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -65,11 +65,8 @@ func (r *Repository) SyncRemote(url, ref string, force bool) error {
 func (r *Repository) updateRemote(path, ref string) error {
 	log.Debugf("Updating remote config repository: %s", path)
 
-	// This is overwriting values for worktrees, otherwise it does not work.
-	git := r.Git.WithEnvs(
-		"GIT_DIR", filepath.Join(path, ".git"),
-		"GIT_INDEX_FILE", filepath.Join(path, ".git", "index"),
-	)
+	// This is overwriting ENVs for worktrees, otherwise it does not work.
+	git := r.Git.WithoutEnvs()
 
 	if len(ref) != 0 {
 		_, err := git.Cmd([]string{
@@ -105,7 +102,7 @@ func (r *Repository) cloneRemote(dest, directoryName, url, ref string) error {
 	}
 	cmdClone = append(cmdClone, url, directoryName)
 
-	_, err := r.Git.Cmd(cmdClone)
+	_, err := r.Git.WithoutEnvs().Cmd(cmdClone)
 	if err != nil {
 		return err
 	}

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -14,7 +14,7 @@ type gitCmd struct {
 	cases map[string]string
 }
 
-func (g gitCmd) WithEnvs(...string) system.Command {
+func (g gitCmd) WithoutEnvs() system.Command {
 	return g
 }
 

--- a/internal/lefthook/run_test.go
+++ b/internal/lefthook/run_test.go
@@ -15,7 +15,7 @@ import (
 
 type gitCmd struct{}
 
-func (g gitCmd) WithEnvs(...string) system.Command {
+func (g gitCmd) WithoutEnvs() system.Command {
 	return g
 }
 

--- a/internal/lefthook/runner/runner_test.go
+++ b/internal/lefthook/runner/runner_test.go
@@ -44,7 +44,7 @@ func (e cmd) RunWithContext(context.Context, []string, string, io.Reader, io.Wri
 	return nil
 }
 
-func (g *gitCmd) WithEnvs(...string) system.Command {
+func (g *gitCmd) WithoutEnvs() system.Command {
 	return g
 }
 

--- a/schema.json
+++ b/schema.json
@@ -412,7 +412,7 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.02.24.",
+  "$comment": "Last updated on 2025.02.26.",
   "properties": {
     "min_version": {
       "type": "string",


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/962

**:wrench: Summary**

- [x] Do not inherit envs when calling Git commands for remotes