### PR TITLE
fix: change "existed" to "exisiting"

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -14,7 +14,7 @@ func (install) New(opts *lefthook.Options) *cobra.Command {
 
 	installCmd := cobra.Command{
 		Use:               "install",
-		Short:             "Write basic configuration file in your project repository. Or initialize existed config",
+		Short:             "Write basic configuration file in your project repository. Or initialize existing config",
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Args:              cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _args []string) error {


### PR DESCRIPTION
Hello! I just corrected that word, but on top of that I think that the wording there is a little clunky, maybe it's worth changing it further to be like this:

```diff
- Write basic configuration file in your project repository. Or initialize existed config",
+ Write a basic configuration file in your project repository, or initialize the existing configuration
```

What do you think?

#### :zap: Summary

<!-- Brief description of what was done -->

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
- [ ] Add documentation

It's just a change in a string, so it's not necessary to meet those requirements I imagine