### PR TITLE
add support for uv

### DIFF
--- a/docs/mdbook/installation/python.md
+++ b/docs/mdbook/installation/python.md
@@ -3,3 +3,7 @@
 ```sh
 python -m pip install --user lefthook
 ```
+
+```sh
+uv add --dev lefthook
+```

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -81,6 +81,9 @@ call_lefthook()
     elif command -v mint >/dev/null 2>&1
     then
       mint run csjones/lefthook-plugin "$@"
+    elif uv run lefthook -h >/dev/null 2>&1
+    then
+      uv run lefthook "$@"
     else
       echo "Can't find lefthook in PATH"
       {{- if .AssertLefthookInstalled}}


### PR DESCRIPTION
#### :zap: Summary

Document and support installing `lefthook` in a venv managed by `uv`.

Given the venv isn't activated, `lefthook` won't be in PATH, and we need to check for it the same way as with other package managers.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [x] Add documentation
