### PR TITLE
docs: allow duplicate files in SUMMARY

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v2
         with:
-          mdbook-version: 'latest'
+          mdbook-version: '0.4.47'
 
       - run: mdbook build
 


### PR DESCRIPTION
**:zap: Summary**

Freeze the mdbook version to 0.4.47 (in 0.4.48 duplicate file references are prohibited)