### PR TITLE
docs: update go installation note

### DIFF
--- a/docs/mdbook/installation/go.md
+++ b/docs/mdbook/installation/go.md
@@ -1,5 +1,15 @@
 ## Go
 
+The minimum Go version required is 1.24 and you can install
+
+- as global package
+
 ```bash
 go install github.com/evilmartians/lefthook@latest
+```
+
+- or as a go tool in your project
+
+```bash
+go get -tool github.com/evilmartians/lefthook
 ```


### PR DESCRIPTION
### Context

The [current documentation of go's installation methods](https://lefthook.dev/installation/go.html) does not reflect what's said in this repository [README.md#install](https://github.com/evilmartians/lefthook?tab=readme-ov-file#install).

### Changes

Adding text about Go's 1.24 version requirement as well as installing it as go tool.
