### PR TITLE
feat: Add shell options to run commands

### DIFF
--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -7,6 +7,8 @@ import (
 var ErrFilesIncompatible = errors.New("One of your runners contains incompatible file types")
 
 type Command struct {
+	Shell []string `json:"shell,omitempty"    jsonschema:"oneof_type=string;array" mapstructure:"shell"      toml:"shell,omitempty"    yaml:",omitempty"`
+
 	Run   string `json:"run"             mapstructure:"run"   toml:"run"             yaml:"run"`
 	Files string `json:"files,omitempty" mapstructure:"files" toml:"files,omitempty" yaml:",omitempty"`
 

--- a/internal/config/job.go
+++ b/internal/config/job.go
@@ -1,10 +1,11 @@
 package config
 
 type Job struct {
-	Name   string `json:"name,omitempty"   mapstructure:"name"                       toml:"name,omitempty"   yaml:",omitempty"`
-	Run    string `json:"run,omitempty"    jsonschema:"oneof_required=Run a command" mapstructure:"run"      toml:"run,omitempty"    yaml:",omitempty"`
-	Script string `json:"script,omitempty" jsonschema:"oneof_required=Run a script"  mapstructure:"script"   toml:"script,omitempty" yaml:",omitempty"`
-	Runner string `json:"runner,omitempty" mapstructure:"runner"                     toml:"runner,omitempty" yaml:",omitempty"`
+	Name   string   `json:"name,omitempty"   mapstructure:"name"                       toml:"name,omitempty"   yaml:",omitempty"`
+	Shell  []string `json:"shell,omitempty"    jsonschema:"oneof_type=string;array" mapstructure:"shell"      toml:"shell,omitempty"    yaml:",omitempty"`
+	Run    string   `json:"run,omitempty"    jsonschema:"oneof_required=Run a command" mapstructure:"run"      toml:"run,omitempty"    yaml:",omitempty"`
+	Script string   `json:"script,omitempty" jsonschema:"oneof_required=Run a script"  mapstructure:"script"   toml:"script,omitempty" yaml:",omitempty"`
+	Runner string   `json:"runner,omitempty" mapstructure:"runner"                     toml:"runner,omitempty" yaml:",omitempty"`
 
 	Glob     []string `json:"glob,omitempty"      jsonschema:"oneof_type=string;array" mapstructure:"glob"      toml:"glob,omitempty"      yaml:",omitempty"`
 	Root     string   `json:"root,omitempty"      mapstructure:"root"                  toml:"root,omitempty"    yaml:",omitempty"`

--- a/internal/lefthook/runner/exec/executor.go
+++ b/internal/lefthook/runner/exec/executor.go
@@ -11,6 +11,7 @@ type Options struct {
 	Commands              []string
 	Env                   map[string]string
 	Interactive, UseStdin bool
+	Shell                 []string
 }
 
 // Executor provides an interface for command execution.

--- a/internal/lefthook/runner/run_jobs.go
+++ b/internal/lefthook/runner/run_jobs.go
@@ -173,6 +173,7 @@ func (r *Runner) runSingleJob(ctx context.Context, domain *domain, id string, jo
 		Interactive: job.Interactive && !r.DisableTTY,
 		UseStdin:    job.UseStdin,
 		Env:         job.Env,
+		Shell:       job.Shell,
 	}, r.Hook.Follow)
 
 	if !ok {

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -498,6 +498,7 @@ func (r *Runner) runCommand(ctx context.Context, name string, command *config.Co
 		Interactive: command.Interactive && !r.DisableTTY,
 		UseStdin:    command.UseStdin,
 		Env:         command.Env,
+		Shell:       command.Shell,
 	}, r.Hook.Follow)
 
 	if !ok {

--- a/schema.json
+++ b/schema.json
@@ -4,6 +4,19 @@
   "$defs": {
     "Command": {
       "properties": {
+        "shell": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "run": {
           "type": "string"
         },
@@ -214,6 +227,19 @@
         "name": {
           "type": "string"
         },
+        "shell": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "run": {
           "type": "string"
         },
@@ -412,7 +438,7 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.02.26.",
+  "$comment": "Last updated on 2025.03.01.",
   "properties": {
     "min_version": {
       "type": "string",


### PR DESCRIPTION
Closes #953

#### :zap: Summary

Add the `shell []string` option to the jobs/commands hook to run the command to provide consistency for Windows and Unix, and the default is empty will not cause compatibility issues.

```yaml
pre-commit:
  jobs:
    - name: test
      shell:
        - powershell
        - -Command
      run: |
        echo test
        $PSVersionTable
```

Note: This is just a simple implementation, any suggestions for improvement are welcome, I'm not very familiar with golang, so I hope this doesn't bother you!

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
