### PR TITLE
fix: do not try to hash-object directories

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -360,7 +360,7 @@ func (r *Repository) AddFiles(files []string) error {
 }
 
 // Changeset returns a map of files and their hashes that are different from the index.
-// The hash for a deleted file is "deleted".
+// The hash for a deleted file is "deleted", and "directory" for a directory.
 func (r *Repository) Changeset() (map[string]string, error) {
 	changeset := make(map[string]string)
 	pathsToHash := make([]string, 0)
@@ -373,6 +373,10 @@ func (r *Repository) Changeset() (map[string]string, error) {
 	r.parseStatusShort(lines, func(path string, index, worktree byte) {
 		if index == 'D' || worktree == 'D' {
 			changeset[path] = "deleted"
+			return
+		}
+		if strings.HasSuffix(path, "/") {
+			changeset[path] = "directory"
 			return
 		}
 

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -114,10 +114,19 @@ func TestChangeset(t *testing.T) {
 			},
 		},
 		{
+			name:         "new dir",
+			gitStatusOut: "?? new-dir/",
+			pathsToHash:  []string{},
+			result: map[string]string{
+				"new-dir/": "directory",
+			},
+		},
+		{
 			name: "mixed changes",
 			gitStatusOut: `M  modified.txt
  D deleted.txt
 ?? new.txt
+?? new-dir/
 RM old-file -> new-file`,
 			gitHashOut:  "123456\n654321\n758213",
 			pathsToHash: []string{"modified.txt", "new.txt", "new-file"},
@@ -125,6 +134,7 @@ RM old-file -> new-file`,
 				"modified.txt": "123456",
 				"deleted.txt":  "deleted",
 				"new.txt":      "654321",
+				"new-dir/":     "directory",
 				"new-file":     "758213",
 			},
 		},


### PR DESCRIPTION
Closes #1170

### Context

<!-- Brief description of what problem PR is solving -->

See #1170.

### Changes

<!-- Summary for changes in the code -->

Avoid running `git hash-object` on directories, short circuit record them in changesets like deleted files.