### PR TITLE
feat: save original executable location in hooks

### DIFF
--- a/internal/command/install.go
+++ b/internal/command/install.go
@@ -244,7 +244,7 @@ func (l *Lefthook) createHooksIfNeeded(cfg *config.Config, hooks []string, force
 			Rc:                      cfg.Rc,
 			AssertLefthookInstalled: cfg.AssertLefthookInstalled,
 			Roots:                   roots,
-			LefthookExe:             cfg.Lefthook,
+			LefthookPath:            cfg.Lefthook,
 		}
 		if err = l.addHook(hook, templateArgs); err != nil {
 			return fmt.Errorf("could not add the hook: %w", err)
@@ -256,7 +256,7 @@ func (l *Lefthook) createHooksIfNeeded(cfg *config.Config, hooks []string, force
 			Rc:                      cfg.Rc,
 			AssertLefthookInstalled: cfg.AssertLefthookInstalled,
 			Roots:                   roots,
-			LefthookExe:             cfg.Lefthook,
+			LefthookPath:            cfg.Lefthook,
 		}
 		if err = l.addHook(config.GhostHookName, templateArgs); err != nil {
 			return nil

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -18,10 +18,15 @@ call_lefthook()
   if test -n "$LEFTHOOK_BIN"
   then
     "$LEFTHOOK_BIN" "$@"
-  {{ if .LefthookExe -}}
-  elif test -n "{{ .LefthookExe }}"
+  {{ if .LefthookPath -}}
+  elif test -n "{{ .LefthookPath }}"
   then
-    {{ .LefthookExe }} "$@"
+    {{ .LefthookPath }} "$@"
+  {{ end -}}
+  {{ if .LefthookPathCurrent -}}
+  elif {{ .LefthookPathCurrent }} -h >/dev/null 2>&1
+  then
+    {{ .LefthookPathCurrent }} "$@"
   {{ end -}}
   elif lefthook{{.Extension}} -h >/dev/null 2>&1
   then
@@ -48,8 +53,8 @@ call_lefthook()
     elif test -f "$dir/node_modules/lefthook/bin/index.js"
     then
       "$dir/node_modules/lefthook/bin/index.js" "$@"
-    {{ $extension := .Extension }}
-    {{- range .Roots -}}
+    {{ $extension := .Extension -}}
+    {{ range .Roots -}}
     elif test -f "$dir/{{.}}/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook{{$extension}}"
     then
       "$dir/{{.}}/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook{{$extension}}" "$@"
@@ -62,7 +67,7 @@ call_lefthook()
     elif test -f "$dir/{{.}}/node_modules/lefthook/bin/index.js"
     then
       "$dir/{{.}}/node_modules/lefthook/bin/index.js" "$@"
-    {{ end }}
+    {{ end -}}
     elif go tool lefthook -h >/dev/null 2>&1
     then
       go tool lefthook "$@"


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1195

### Context

Lefthook when calling `lefthook install` can get it's absolute location and store it in hook. This should simplify cases when you have to tweak PATH env variable to get lefthook available, but you don't want to or can't do it (in CI, for instance).

### Changes

Save `os.Executable()` absolute path in hooks. 

To overwrite this frozen path in hooks: call `lefthook install` or provide `LEFTHOOK_BIN` env variable.