### PR TITLE
feat: recursively log successful results in summary

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -253,6 +253,10 @@ func logResults(indent int, results []result.Result, logSettings log.Settings) {
 			}
 
 			log.Success(indent, result.Name, result.Duration)
+
+			if len(result.Sub) > 0 {
+				logResults(indent+1, result.Sub, logSettings)
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #1106

#### :zap: Summary

This change uses the same recursive display of results messages that failure results currently use, but with success messages as well.

#### :ballot_box_with_check: Checklist

- [X] Check locally
- [ ] Add tests (fairly simple change, works locally, difficult to test without making printSummary or logResults public)
- [ ] Add documentation (no docs needed)
