### PR TITLE
fix: add mutex to prevent concurrent git adds

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -53,6 +53,9 @@ var (
 
 // Repository represents a git repository.
 type Repository struct {
+	// Mutex helps syncing Git commands which can't be run concurrently, e.g. `git add`.
+	mu sync.Mutex
+
 	Fs                afero.Fs
 	Git               *CommandExecutor
 	HooksPath         string
@@ -356,6 +359,9 @@ func (r *Repository) AddFiles(files []string) error {
 	if len(files) == 0 {
 		return nil
 	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	_, err := r.Git.BatchedCmd(cmdStageFiles, files)
 


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1084

### Context

For lots of jobs with `stage_fixed: true` lefthook may run `git add` concurrently and fail because Git creates a lockfile for such commands.

### Changes

Add a mutex to make `git add` calls sequential.