### PR TITLE
fix: respect LEFTHOOK_CONFIG in lefthook install

### DIFF
--- a/internal/command/install.go
+++ b/internal/command/install.go
@@ -89,6 +89,17 @@ func (l *Lefthook) configExists(path string) bool {
 }
 
 func (l *Lefthook) findMainConfig(path string) (string, error) {
+	configOverride := os.Getenv("LEFTHOOK_CONFIG")
+	if len(configOverride) != 0 {
+		if !filepath.IsAbs(configOverride) {
+			configOverride = filepath.Join(path, configOverride)
+		}
+		if ok, _ := afero.Exists(l.fs, configOverride); !ok {
+			return "", errors.New(fmt.Sprintf("Config file \"%s\" not found!", configOverride))
+		}
+		return configOverride, nil
+	}
+
 	for _, name := range config.MainConfigNames {
 		for _, extension := range []string{
 			".yml", ".yaml", ".toml", ".json",


### PR DESCRIPTION
#### :zap: Summary

Just recently found out that `lefthook install` has it's own logic for checking if the config exists which I didn't notice when implementing support for `LEFTHOOK_CONFIG`. This adds the same logic for handling the config override to the install command, this way it doesn't create `lefthook.yml` when `LEFTHOOK_CONFIG` is set.

It actually currently still loads the correct config from the env var, just the install command didn't correctly find it and always created a sample config which was ignored. 

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [ ] Add tests
- [ ] Add documentation
