### PR TITLE
chore(release): publish artifact attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
       - "*"
 
 permissions:
+  attestations: write
   contents: write
+  id-token: write
 
 jobs:
   build:
@@ -42,6 +44,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-checksums: dist/lefthook_checksums.txt
 
       - name: Preserve artifacts permissions with tar
         run: tar -cvf dist.tar dist/


### PR DESCRIPTION

### Context

<!-- Brief description of what problem PR is solving -->

https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations

Untested, but I believe this should work. Have done it for other projects.

### Changes

<!-- Summary for changes in the code -->

Generates and publishes artifact attestations for build provenance.