### PR TITLE
feat(npm): allow installing hooks in CI

### DIFF
--- a/docs/mdbook/usage/env.md
+++ b/docs/mdbook/usage/env.md
@@ -70,3 +70,8 @@ Set `NO_COLOR=true` to disable colored output in lefthook and all subcommands th
 
 Set `CLICOLOR_FORCE=true` to force colored output in lefthook and all subcommands.
 
+### `CI`
+
+Use `CI=true` to prevent lefthook from installing hooks during the postinstall script.
+
+To override this behavior and allow hook installation despite `CI=true`, set `LEFTHOOK=1` or `LEFTHOOK=true`. This takes precedence over the `CI` variable.

--- a/docs/mdbook/usage/env.md
+++ b/docs/mdbook/usage/env.md
@@ -12,6 +12,16 @@ Use `LEFTHOOK=0 git ...` or `LEFTHOOK=false git ...` to disable lefthook when ru
 LEFTHOOK=0 git commit -am "Lefthook skipped"
 ```
 
+When using NPM package `lefthook` in CI, and your CI sets `CI=true` automatically, use `LEFTHOOK=1` or `LEFTHOOK=true` to install hooks in the postinstall script:
+
+**Example**
+
+```bash
+LEFTHOOK=1 npm install
+LEFTHOOK=1 yarn install
+LEFTHOOK=1 pnpm install
+```
+
 ### `LEFTHOOK_EXCLUDE`
 
 Use `LEFTHOOK_EXCLUDE={list of tags or command names to be excluded}` to skip some commands or scripts by tag or name (for commands only). See the [`exclude_tags`](../configuration/exclude_tags.md) configuration option for more details.
@@ -72,6 +82,12 @@ Set `CLICOLOR_FORCE=true` to force colored output in lefthook and all subcommand
 
 ### `CI`
 
-Use `CI=true` to prevent lefthook from installing hooks during the postinstall script.
+When using NPM package `lefthook`, set `CI=true` in your CI (if it does not set it automatically) to prevent lefthook from installing hooks in the postinstall script:
 
-To override this behavior and allow hook installation despite `CI=true`, set `LEFTHOOK=1` or `LEFTHOOK=true`. This takes precedence over the `CI` variable.
+```bash
+CI=true npm install
+CI=true yarn install
+CI=true pnpm install
+```
+
+> **Note:** Set `LEFTHOOK=1` or `LEFTHOOK=true` to override this behavior and install hooks in the postinstall script (despite `CI=true`).

--- a/docs/mdbook/usage/tips.md
+++ b/docs/mdbook/usage/tips.md
@@ -8,7 +8,11 @@ Use `lefthook-local.yml` to overwrite or extend options from the main config. (D
 
 ### Disable lefthook in CI
 
-When using NPM package `lefthook` set `CI=true` in your CI (if it does not set automatically). When `CI=true` is set lefthook NPM package won't install the hooks in the postinstall script.
+When using NPM package `lefthook`, set `CI=true` in your CI (if it does not set it automatically) to prevent lefthook from installing hooks in the postinstall script.
+
+### Enable lefthook in CI
+
+When using NPM package `lefthook`, and your CI sets `CI=true` automatically, set `LEFTHOOK=1` to install the hooks in the postinstall script.
 
 ### Commitlint example
 

--- a/packaging/npm-bundled/postinstall.js
+++ b/packaging/npm-bundled/postinstall.js
@@ -1,4 +1,4 @@
-if (!process.env.CI) {
+if (!process.env.CI || process.env.LEFTHOOK == '1' && process.env.LEFTHOOK == 'true') {
   const { spawnSync } = require('child_process');
   const { getExePath } = require('./get-exe');
 

--- a/packaging/npm-bundled/postinstall.js
+++ b/packaging/npm-bundled/postinstall.js
@@ -1,4 +1,5 @@
-if (!process.env.CI || process.env.LEFTHOOK == '1' && process.env.LEFTHOOK == 'true') {
+const isEnabled = (value) => value && value !== "0" && value !== "false";
+if (!isEnabled(process.env.CI) || isEnabled(process.env.LEFTHOOK)) {
   const { spawnSync } = require('child_process');
   const { getExePath } = require('./get-exe');
 

--- a/packaging/npm-installer/install.js
+++ b/packaging/npm-installer/install.js
@@ -6,7 +6,8 @@ const chp = require("child_process")
 const iswin = ["win32", "cygwin"].includes(process.platform)
 
 async function install() {
-  if (process.env.CI && process.env.LEFTHOOK != '1' && process.env.LEFTHOOK != 'true') {
+  const isEnabled = (value) => value && value !== "0" && value !== "false";
+  if (isEnabled(process.env.CI) && !isEnabled(process.env.LEFTHOOK)) {
     return
   }
   const downloadURL = getDownloadURL()

--- a/packaging/npm-installer/install.js
+++ b/packaging/npm-installer/install.js
@@ -6,7 +6,7 @@ const chp = require("child_process")
 const iswin = ["win32", "cygwin"].includes(process.platform)
 
 async function install() {
-  if (process.env.CI) {
+  if (process.env.CI && process.env.LEFTHOOK != '1' && process.env.LEFTHOOK != 'true') {
     return
   }
   const downloadURL = getDownloadURL()

--- a/packaging/npm/lefthook/postinstall.js
+++ b/packaging/npm/lefthook/postinstall.js
@@ -2,8 +2,9 @@ const { spawnSync } = require("child_process");
 const { getExePath } = require("./get-exe");
 
 function install() {
-  if (process.env.CI && process.env.LEFTHOOK != '1' && process.env.LEFTHOOK != 'true') {
-    return;
+  const isEnabled = (value) => value && value !== "0" && value !== "false";
+  if (isEnabled(process.env.CI) && !isEnabled(process.env.LEFTHOOK)) {
+    return
   }
 
   spawnSync(getExePath(), ["install", "-f"], {

--- a/packaging/npm/lefthook/postinstall.js
+++ b/packaging/npm/lefthook/postinstall.js
@@ -2,7 +2,7 @@ const { spawnSync } = require("child_process");
 const { getExePath } = require("./get-exe");
 
 function install() {
-  if (process.env.CI) {
+  if (process.env.CI && process.env.LEFTHOOK != '1' && process.env.LEFTHOOK != 'true') {
     return;
   }
 


### PR DESCRIPTION
#### :zap: Summary

Allows installing hooks in CI (if it sets `CI=true` automatically) by setting `LEFTHOOK=1` or `LEFTHOOK=true` (recommended), or overriding it with `CI=0` or `CI=false`.

_Background_: MDN recently migrated most of its repositories from husky+lint-staged to lefthook, but we noticed that lefthook behaves different in CI (GitHub workflows): Husky installs hooks by default (which can be disabled with `HUSKY=0`), whereas lefthook doesn't install hooks (if `CI=true` is set). The only workarounds seem to have been setting `CI=""` (which may have side-effects on linting tools), or by running the hooks manually (e.g. via `npx lefthook run pre-commit`).

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [x] Add documentation
