### PR TITLE
Fix local config only

### DIFF
--- a/docs/mdbook/configuration/README.md
+++ b/docs/mdbook/configuration/README.md
@@ -26,7 +26,7 @@ Filenames without the leading dot will also be looked up from the [`.config` sub
 
 Lefthook also merges an extra config with the name `lefthook-local`. All supported formats can be applied to this `-local` config. If you name your main config with the leading dot, like `.lefthook.json`, the `-local` config also must be named with the leading dot: `.lefthook-local.json`.
 
-The `-local` config can be used without a main config file. This is useful when you want to use lefthook locally without imposing it on your teammates – just create a `lefthook-local.yml` file and add it to your `.gitignore`.
+The `-local` config can be used without a main config file. This is useful when you want to use lefthook locally without imposing it on your teammates – just create a `lefthook-local.yml` file and add it to your global `.gitignore`.
 
 ## Options
 

--- a/docs/mdbook/configuration/README.md
+++ b/docs/mdbook/configuration/README.md
@@ -26,6 +26,8 @@ Filenames without the leading dot will also be looked up from the [`.config` sub
 
 Lefthook also merges an extra config with the name `lefthook-local`. All supported formats can be applied to this `-local` config. If you name your main config with the leading dot, like `.lefthook.json`, the `-local` config also must be named with the leading dot: `.lefthook-local.json`.
 
+The `-local` config can be used without a main config file. This is useful when you want to use lefthook locally without imposing it on your teammates – just create a `lefthook-local.yml` file and add it to your `.gitignore`.
+
 ## Options
 
 - [`assert_lefthook_installed`](./assert_lefthook_installed.md)

--- a/docs/mdbook/usage/tips.md
+++ b/docs/mdbook/usage/tips.md
@@ -6,6 +6,8 @@
 
 Use `lefthook-local.yml` to overwrite or extend options from the main config. (Don't forget to add this file to `.gitignore`)
 
+You can also use `lefthook-local.yml` without a main config file. This is useful when you want to use lefthook locally without imposing it on your teammates.
+
 ### Disable lefthook in CI
 
 When using NPM package `lefthook`, set `CI=true` in your CI (if it does not set it automatically) to prevent lefthook from installing hooks in the postinstall script.

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -871,6 +871,68 @@ pre-commit:
 				},
 			},
 		},
+		"with lefthook-local.yml only": {
+			files: map[string]string{
+				"lefthook-local.yml": `
+pre-commit:
+  commands:
+    tests:
+      run: yarn test
+post-commit:
+  commands:
+    ping-done:
+      run: curl -x POST status.com/done
+`,
+			},
+			result: &Config{
+				SourceDir:      DefaultSourceDir,
+				SourceDirLocal: DefaultSourceDirLocal,
+				Colors:         nil,
+				Hooks: map[string]*Hook{
+					"pre-commit": {
+						Parallel: false,
+						Commands: map[string]*Command{
+							"tests": {
+								Run: "yarn test",
+							},
+						},
+					},
+					"post-commit": {
+						Parallel: false,
+						Commands: map[string]*Command{
+							"ping-done": {
+								Run: "curl -x POST status.com/done",
+							},
+						},
+					},
+				},
+			},
+		},
+		"with .lefthook-local.yml only": {
+			files: map[string]string{
+				".lefthook-local.yml": `
+pre-commit:
+  commands:
+    tests:
+      run: yarn test
+`,
+			},
+			result: &Config{
+				SourceDir:      DefaultSourceDir,
+				SourceDirLocal: DefaultSourceDirLocal,
+				Colors:         nil,
+				Hooks: map[string]*Hook{
+					"pre-commit": {
+						Parallel: false,
+						Commands: map[string]*Command{
+							"tests": {
+								Run: "yarn test",
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
 		repo := &git.Repository{


### PR DESCRIPTION
#### :zap: Summary

This allows using `lefthook-local.yml` without requiring a main `lefthook.yml` file to be present. This is useful for developers who want to use lefthook locally without imposing it on their teammates.

The implementation:
- Checks for local config files when main config loading fails
- Preserves existing error handling when neither config exists
- Maintains backward compatibility with existing behavior

Amp helped me make this:
https://ampcode.com/threads/T-8d5d41cf-8d3e-414d-9713-d23a566f99d5

I installed the new binary locally and tried it out. I can now use local configs without non-local configs 👌🏻 

Closes #1070

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
- [x] Add documentation
