### PR TITLE
feat: add optional standard glob matcher (doublestar)

### DIFF
--- a/docs/mdbook/SUMMARY.md
+++ b/docs/mdbook/SUMMARY.md
@@ -54,6 +54,7 @@
   - [`source_dir`](./configuration/source_dir.md)
   - [`source_dir_local`](./configuration/source_dir_local.md)
   - [`skip_lfs`](./configuration/skip_lfs.md)
+  - [`glob_matcher`](./configuration/glob_matcher.md)
   - [`templates`](./configuration/templates.md)
   - [{Git hook name}](./configuration/Hook.md)
     - [`files`](./configuration/files-global.md)

--- a/docs/mdbook/configuration/exclude.md
+++ b/docs/mdbook/configuration/exclude.md
@@ -2,6 +2,8 @@
 
 This option allows to setup a list of globs for files to be excluded in files template.
 
+> **Note:** The glob patterns used in `exclude` are affected by the [`glob_matcher`](./glob_matcher.md) setting. See the glob_matcher documentation for details on how `**` patterns behave.
+
 **Example**
 
 Run Rubocop on staged files with `.rb` extension except for `application.rb`, `routes.rb`, `rails_helper.rb`, and all Ruby files in `config/initializers/`.

--- a/docs/mdbook/configuration/glob.md
+++ b/docs/mdbook/configuration/glob.md
@@ -50,6 +50,8 @@ You'll need:
 glob: "src/*.js"
 ```
 
+Alternatively, you can opt-in to standard glob behavior by setting [`glob_matcher: doublestar`](./glob_matcher.md) at the top level of your configuration. With this setting, `**` will match 0 or more directories, making it consistent with most other glob implementations.
+
 ***Using `glob` without a files template in`run`***
 
 If you've specified `glob` but don't have a files template in [`run`](./run.md) option, lefthook will check `{staged_files}` for `pre-commit` hook and `{push_files}` for `pre-push` hook and apply filtering. If no files left, the command will be skipped.

--- a/docs/mdbook/configuration/glob_matcher.md
+++ b/docs/mdbook/configuration/glob_matcher.md
@@ -1,0 +1,85 @@
+## `glob_matcher`
+
+You can configure which glob matching engine lefthook uses to filter files. By default, lefthook uses `gobwas/glob`, but you can opt-in to use `doublestar` for standard glob behavior.
+
+**Values:**
+- `gobwas` (default): The current glob implementation
+- `doublestar`: Standard glob behavior where `**` matches 0 or more directories
+
+**Example:**
+
+```yml
+# lefthook.yml
+
+glob_matcher: doublestar
+
+pre-commit:
+  jobs:
+    - name: lint
+      run: yarn eslint {staged_files}
+      glob: "**/*.{js,ts}"
+```
+
+### Key Differences
+
+The main difference between the two matchers is how they handle `**`:
+
+#### Default behavior (`gobwas`)
+
+The `**` pattern matches **1 or more** directories:
+- `**/*.js` matches `folder/file.js`, `a/b/c/file.js`
+- `**/*.js` does **NOT** match `file.js` at the root level
+
+#### Standard behavior (`doublestar`)
+
+The `**` pattern matches **0 or more** directories:
+- `**/*.js` matches `file.js`, `folder/file.js`, `a/b/c/file.js`
+- This is consistent with most glob implementations
+
+### When to Use
+
+**Use `glob_matcher: doublestar` when:**
+- You want standard glob behavior consistent with other tools
+- You need `**` to match files at any level including the root
+- You're migrating from other tools that use standard glob patterns
+
+**Keep the default (`gobwas`) when:**
+- You want to maintain existing behavior
+- You specifically need `**` to require at least one directory level
+- You have existing patterns that depend on the current behavior
+
+### Example Comparison
+
+```yml
+# With default (gobwas)
+glob_matcher: gobwas  # or omit this line
+
+pre-commit:
+  jobs:
+    - run: eslint {staged_files}
+      glob: "**/*.js"
+      # Matches: src/app.js, lib/util.js
+      # Does NOT match: app.js
+
+    - run: eslint {staged_files}
+      glob: "*.js"
+      # Matches: app.js
+      # Does NOT match: src/app.js
+```
+
+```yml
+# With doublestar
+glob_matcher: doublestar
+
+pre-commit:
+  jobs:
+    - run: eslint {staged_files}
+      glob: "**/*.js"
+      # Matches: app.js, src/app.js, lib/util.js
+```
+
+### Notes
+
+- The `glob_matcher` setting is global and applies to all `glob` and `exclude` patterns in your configuration
+- This setting does not affect `root` or other path-related options
+- The setting is fully backward compatible - existing configurations continue to work without modification

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
+github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
 github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -134,6 +134,7 @@ func (l *Lefthook) Run(ctx context.Context, args RunArgs) error {
 		DisableTTY:    cfg.NoTTY || args.NoTTY,
 		SkipLFS:       cfg.SkipLFS || args.SkipLFS,
 		Templates:     cfg.Templates,
+		GlobMatcher:   cfg.GlobMatcher,
 		GitArgs:       args.GitArgs,
 		ExcludeFiles:  args.Exclude,
 		Files:         args.Files,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,8 @@ type Config struct {
 
 	SkipLFS bool `json:"skip_lfs,omitempty" jsonschema:"description=Skip running Git LFS hooks (enabled by default)" koanf:"skip_lfs" mapstructure:"skip_lfs,omitempty"`
 
+	GlobMatcher string `json:"glob_matcher,omitempty" jsonschema:"description=Choose the glob matching engine: 'gobwas' (default) or 'doublestar' (standard ** behavior),enum=gobwas;doublestar,default=gobwas" koanf:"glob_matcher" mapstructure:"glob_matcher,omitempty"`
+
 	Remotes []*Remote `json:"remotes,omitempty" jsonschema:"description=Provide multiple remote configs to use lefthook configurations shared across projects. Lefthook will automatically download and merge configurations into main config." mapstructure:"remotes,omitempty"`
 
 	Templates map[string]string `json:"templates,omitempty" jsonschema:"description=Custom templates for replacements in run commands." mapstructure:"templates,omitempty"`

--- a/internal/config/jsonschema.json
+++ b/internal/config/jsonschema.json
@@ -433,7 +433,7 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.11.07.",
+  "$comment": "Last updated on 2025.11.11.",
   "properties": {
     "min_version": {
       "type": "string",
@@ -496,6 +496,14 @@
     "skip_lfs": {
       "type": "boolean",
       "description": "Skip running Git LFS hooks (enabled by default)"
+    },
+    "glob_matcher": {
+      "type": "string",
+      "enum": [
+        "gobwas;doublestar"
+      ],
+      "description": "Choose the glob matching engine: 'gobwas' (default) or 'doublestar' (standard ** behavior)",
+      "default": "gobwas"
     },
     "remotes": {
       "items": {

--- a/internal/run/controller/command/build.go
+++ b/internal/run/controller/command/build.go
@@ -21,12 +21,13 @@ type JobParams struct {
 }
 
 type BuilderOptions struct {
-	HookName   string
-	GitArgs    []string
-	ForceFiles []string
-	SourceDirs []string
-	Templates  map[string]string
-	Force      bool
+	HookName    string
+	GitArgs     []string
+	ForceFiles  []string
+	SourceDirs  []string
+	Templates   map[string]string
+	GlobMatcher string
+	Force       bool
 }
 
 type Builder struct {

--- a/internal/run/controller/command/build_command.go
+++ b/internal/run/controller/command/build_command.go
@@ -74,6 +74,7 @@ func (b *Builder) buildCommand(params *JobParams) ([]string, []string, error) {
 		ExcludeFiles: params.ExcludeFiles,
 		Root:         params.Root,
 		FileTypes:    params.FileTypes,
+		GlobMatcher:  b.opts.GlobMatcher,
 	}
 	for filesType, fn := range filesFns {
 		cnt := strings.Count(params.Run, filesType)

--- a/internal/run/controller/controller.go
+++ b/internal/run/controller/controller.go
@@ -33,6 +33,7 @@ type Options struct {
 	RunOnlyTags   []string
 	SourceDirs    []string
 	Templates     map[string]string
+	GlobMatcher   string
 	DisableTTY    bool
 	FailOnChanges bool
 	Force         bool

--- a/internal/run/controller/filters/filters_test.go
+++ b/internal/run/controller/filters/filters_test.go
@@ -29,35 +29,87 @@ func TestByGlob(t *testing.T) {
 	for i, tt := range [...]struct {
 		source, result []string
 		glob           []string
+		globMatcher    string
 	}{
 		{
-			source: []string{"folder/subfolder/0.rb", "1.txt", "2.RB", "3.rbs"},
-			glob:   []string{},
-			result: []string{"folder/subfolder/0.rb", "1.txt", "2.RB", "3.rbs"},
+			source:      []string{"folder/subfolder/0.rb", "1.txt", "2.RB", "3.rbs"},
+			glob:        []string{},
+			globMatcher: "",
+			result:      []string{"folder/subfolder/0.rb", "1.txt", "2.RB", "3.rbs"},
 		},
 		{
-			source: []string{"folder/subfolder/0.rb", "1.txt", "2.RB", "3.rbs"},
-			glob:   []string{"*.rb"},
-			result: []string{"folder/subfolder/0.rb", "2.RB"},
+			source:      []string{"folder/subfolder/0.rb", "1.txt", "2.RB", "3.rbs"},
+			glob:        []string{"*.rb"},
+			globMatcher: "",
+			result:      []string{"folder/subfolder/0.rb", "2.RB"},
 		},
 		{
-			source: []string{"folder/subfolder/0.rb", "1.rbs"},
-			glob:   []string{"**/*.rb"},
-			result: []string{"folder/subfolder/0.rb"},
+			source:      []string{"folder/subfolder/0.rb", "1.rbs"},
+			glob:        []string{"**/*.rb"},
+			globMatcher: "",
+			result:      []string{"folder/subfolder/0.rb"},
 		},
 		{
-			source: []string{"folder/0.rb", "1.rBs", "2.rbv"},
-			glob:   []string{"*.rb?"},
-			result: []string{"1.rBs", "2.rbv"},
+			source:      []string{"folder/0.rb", "1.rBs", "2.rbv"},
+			glob:        []string{"*.rb?"},
+			globMatcher: "",
+			result:      []string{"1.rBs", "2.rbv"},
 		},
 		{
-			source: []string{"f.a", "f.b", "f.c", "f.cn"},
-			glob:   []string{"*.{a,b,cn}"},
-			result: []string{"f.a", "f.b", "f.cn"},
+			source:      []string{"f.a", "f.b", "f.c", "f.cn"},
+			glob:        []string{"*.{a,b,cn}"},
+			globMatcher: "",
+			result:      []string{"f.a", "f.b", "f.cn"},
 		},
 	} {
 		t.Run(fmt.Sprintf("%d:", i), func(t *testing.T) {
-			res := byGlob(tt.source, tt.glob)
+			res := byGlob(tt.source, tt.glob, tt.globMatcher)
+			if !slicesEqual(res, tt.result) {
+				t.Errorf("expected %v to be equal to %v", res, tt.result)
+			}
+		})
+	}
+}
+
+func TestByGlobDoublestar(t *testing.T) {
+	for i, tt := range [...]struct {
+		source, result []string
+		glob           []string
+		globMatcher    string
+	}{
+		{
+			source:      []string{"0.rb", "folder/1.rb", "folder/subfolder/2.rb"},
+			glob:        []string{"**/*.rb"},
+			globMatcher: "doublestar",
+			result:      []string{"0.rb", "folder/1.rb", "folder/subfolder/2.rb"},
+		},
+		{
+			source:      []string{"0.rb", "folder/1.rb", "folder/subfolder/2.rb"},
+			glob:        []string{"**/*.rb"},
+			globMatcher: "",
+			result:      []string{"folder/1.rb", "folder/subfolder/2.rb"},
+		},
+		{
+			source:      []string{"a/b.go", "a/c/d.go", "e.go"},
+			glob:        []string{"**/*.go"},
+			globMatcher: "doublestar",
+			result:      []string{"a/b.go", "a/c/d.go", "e.go"},
+		},
+		{
+			source:      []string{"a/b.go", "a/c/d.go", "e.go"},
+			glob:        []string{"**/*.go"},
+			globMatcher: "",
+			result:      []string{"a/b.go", "a/c/d.go"},
+		},
+		{
+			source:      []string{"test.js", "src/app.js", "src/lib/util.js"},
+			glob:        []string{"**/*.js"},
+			globMatcher: "doublestar",
+			result:      []string{"test.js", "src/app.js", "src/lib/util.js"},
+		},
+	} {
+		t.Run(fmt.Sprintf("doublestar-%d:", i), func(t *testing.T) {
+			res := byGlob(tt.source, tt.glob, tt.globMatcher)
 			if !slicesEqual(res, tt.result) {
 				t.Errorf("expected %v to be equal to %v", res, tt.result)
 			}
@@ -69,20 +121,63 @@ func TestByExclude(t *testing.T) {
 	for i, tt := range [...]struct {
 		source, result []string
 		exclude        []string
+		globMatcher    string
 	}{
 		{
-			source:  []string{"folder/subfolder/0.rb", "1.txt", "2.RB", "3.rb"},
-			exclude: []string{},
-			result:  []string{"folder/subfolder/0.rb", "1.txt", "2.RB", "3.rb"},
+			source:      []string{"folder/subfolder/0.rb", "1.txt", "2.RB", "3.rb"},
+			exclude:     []string{},
+			globMatcher: "",
+			result:      []string{"folder/subfolder/0.rb", "1.txt", "2.RB", "3.rb"},
 		},
 		{
-			source:  []string{"f.a", "f.b", "f.c", "f.cn"},
-			exclude: []string{"*.a", "*.b", "*.cn"},
-			result:  []string{"f.c"},
+			source:      []string{"f.a", "f.b", "f.c", "f.cn"},
+			exclude:     []string{"*.a", "*.b", "*.cn"},
+			globMatcher: "",
+			result:      []string{"f.c"},
 		},
 	} {
 		t.Run(fmt.Sprintf("%d:", i), func(t *testing.T) {
-			res := byExclude(tt.source, tt.exclude)
+			res := byExclude(tt.source, tt.exclude, tt.globMatcher)
+			if !slicesEqual(res, tt.result) {
+				t.Errorf("expected %v to be equal to %v", res, tt.result)
+			}
+		})
+	}
+}
+
+func TestByExcludeDoublestar(t *testing.T) {
+	for i, tt := range [...]struct {
+		source, result []string
+		exclude        []string
+		globMatcher    string
+	}{
+		{
+			source:      []string{"0.rb", "folder/1.rb", "folder/subfolder/2.rb", "test.js"},
+			exclude:     []string{"**/*.rb"},
+			globMatcher: "doublestar",
+			result:      []string{"test.js"},
+		},
+		{
+			source:      []string{"0.rb", "folder/1.rb", "folder/subfolder/2.rb", "test.js"},
+			exclude:     []string{"**/*.rb"},
+			globMatcher: "",
+			result:      []string{"0.rb", "test.js"},
+		},
+		{
+			source:      []string{"src/app.js", "src/lib/util.js", "test.py", "src/test.py"},
+			exclude:     []string{"**/*.py"},
+			globMatcher: "doublestar",
+			result:      []string{"src/app.js", "src/lib/util.js"},
+		},
+		{
+			source:      []string{"a.go", "src/b.go", "src/lib/c.go"},
+			exclude:     []string{"**/*.go"},
+			globMatcher: "doublestar",
+			result:      []string{},
+		},
+	} {
+		t.Run(fmt.Sprintf("doublestar-%d:", i), func(t *testing.T) {
+			res := byExclude(tt.source, tt.exclude, tt.globMatcher)
 			if !slicesEqual(res, tt.result) {
 				t.Errorf("expected %v to be equal to %v", res, tt.result)
 			}

--- a/internal/run/controller/job.go
+++ b/internal/run/controller/job.go
@@ -93,12 +93,13 @@ func (c *Controller) runSingleJob(ctx context.Context, scope *scope, id string, 
 	}
 
 	builder := command.NewBuilder(c.git, command.BuilderOptions{
-		HookName:   scope.hookName,
-		ForceFiles: scope.opts.Files,
-		Force:      scope.opts.Force,
-		SourceDirs: scope.opts.SourceDirs,
-		GitArgs:    scope.opts.GitArgs,
-		Templates:  scope.opts.Templates,
+		HookName:    scope.hookName,
+		ForceFiles:  scope.opts.Files,
+		Force:       scope.opts.Force,
+		SourceDirs:  scope.opts.SourceDirs,
+		GitArgs:     scope.opts.GitArgs,
+		Templates:   scope.opts.Templates,
+		GlobMatcher: scope.opts.GlobMatcher,
 	})
 	commands, files, err := builder.BuildCommands(&command.JobParams{
 		Name:         name,
@@ -155,6 +156,7 @@ func (c *Controller) runSingleJob(ctx context.Context, scope *scope, id string, 
 				Root:         scope.root,
 				ExcludeFiles: scope.excludeFiles,
 				FileTypes:    scope.fileTypes,
+				GlobMatcher:  scope.opts.GlobMatcher,
 			})
 		}
 

--- a/schema.json
+++ b/schema.json
@@ -433,7 +433,7 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.11.07.",
+  "$comment": "Last updated on 2025.11.11.",
   "properties": {
     "min_version": {
       "type": "string",
@@ -496,6 +496,14 @@
     "skip_lfs": {
       "type": "boolean",
       "description": "Skip running Git LFS hooks (enabled by default)"
+    },
+    "glob_matcher": {
+      "type": "string",
+      "enum": [
+        "gobwas;doublestar"
+      ],
+      "description": "Choose the glob matching engine: 'gobwas' (default) or 'doublestar' (standard ** behavior)",
+      "default": "gobwas"
     },
     "remotes": {
       "items": {


### PR DESCRIPTION
Closes #1187

### Context

The current glob pattern behavior in lefthook differs from standard implementations in two ways:
1. `*` wildcard recursively matches subdirectories (very unusual)
2. `**` requires at least 1 directory level instead of the standard 0+

Current behavior (gobwas):
- `*.js` matches at **all levels**: `file.js`, `folder/file.js`, `a/b/file.js`
- `**/*.js` matches **only nested** (1+ levels): `folder/file.js`, `a/b/file.js`

Standard behavior (bash, zsh, .gitignore, pre-commit, lint-staged):
- `*.js` matches **only root level**: `file.js`
- `**/*.js` matches **all levels** (0+ levels): `file.js`, `folder/file.js`, `a/b/file.js`

As discussed in #1187, this non-standard behavior creates friction:
- Users must learn lefthook-specific glob patterns
- Patterns can't be easily copied from other tools
- AI coding assistants consistently generate incorrect patterns
- Documentation burden to explain the difference

This PR implements an opt-in solution that maintains full backward compatibility while allowing users to choose standard glob behavior.

### Changes

**Core Implementation:**
- Add `glob_matcher` config option with values: `gobwas` (default) or `doublestar`
- Implement dual matcher support in filters package using `github.com/bmatcuk/doublestar/v4`
- Refactor glob/exclude matching logic to reduce complexity (fixes nestif linter issues)
- Thread `GlobMatcher` through the entire execution pipeline

**Testing:**
- Add `TestByGlobDoublestar` with 5 test cases comparing both matchers
- Add `TestByExcludeDoublestar` with 4 test cases for exclusion patterns
- Update existing tests to include `globMatcher` parameter
- All tests pass including race condition testing

**Documentation:**
- New `docs/mdbook/configuration/glob_matcher.md` with complete reference
- Update `glob.md` to reference the new option
- Update `exclude.md` to note glob_matcher affects exclude patterns  
- Add entry to `SUMMARY.md` table of contents
- Create implementation guide for developers

**Behavior Comparison:**

Default (gobwas):
```yaml
glob: "*.js"
# Matches: file.js, folder/file.js, a/b/file.js (all levels - unusual!)

glob: "**/*.js"  
# Matches: folder/file.js, a/b/file.js (nested only)
# Does NOT match: file.js (root level)
```

With `glob_matcher: doublestar`:
```yaml
glob_matcher: doublestar

glob: "*.js"
# Matches: file.js (root level only - standard behavior)

glob: "**/*.js"
# Matches: file.js, folder/file.js, a/b/file.js (all levels - standard!)
```

**Files Changed:** 16 files
- 8 implementation files
- 1 test file  
- 4 documentation files
- 3 generated/schema files

**Backward Compatibility:**
- ✅ Default behavior unchanged
- ✅ Opt-in only via configuration
- ✅ No breaking changes
- ✅ All existing configs work as-is

This implementation provides a path forward for users who want standard glob behavior while respecting the existing behavior for current users.
