### PR TITLE
feat: add support for devbox

### DIFF
--- a/docs/mdbook/installation/devbox.md
+++ b/docs/mdbook/installation/devbox.md
@@ -1,0 +1,10 @@
+## Devbox
+
+Add lefthook in the devbox environment.
+lefthook already exists in the [Nix package](https://search.nixos.org/packages?channel=25.05&show=lefthook&from=0&size=50&sort=relevance&type=packages&query=lefthook)
+
+```bash
+devbox add lefthook@latest
+```
+
+**Note**: The devbox plugin for lefthook is maintained by the community. While we appreciate their contribution, the lefthook team cannot provide direct support for devbox-specific installation issues.

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -87,6 +87,9 @@ call_lefthook()
     elif mise exec -- lefthook -h >/dev/null 2>&1
     then
       mise exec -- lefthook "$@"
+    elif devbox run lefthook -h >/dev/null 2>&1
+    then
+      devbox run lefthook "$@"
     else
       echo "Can't find lefthook in PATH"
       {{- if .AssertLefthookInstalled}}


### PR DESCRIPTION
#### :zap: Summary

Add support for [Devbox tool](https://github.com/jetify-com/devbox) and a documentation on how to install lefthook using devbox
Before the change Visual Code didn't run lefthook in the context of devbox so it fails (it did work from the terminal though)

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [x] Add documentation
