### PR TITLE
fix: unquote paths to valid UTF-8

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -399,6 +400,13 @@ func (r *Repository) extractFiles(lines []string, checkExistence bool) ([]string
 		file := strings.TrimSpace(line)
 		if len(file) == 0 {
 			continue
+		}
+
+		unescaped, err := strconv.Unquote(file)
+		if err == nil {
+			file = unescaped
+		} else {
+			log.Debug("[lefthook] couldn't unquote "+file, err)
 		}
 
 		if !checkExistence {


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/786

**:wrench: Summary**

Unquote the file names in case git has `git core.quotepath true` setting.