### PR TITLE
fix: re evaluate status for changeset

### DIFF
--- a/tests/integrity/fail_on_changes.txt
+++ b/tests/integrity/fail_on_changes.txt
@@ -2,7 +2,7 @@ exec git init
 exec lefthook install
 exec git config user.email "you@example.com"
 exec git config user.name "Your Name"
-exec git add -A
+exec git add file.txt
 
 ! exec lefthook run pre-commit --fail-on-changes
 stdout '│  Error: files were modified by a hook, and fail_on_changes is enabled'
@@ -25,4 +25,4 @@ hook-setting:
       stage_fixed: true
 
 -- file.txt --
-firstline
+1

--- a/tests/integrity/fail_on_changes_issue_1125.txt
+++ b/tests/integrity/fail_on_changes_issue_1125.txt
@@ -1,0 +1,20 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add .
+exec git commit -m "firstcommit"
+exec lefthook install
+
+# This should fail because README.md is modified
+! exec lefthook run pre-commit --all-files
+stdout '│  Error: files were modified by a hook, and fail_on_changes is enabled'
+
+-- README.md --
+This is a readme.
+
+-- lefthook.yml --
+pre-commit:
+  fail_on_changes: true
+  jobs:
+    - name: test-job
+      run: echo 123 >> README.md


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1125
Closes https://github.com/evilmartians/lefthook/pull/1128

### Context

Status is not being re-evaluated when calling `Changeset()`, it was using the cached results.

### Changes

For `Changeset()` re-evaluate `git status --short`