### PR TITLE
docs: add fail_on_changes to configuration/README.md

### DIFF
--- a/docs/mdbook/configuration/README.md
+++ b/docs/mdbook/configuration/README.md
@@ -54,6 +54,7 @@ The `-local` config can be used without a main config file. This is useful when 
   - [`parallel`](./parallel.md)
   - [`piped`](./piped.md)
   - [`follow`](./follow.md)
+  - [`fail_on_changes`](./fail_on_changes.md)
   - [`exclude_tags`](./exclude_tags.md)
   - [`skip`](./skip.md)
   - [`only`](./only.md)


### PR DESCRIPTION
### Context

The `fail_on_changes` option is missing from docs/mdbook/configuration/README.md.

### Changes

Added the `fail_on_changes` option to docs/mdbook/configuration/README.md.