### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,8 +76,8 @@ builds:
 
 archives:
   - id: lefthook
-    format: binary
-    builds:
+    formats: [binary]
+    ids:
       - lefthook
     files:
       - none*
@@ -91,8 +91,8 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
 
   - id: lefthook-gz
-    format: gz
-    builds:
+    formats: [gz]
+    ids:
       - lefthook
     files:
     - none*
@@ -106,8 +106,8 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
 
   - id: lefthook-linux-aarch64
-    format: binary
-    builds:
+    formats: [binary]
+    ids:
       - lefthook-linux-aarch64
     files:
       - none*
@@ -122,8 +122,8 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
 
   - id: lefthook-linux-aarch64-gz
-    format: gz
-    builds:
+    formats: [gz]
+    ids:
       - lefthook-linux-aarch64
     files:
       - none*
@@ -142,7 +142,7 @@ checksum:
   algorithm: sha256
 
 snapshot:
-  name_template: "{{ .Tag }}"
+  version_template: "{{ .Tag }}"
 
 changelog:
   sort: asc
@@ -163,7 +163,7 @@ snapcrafts:
     confinement: classic
     publish: true
     license: MIT
-    builds:
+    ids:
       - no_self_update
 
 nfpms:
@@ -173,7 +173,7 @@ nfpms:
     maintainer: Evil Martians <lefthook@evilmartians.com>
     license: MIT
     vendor: Evil Martians
-    builds:
+    ids:
       - no_self_update
     formats:
       - apk


### PR DESCRIPTION
#### :zap: Summary
This small PR updates the GoReleaser configuration to resolve the following warnings which you can find in the [CI logs](https://github.com/evilmartians/lefthook/actions/runs/15475766066/job/43570603020#step:4:52): 
```
DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
DEPRECATED: nfpms.builds should not be used anymore, check https://goreleaser.com/deprecations#nfpmsbuilds for more info
DEPRECATED: snaps.builds should not be used anymore, check https://goreleaser.com/deprecations#snapsbuilds for more info
```

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
