### PR TITLE
Improve wording of `run`, `files`, and `files-global` config descriptions, document that the `sh` shell is used

### DIFF
--- a/docs/mdbook/configuration/files-global.md
+++ b/docs/mdbook/configuration/files-global.md
@@ -1,6 +1,6 @@
 ## `files` (global)
 
-A custom git command for files to be referenced in `{files}` template. See [`run`](#run) and [`files`](#files).
+A custom command executed by the `sh` shell that returns the files or directories to be referenced in `{files}` template. See [`run`](#run) and [`files`](#files).
 
 If the result of this command is empty, the execution of commands will be skipped.
 

--- a/docs/mdbook/configuration/files.md
+++ b/docs/mdbook/configuration/files.md
@@ -1,6 +1,6 @@
 ## `files`
 
-A custom git command for files or directories to be referenced in `{files}` template for [`run`](./run.md) setting.
+A custom command executed by the `sh` shell that returns the files or directories to be referenced in `{files}` template for [`run`](./run.md) setting.
 
 If the result of this command is empty, the execution of commands will be skipped.
 

--- a/docs/mdbook/configuration/run.md
+++ b/docs/mdbook/configuration/run.md
@@ -1,6 +1,6 @@
 ## `run`
 
-This is a mandatory option for a command, that specifies the actual command to be run using the `sh` shell.
+This is a mandatory option for a command, which specifies the actual command to be run using the `sh` shell.
 
 You can use files templates that will be substituted with the appropriate files on execution:
 

--- a/docs/mdbook/configuration/run.md
+++ b/docs/mdbook/configuration/run.md
@@ -1,6 +1,6 @@
 ## `run`
 
-This is a mandatory option for a command. This is actually a command that is executed for the hook.
+This is a mandatory option for a command, that specifies the actual command to be run using the `sh` shell.
 
 You can use files templates that will be substituted with the appropriate files on execution:
 


### PR DESCRIPTION
#### :zap: Summary

I cleaned up the wording of the first line of the `run`, `files`, and `files-global` config entry descriptions a little bit, and added the information that the `sh` shell is used.

I removed the word "git" since my understanding is that there is no requirement that the provided command be a git command.

#### :ballot_box_with_check: Checklist

- [ ] Check locally
- [ ] Add tests
- [x] Add documentation
