### PR TITLE
fix: accept false as valid override argument

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,6 +13,10 @@ import (
 func run() *cli.Command {
 	var args command.RunArgs
 	var colors string
+	failOnChanges := &cli.BoolWithInverseFlag{
+		Name:  "fail-on-changes",
+		Usage: "exit with 1 if some of the files were changed",
+	}
 
 	return &cli.Command{
 		Name:      "run",
@@ -86,11 +90,7 @@ func run() *cli.Command {
 				Usage:       "do not run LFS hooks",
 				Destination: &args.SkipLFS,
 			},
-			&cli.BoolFlag{
-				Name:        "fail-on-changes",
-				Usage:       "exit with 1 if some of the files were changed",
-				Destination: &args.FailOnChanges,
-			},
+			failOnChanges,
 			&cli.BoolFlag{
 				Name:        "files-from-stdin",
 				Usage:       "parse filelist from STDIN",
@@ -101,6 +101,11 @@ func run() *cli.Command {
 			l, err := command.NewLefthook(args.Verbose, colors)
 			if err != nil {
 				return err
+			}
+
+			if failOnChanges.IsSet() {
+				value := cmd.Bool("fail-on-changes")
+				args.FailOnChanges = &value
 			}
 
 			if cmd.Args().Len() < 1 {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -34,7 +34,7 @@ type RunArgs struct {
 	NoStageFixed    bool
 	SkipLFS         bool
 	Verbose         bool
-	FailOnChanges   bool
+	FailOnChanges   *bool
 	Hook            string
 	Exclude         []string
 	Files           []string
@@ -207,9 +207,9 @@ func getSourceDirs(repo *git.Repository, cfg *config.Config) []string {
 	return sourceDirs
 }
 
-func shouldFailOnChanges(fromArg bool, fromHook string) (bool, error) {
-	if fromArg {
-		return true, nil
+func shouldFailOnChanges(fromArg *bool, fromHook string) (bool, error) {
+	if fromArg != nil {
+		return *fromArg, nil
 	}
 
 	switch fromHook {

--- a/tests/integration/fail_on_changes.txt
+++ b/tests/integration/fail_on_changes.txt
@@ -10,6 +10,8 @@ stdout '│  Error: files were modified by a hook, and fail_on_changes is enable
 ! exec lefthook run hook-setting
 stdout '│  Error: files were modified by a hook, and fail_on_changes is enabled'
 
+exec lefthook run hook-setting --fail-on-changes=false
+
 -- lefthook.yml --
 pre-commit:
   commands:


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1121

### Context

`--fail-on-changes=false` doesn't override config value.

### Changes

Make `--fail-on-changes=false` override the value in the config.