### PR TITLE
docs: fix grammatical error in `Local config` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ pre-commit:
 
 * ### **Local config**
 
-If you a frontend/backend developer and want to skip unnecessary commands or override something into Docker. [docs][usage-local-config]
+If you are a frontend/backend developer and want to skip unnecessary commands or override something in Docker. [docs][usage-local-config]
 
 ```yml
 # lefthook-local.yml


### PR DESCRIPTION
#### :zap: Summary
Fixed a grammatical error in the Local config section of the `README.md`. Specifically, I have added the missing word “are” in "If you a frontend/backend developer" and replaced "into Docker" with "in Docker" for clarity.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [x] Add documentation
