### PR TITLE
docs: update pnpm installation note

### DIFF
--- a/docs/mdbook/installation/node.md
+++ b/docs/mdbook/installation/node.md
@@ -12,7 +12,7 @@ yarn add --dev lefthook
 pnpm add -D lefthook
 ```
 
-> **Note:** If you use `pnpm` package manager make sure you set `side-effects-cache = false` in your .npmrc, otherwise the postinstall script of the lefthook package won't be executed and hooks won't be installed.
+> **Note:** If you use `pnpm` package manager make sure to update `pnpm-workspace.yaml`s `onlyBuiltDependencies` with `lefthook` and add `lefthook` to `pnpm.onlyBuiltDependencies` in your root `package.json`, otherwise the `postinstall` script of the `lefthook` package won't be executed and hooks won't be installed.
 
 **Note**: lefthook has three NPM packages with different ways to deliver the executables
 


### PR DESCRIPTION
There is a way not to turn off `side-effects-cache` completely, so I provided updated guidelines
