### PR TITLE
fix: use dedicated build path for swift plugin

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -72,9 +72,9 @@ call_lefthook()
     elif pnpm lefthook -h >/dev/null 2>&1
     then
       pnpm lefthook "$@"
-    elif swift package plugin lefthook >/dev/null 2>&1
+    elif swift package lefthook >/dev/null 2>&1
     then
-      swift package --disable-sandbox plugin lefthook "$@"
+      swift package --build-path .build/lefthook --disable-sandbox lefthook "$@"
     elif command -v mint >/dev/null 2>&1
     then
       mint run csjones/lefthook-plugin "$@"


### PR DESCRIPTION
Closes # (issue)

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Swift 6 introduces a locking mechanism on the package build directory to prevent concurrent builds and tests. However, the change also affects Swift plugins, blocking lefthook from finishing execution when running Swift commands within `lefthook.yml`.

For example, the following configuration will hang on Swift 6:

```yml
pre-commit:
  commands:
    1_list:
      run: swift package plugin --list
```

<!-- Brief description of what was done -->

This PR adds a `--build-path` argument pointing to a dedicated local `.build/lefthook` directory. This allows Swift commands to run without being blocked by lefthook's execution.

**Alternatives considered:**
- `--ignore-lock`: Hidden escape hatch; unsafe but this has been the default behavior for years.
- `--scratch-path`: Newer and deprecates `--build-path` but unavailable in older versions of Swift.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
