### PR TITLE
fix: use batched cmd for calculating git hashes

### DIFF
--- a/internal/git/command_executor_test.go
+++ b/internal/git/command_executor_test.go
@@ -1,0 +1,31 @@
+package git
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/evilmartians/lefthook/internal/system"
+)
+
+type mockCmd struct{}
+
+func (m mockCmd) WithoutEnvs(...string) system.Command { return mockCmd{} }
+func (m mockCmd) Run(cmd []string, root string, in io.Reader, out io.Writer, errOut io.Writer) error {
+	for _, str := range cmd {
+		_, _ = out.Write([]byte(str))
+		_, _ = out.Write([]byte("\n"))
+	}
+
+	return nil
+}
+
+func TestBatchedCmd(t *testing.T) {
+	assert := assert.New(t)
+	c := CommandExecutor{cmd: mockCmd{}, maxCmdLen: 2}
+	out, err := c.BatchedCmd([]string{"hello"}, []string{"1", "2", "3", "4"})
+	assert.NoError(err)
+
+	assert.Equal("hello\n1\nhello\n2\nhello\n3\nhello\n4\n", out)
+}

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -390,11 +390,12 @@ func (r *Repository) Changeset() (map[string]string, error) {
 		return changeset, nil
 	}
 
-	hashes, err := r.Git.CmdLines(append([]string{"git", "hash-object"}, pathsToHash...))
+	out, err := r.Git.BatchedCmd([]string{"git", "hash-object"}, pathsToHash)
 	if err != nil {
 		return nil, err
 	}
 
+	hashes := strings.Split(strings.TrimSpace(out), "\n")
 	for i, hash := range hashes {
 		changeset[pathsToHash[i]] = hash
 	}

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -142,6 +142,7 @@ RM old-file -> new-file`,
 					cmd: gitCmd{
 						cases: gitCmds,
 					},
+					maxCmdLen: 7000,
 				},
 			}
 			repository.Setup()


### PR DESCRIPTION
### Context

Staged files list may exceed the max command length for OS. Address this change.

### Changes

- Replace CmdLines with BatchedCmd
- Add tests on BatchedCmd