### PR TITLE
fix: lock before all git commands

### DIFF
--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -33,13 +33,11 @@ func TestRun(t *testing.T) {
 	configPath := filepath.Join(root, "lefthook.yml")
 
 	for i, tt := range [...]struct {
-		name, hook, config     string
-		gitArgs                []string
-		envs                   map[string]string
-		existingDirs           []string
-		hookNameCompletions    []string
-		hookCommandCompletions []string
-		error                  bool
+		name, hook, config string
+		gitArgs            []string
+		envs               map[string]string
+		existingDirs       []string
+		error              bool
 	}{
 		{
 			name: "Skip case",
@@ -81,8 +79,7 @@ pre-commit:
   parallel: true
   piped: true
 `,
-			hookNameCompletions: []string{"pre-commit"},
-			error:               true,
+			error: true,
 		},
 		{
 			name: "Valid hook",
@@ -92,8 +89,7 @@ pre-commit:
   parallel: false
   piped: true
 `,
-			hookNameCompletions: []string{"pre-commit"},
-			error:               false,
+			error: false,
 		},
 		{
 			name: "When in git rebase-merge flow",
@@ -112,9 +108,7 @@ pre-commit:
 			existingDirs: []string{
 				filepath.Join(gitPath, "rebase-merge"),
 			},
-			hookNameCompletions:    []string{"pre-commit"},
-			hookCommandCompletions: []string{"echo"},
-			error:                  false,
+			error: false,
 		},
 		{
 			name: "When in git rebase-apply flow",
@@ -133,9 +127,7 @@ pre-commit:
 			existingDirs: []string{
 				filepath.Join(gitPath, "rebase-apply"),
 			},
-			hookNameCompletions:    []string{"pre-commit"},
-			hookCommandCompletions: []string{"echo"},
-			error:                  false,
+			error: false,
 		},
 		{
 			name: "When not in rebase flow",
@@ -151,9 +143,7 @@ post-commit:
         - merge
       run: echo 'SHOULD RUN'
 `,
-			hookNameCompletions:    []string{"post-commit"},
-			hookCommandCompletions: []string{"echo"},
-			error:                  true,
+			error: true,
 		},
 	} {
 		t.Run(fmt.Sprintf("%d: %s", i, tt.name), func(t *testing.T) {
@@ -181,12 +171,6 @@ post-commit:
 			} else {
 				assert.NoError(err)
 			}
-
-			// hookNameCompletions := lefthook.configHookCompletions()
-			// assert.ElementsMatch(tt.hookNameCompletions, hookNameCompletions)
-			//
-			// hookCommandCompletions := lefthook.configHookCommandCompletions(tt.hook)
-			// assert.ElementsMatch(tt.hookCommandCompletions, hookCommandCompletions)
 		})
 	}
 }

--- a/internal/git/command_executor.go
+++ b/internal/git/command_executor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/evilmartians/lefthook/v2/internal/log"
 	"github.com/evilmartians/lefthook/v2/internal/system"
@@ -12,6 +13,7 @@ import (
 
 // CommandExecutor provides some methods that take some effect on execution and/or result data.
 type CommandExecutor struct {
+	mu            *sync.Mutex
 	cmd           system.Command
 	root          string
 	maxCmdLen     int
@@ -21,7 +23,11 @@ type CommandExecutor struct {
 
 // NewExecutor returns an object that executes given commands in the OS.
 func NewExecutor(cmd system.Command) *CommandExecutor {
-	return &CommandExecutor{cmd: cmd, maxCmdLen: system.MaxCmdLen()}
+	return &CommandExecutor{
+		mu:        new(sync.Mutex),
+		cmd:       cmd,
+		maxCmdLen: system.MaxCmdLen(),
+	}
 }
 
 func (c CommandExecutor) WithoutEnvs(envs ...string) CommandExecutor {
@@ -100,6 +106,11 @@ func (c CommandExecutor) CmdLinesWithinFolder(cmd []string, folder string) ([]st
 }
 
 func (c CommandExecutor) execute(cmd []string, root string) (string, error) {
+	if len(cmd) > 0 && cmd[0] == "git" {
+		// Preventing Git lock issues for all Git commands
+		c.mu.Lock()
+		defer c.mu.Unlock()
+	}
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	err := c.cmd.Run(cmd, root, system.NullReader, stdout, stderr)

--- a/internal/git/command_executor_test.go
+++ b/internal/git/command_executor_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,7 +24,7 @@ func (m mockCmd) Run(cmd []string, root string, in io.Reader, out io.Writer, err
 
 func TestBatchedCmd(t *testing.T) {
 	assert := assert.New(t)
-	c := CommandExecutor{cmd: mockCmd{}, maxCmdLen: 2}
+	c := CommandExecutor{cmd: mockCmd{}, mu: new(sync.Mutex), maxCmdLen: 2}
 	out, err := c.BatchedCmd([]string{"hello"}, []string{"1", "2", "3", "4"})
 	assert.NoError(err)
 

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -53,9 +53,6 @@ var (
 
 // Repository represents a git repository.
 type Repository struct {
-	// Mutex helps syncing Git commands which can't be run concurrently, e.g. `git add`.
-	mu sync.Mutex
-
 	Fs                afero.Fs
 	Git               *CommandExecutor
 	HooksPath         string
@@ -362,9 +359,6 @@ func (r *Repository) AddFiles(files []string) error {
 	if len(files) == 0 {
 		return nil
 	}
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
 
 	_, err := r.Git.BatchedCmd(cmdStageFiles, files)
 

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/evilmartians/lefthook/v2/internal/system"
@@ -49,6 +50,7 @@ MM staged but changed
 		t.Run(fmt.Sprintf("%d: %s", i, tt.name), func(t *testing.T) {
 			repository := &Repository{
 				Git: &CommandExecutor{
+					mu: new(sync.Mutex),
 					cmd: gitCmd{
 						cases: map[string]string{
 							"git status --short --porcelain": tt.gitOut,
@@ -139,6 +141,7 @@ RM old-file -> new-file`,
 
 			repository := &Repository{
 				Git: &CommandExecutor{
+					mu: new(sync.Mutex),
 					cmd: gitCmd{
 						cases: gitCmds,
 					},


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1173

### Context

Adding a mutex on just `stage_fixed` didn't help. That's probably because Git uses locks not only for `git add`, but also for `git stash`, `git diff`, and many other subcommands. Although I couldn't discover what exactly is causing the problem, I think it can be caused by the concurrent calls to `git`. 

If it doesn't help the problem may not be just in lefthook, maybe other programs are using git while lefthook is running hooks. In this case we need an external synchronization mechanism or a retry logic.

### Changes

When it's `git` command, use the mutex.