### PR TITLE
feat: inherit group envs

### DIFF
--- a/docs/mdbook/configuration/group.md
+++ b/docs/mdbook/configuration/group.md
@@ -21,6 +21,29 @@ pre-commit:
           - run: echo 3
 ```
 
+If you specify `env`, `root`, `glob`, or `exclude` on a group, they will be inherited to the underlying jobs.
+
+```yml
+# lefthook.yml
+
+pre-commit:
+  jobs:
+    - env:
+        E1: hello
+      glob:
+        - "*.md"
+      exclude:
+        - "README.md"
+      root: "subdir/"
+      group:
+        parallel: true
+        jobs:
+          - run: echo $E1
+          - run: echo $E1
+            env:
+              E1: bonjour
+```
+
 > **Note:** To make a group mergeable with settings defined in local config or extends you have to specify the name of the job group belongs to:
 > ```yml
 > pre-commit:

--- a/testdata/group_envs.txt
+++ b/testdata/group_envs.txt
@@ -1,0 +1,22 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add -A
+exec lefthook install
+exec lefthook run test
+stdout '\s*1\s*3\s*'
+
+-- lefthook.yml --
+output:
+  - execution_out
+test:
+  jobs:
+    - env:
+        E1: 1
+        E2: 2
+      group:
+        jobs:
+          - run: echo $E1
+          - run: echo $E2
+            env:
+              E2: 3


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1053

**:zap: Summary**

Inherit `env` from a job where group is defined.

```yml
# lefthook.yml

hook:
  jobs:
    - env:
        E1: 1
        E2: 2
      group:
        jobs:
          - run: echo E1 - $E1
          - run: echo E2 - $E2
          - env:
              E1: new
            run: echo new E1 - $E1

```

- [x] Add tests
- [x] Update docs