### PR TITLE
fix: add exclude option to hook level

### DIFF
--- a/internal/config/hook.go
+++ b/internal/config/hook.go
@@ -15,6 +15,7 @@ type Hook struct {
 	FailOnChanges string      `json:"fail_on_changes,omitempty" jsonschema:"enum=true,enum=1,enum=0,enum=false,enum=never,enum=always,enum=ci" koanf:"fail_on_changes"     mapstructure:"fail_on_changes" toml:"fail_on_changes,omitempty" yaml:"fail_on_changes,omitempty"`
 	Files         string      `json:"files,omitempty"           mapstructure:"files"                                                           toml:"files,omitempty"      yaml:",omitempty"`
 	ExcludeTags   []string    `json:"exclude_tags,omitempty"    koanf:"exclude_tags"                                                           mapstructure:"exclude_tags" toml:"exclude_tags,omitempty"  yaml:"exclude_tags,omitempty"`
+	Exclude       []string    `json:"exclude,omitempty"         koanf:"exclude"                                                                mapstructure:"exclude"      toml:"exclude,omitempty"       yaml:"exclude,omitempty"`
 	Skip          interface{} `json:"skip,omitempty"            jsonschema:"oneof_type=boolean;array"                                          mapstructure:"skip"         toml:"skip,omitempty,inline"   yaml:",omitempty"`
 	Only          interface{} `json:"only,omitempty"            jsonschema:"oneof_type=boolean;array"                                          mapstructure:"only"         toml:"only,omitempty,inline"   yaml:",omitempty"`
 

--- a/internal/run/controller/scope.go
+++ b/internal/run/controller/scope.go
@@ -24,11 +24,16 @@ type scope struct {
 }
 
 func newScope(hook *config.Hook, opts Options) *scope {
-	excludeFiles := make([]interface{}, len(opts.ExcludeFiles))
-	if len(opts.ExcludeFiles) > 0 {
-		for i, e := range opts.ExcludeFiles {
-			excludeFiles[i] = e
-		}
+	excludeFiles := make([]interface{}, len(opts.ExcludeFiles)+len(hook.Exclude))
+
+	i := 0
+	for _, e := range opts.ExcludeFiles {
+		excludeFiles[i] = e
+		i += 1
+	}
+	for _, e := range hook.Exclude {
+		excludeFiles[i] = e
+		i += 1
 	}
 
 	return &scope{

--- a/internal/run/controller/scope_test.go
+++ b/internal/run/controller/scope_test.go
@@ -10,6 +10,58 @@ import (
 	"github.com/evilmartians/lefthook/tests/helpers/configtest"
 )
 
+func Test_newScope(t *testing.T) {
+	t.Run("with excluded files in hook and opts", func(t *testing.T) {
+		opts := Options{
+			ExcludeFiles: []string{
+				"file1.txt",
+				"file2.txt",
+			},
+		}
+		hook := &config.Hook{
+			Exclude: []string{
+				"file3.txt",
+				"file4.txt",
+				"file5.txt",
+			},
+		}
+
+		scope := newScope(hook, opts)
+		assert.Equal(t, scope.excludeFiles, []interface{}{
+			"file1.txt",
+			"file2.txt",
+			"file3.txt",
+			"file4.txt",
+			"file5.txt",
+		})
+		assert.NotEqual(t, scope.env, nil)
+	})
+
+	t.Run("without excluded files", func(t *testing.T) {
+		opts := Options{}
+		hook := &config.Hook{}
+
+		scope := newScope(hook, opts)
+		assert.Equal(t, scope.excludeFiles, []interface{}{})
+	})
+
+	t.Run("without excluded files from hook only", func(t *testing.T) {
+		opts := Options{}
+		hook := &config.Hook{
+			Exclude: []string{
+				"file1.txt",
+				"file2.txt",
+			},
+		}
+
+		scope := newScope(hook, opts)
+		assert.Equal(t, scope.excludeFiles, []interface{}{
+			"file1.txt",
+			"file2.txt",
+		})
+	})
+}
+
 func TestScope_extend(t *testing.T) {
 	for i, tt := range [...]struct {
 		initial *scope

--- a/schema.json
+++ b/schema.json
@@ -159,6 +159,12 @@
           },
           "type": "array"
         },
+        "exclude": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "skip": {
           "oneOf": [
             {


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/593

### Context

We have job-level `exclude` option. We sometimes it's convenient to use it hook-level.

### Changes

Add hook-level `exclude` option. It's a list of strings

```yml
pre-commit:
  exclude:
    - README.md
    - Makefile
    - "bin/*.sh"
  jobs:
    - ...
```