### PR TITLE
chore: encourage python install using pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ gem install lefthook
 For **Python**:
 
 ```bash
-pip install lefthook
+pipx install lefthook
 ```
 
 **[Installation guide][installation]** with more ways to install lefthook: [apt][install-apt], [brew][install-brew], [winget][install-winget], and others.

--- a/docs/mdbook/installation/python.md
+++ b/docs/mdbook/installation/python.md
@@ -7,3 +7,7 @@ python -m pip install --user lefthook
 ```sh
 uv add --dev lefthook
 ```
+
+```sh
+pipx install lefthook
+```


### PR DESCRIPTION
### Context
Avoid 
```
pip install lefthook                                                                                                                                                                    [12:48:35]
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.

    If you wish to install a Python library that isn't in Homebrew,
    use a virtual environment:

    python3 -m venv path/to/venv
    source path/to/venv/bin/activate
    python3 -m pip install xyz

    If you wish to install a Python application that isn't in Homebrew,
    it may be easiest to use 'pipx install xyz', which will manage a
    virtual environment for you. You can install pipx with

    brew install pipx

    You may restore the old behavior of pip by passing
    the '--break-system-packages' flag to pip, or by adding
    'break-system-packages = true' to your pip.conf file. The latter
    will permanently disable this error.

    If you disable this error, we STRONGLY recommend that you additionally
    pass the '--user' flag to pip, or set 'user = true' in your pip.conf
    file. Failure to do this can result in a broken Homebrew installation.

    Read more about this behavior here: <https://peps.python.org/pep-0668/>

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
<img width="1512" height="633" alt="image" src="https://github.com/user-attachments/assets/40460856-78b1-4f0d-9753-4573bb78c4da" />


This PR is to update the documentation to encourage installing the CLI tool using `pipx` instead of `pip`.

`pipx` ensures seamless operation and minimal maintenance CLI tools that are frequently used across multiple projects or system-wide by automatically creating virtual environment, expose it globally to system PATH, and ensuring no conflicts arise between system and CLI dependencies.

<!-- Brief description of what problem PR is solving -->

### Changes

Instead of using `pip`. Encourage user to install using `pipx` 
