### PR TITLE
feat: add exclude arg

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -98,6 +98,11 @@ func (run) New(opts *lefthook.Options) *cobra.Command {
 		"run on specified file (repeat for multiple files). takes precedence over --all-files",
 	)
 
+	runCmd.Flags().StringArrayVar(
+		&runArgs.Exclude, "exclude", nil,
+		"exclude specified file (repeat for multiple files)",
+	)
+
 	runCmd.Flags().StringSliceVar(
 		&runArgs.RunOnlyCommands, "commands", nil,
 		"run only specified commands",

--- a/internal/lefthook/run.go
+++ b/internal/lefthook/run.go
@@ -32,6 +32,7 @@ type RunArgs struct {
 	Force           bool
 	NoAutoInstall   bool
 	SkipLFS         bool
+	Exclude         []string
 	Files           []string
 	RunOnlyCommands []string
 	RunOnlyJobs     []string
@@ -177,6 +178,7 @@ func (l *Lefthook) Run(hookName string, args RunArgs, gitArgs []string) error {
 			DisableTTY:      cfg.NoTTY || args.NoTTY,
 			SkipLFS:         cfg.SkipLFS || args.SkipLFS,
 			Templates:       cfg.Templates,
+			Exclude:         args.Exclude,
 			Files:           args.Files,
 			Force:           args.Force,
 			RunOnlyCommands: args.RunOnlyCommands,

--- a/internal/lefthook/runner/run_jobs.go
+++ b/internal/lefthook/runner/run_jobs.go
@@ -37,11 +37,20 @@ type jobContext struct {
 	env      map[string]string
 }
 
-func newJobContext(onlyJobs []string) *jobContext {
+func newJobContext(onlyJobs []string, exclude []string) *jobContext {
 	var failed atomic.Bool
+	var excludeInterface []interface{}
+	if len(exclude) > 0 {
+		excludeInterface = make([]interface{}, len(exclude))
+		for i, e := range exclude {
+			excludeInterface[i] = e
+		}
+	}
+
 	return &jobContext{
 		failed:   &failed,
 		onlyJobs: onlyJobs,
+		exclude:  excludeInterface,
 		env:      make(map[string]string),
 	}
 }
@@ -52,7 +61,7 @@ func (r *Runner) runJobs(ctx context.Context) []result.Result {
 	results := make([]result.Result, 0, len(r.Hook.Jobs))
 	resultsChan := make(chan result.Result, len(r.Hook.Jobs))
 
-	jobContext := newJobContext(r.RunOnlyJobs)
+	jobContext := newJobContext(r.RunOnlyJobs, r.Exclude)
 
 	for i, job := range r.Hook.Jobs {
 		id := strconv.Itoa(i)

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -469,13 +469,14 @@ func (r *Runner) runCommand(ctx context.Context, name string, command *config.Co
 	exclude := command.Exclude
 	switch list := exclude.(type) {
 	case string:
-		// Ignorint regexp exclude
+		// Can't merge with regexp exclude
 	case []interface{}:
 		for _, e := range r.Exclude {
 			list = append(list, e)
 		}
 		exclude = list
 	default:
+		// In case it's nil – simply replace
 		excludeList := make([]interface{}, len(r.Exclude))
 		for i, e := range r.Exclude {
 			excludeList[i] = e

--- a/internal/lefthook/runner/runner.go
+++ b/internal/lefthook/runner/runner.go
@@ -41,6 +41,7 @@ type Options struct {
 	DisableTTY      bool
 	SkipLFS         bool
 	Force           bool
+	Exclude         []string
 	Files           []string
 	RunOnlyCommands []string
 	RunOnlyJobs     []string

--- a/testdata/exclude_arg.txt
+++ b/testdata/exclude_arg.txt
@@ -1,0 +1,29 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add -A
+exec lefthook install
+exec lefthook run test --exclude file1.txt
+stdout '\s*file2.txt\s*file2.txt\s*'
+exec lefthook run test --exclude file2.txt
+stdout '\s*file1.txt\s*file1.txt\s*'
+
+-- lefthook.yml --
+output:
+  - execution_out
+test:
+  commands:
+    list:
+      run: echo {all_files}
+      exclude:
+        - lefthook.yml
+  jobs:
+    - run: echo {all_files}
+      exclude:
+        - lefthook.yml
+
+-- file1.txt --
+Hello
+
+-- file2.txt --
+Hi


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/593

**:zap: Summary**

Add ability to extend the exclude list manually via `--exclude` argument.

```
lefthook run pre-commit --exclude file1 --exclude file2
```

Works for jobs which don’t have `exclude: "regexp»` but instead use the glob list. If regexp is given it overwrites any inherited exclude list. Regexp excludes will be deprecated.

```yml
exclude:
  - "glob1"
  - "glob2"
```