### PR TITLE
fix: prefer using lefthook from the $PATH

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -18,6 +18,11 @@ call_lefthook()
   if test -n "$LEFTHOOK_BIN"
   then
     "$LEFTHOOK_BIN" "$@"
+  {{ if .LefthookPath -}}
+  elif test -n "{{ .LefthookPath }}"
+  then
+    {{ .LefthookPath }} "$@"
+  {{ end -}}
   elif lefthook{{.Extension}} -h >/dev/null 2>&1
   then
     lefthook{{.Extension}} "$@"
@@ -26,11 +31,6 @@ call_lefthook()
   elif lefthook.bat -h >/dev/null 2>&1
   then
     lefthook.bat "$@"
-  {{ end -}}
-  {{ if .LefthookPath -}}
-  elif test -n "{{ .LefthookPath }}"
-  then
-    {{ .LefthookPath }} "$@"
   {{ end -}}
   {{ if .LefthookPathCurrent -}}
   elif {{ .LefthookPathCurrent }} -h >/dev/null 2>&1


### PR DESCRIPTION
### Context

See https://github.com/evilmartians/lefthook/issues/1195#issuecomment-3606444311

### Changes

From
```bash
elif /home/$USER/.local/share/mise/installs/lefthook/2.0.6/lefthook_2.0.6_Linux_x86_64 -h >/dev/null 2>&1
then
  /home/$USER/.local/share/mise/installs/lefthook/2.0.6/lefthook_2.0.6_Linux_x86_64 "$@"
elif lefthook -h >/dev/null 2>&1
then
  lefthook "$@"
else
```
to:
```bash
elif lefthook -h >/dev/null 2>&1
then
  lefthook "$@"
elif /home/$USER/.local/share/mise/installs/lefthook/2.0.6/lefthook_2.0.6_Linux_x86_64 -h >/dev/null 2>&1
then
  /home/$USER/.local/share/mise/installs/lefthook/2.0.6/lefthook_2.0.6_Linux_x86_64 "$@"
else
```

###  Tests

```bash
$ go build -o lefthook
$ cd .. && mkdir testLefthook && cd testLefthook && git init
$ vim lefthook.yml
pre-commit:
  jobs:
    - run: yarn eslint {staged_files}
      glob: "*.{js,ts,jsx,tsx}"
$ ../lefthook/lefthook install
$ cat .git/hooks/pre-commit
  if test -n "$LEFTHOOK_BIN"
  then
    "$LEFTHOOK_BIN" "$@"
  elif lefthook -h >/dev/null 2>&1
  then
    lefthook "$@"
  elif $HOME/git/lefthook/lefthook -h >/dev/null 2>&1
  then
    $HOME/git/lefthook/lefthook "$@"
  else
```