### PR TITLE
Fix: Clear cache before second call to ChangeSet

### DIFF
--- a/internal/run/controller.go
+++ b/internal/run/controller.go
@@ -237,6 +237,7 @@ func (c *Controller) preHook() {
 
 func (c *Controller) postHook() error {
 	if c.FailOnChanges {
+		c.Repo.Setup() // Reset the cache to get an up-to-date git status
 		changesetAfter, err := c.Repo.Changeset()
 		if err != nil {
 			log.Warnf("Couldn't get changeset: %s\n", err)

--- a/tests/integrity/fail_on_changes_ci.txt
+++ b/tests/integrity/fail_on_changes_ci.txt
@@ -1,0 +1,20 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add .
+exec git commit -m "firstcommit"
+exec lefthook install
+
+# This should fail because README.md is modified and fail_on_changes is 'ci'
+! exec lefthook run pre-commit --all-files
+stdout '│  Error: files were modified by a hook, and fail_on_changes is enabled'
+
+-- README.md --
+This is a readme.
+
+-- lefthook.yml --
+pre-commit:
+  fail_on_changes: always
+  jobs:
+    - name: test-job
+      run: echo 123 >> README.md


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1125

The `ChangeSet` method was relying on a cached git status 🙄 