### PR TITLE
fix: load scripts from dot config too

### DIFF
--- a/docs/mdbook/configuration/README.md
+++ b/docs/mdbook/configuration/README.md
@@ -2,14 +2,23 @@
 
 Lefthook supports the following file names for the main config:
 
-- `lefthook.yml`
-- `.lefthook.yml`
-- `lefthook.yaml`
-- `.lefthook.yaml`
-- `lefthook.toml`
-- `.lefthook.toml`
-- `lefthook.json`
-- `.lefthook.json`
+| Format | File name |
+|-------|-----------|
+| YAML  | `lefthook.yml` |
+| YAML  | `.lefthook.yml` |
+| YAML  | `.config/lefthook.yml` |
+|-------|-----------|
+| YAML  | `lefthook.yaml` |
+| YAML  | `.lefthook.yaml` |
+| YAML  | `.config/lefthook.yaml` |
+|-------|-----------|
+| TOML  | `lefthook.toml` |
+| TOML  | `.lefthook.toml` |
+| TOML  | `.config/lefthook.toml` |
+|-------|-----------|
+| JSON  | `lefthook.json` |
+| JSON  | `.lefthook.json` |
+| JSON  | `.config/lefthook.json` |
 
 If there are more than 1 file in the project, only one will be used, and you'll never know which one. So, please, use one format in a project.
 

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -144,6 +144,10 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 	sourceDirs := []string{
 		filepath.Join(l.repo.RootPath, cfg.SourceDir),
 		filepath.Join(l.repo.RootPath, cfg.SourceDirLocal),
+
+		// Additional source dirs to support .config/
+		filepath.Join(l.repo.RootPath, ".config", "lefthook"),
+		filepath.Join(l.repo.RootPath, ".config", "lefthook-local"),
 	}
 
 	for _, remote := range cfg.Remotes {


### PR DESCRIPTION
**:wrench: Summary**

- [x] Add `.config/lefthook/` and `.config/lefthook-local/` as dirs for scripts[^1]

[^1]: They still have to be within subdirs by hook name, e.g.: `.config/lefthook/pre-commit/lint.sh`