### PR TITLE
fix: check and report Scanner errors

### DIFF
--- a/internal/command/install.go
+++ b/internal/command/install.go
@@ -330,6 +330,10 @@ func (l *Lefthook) checkHooksSynchronized(cfg *config.Config) (bool, []string) {
 			break
 		}
 	}
+	if err = scanner.Err(); err != nil {
+		log.Warnf("Could not read %s: %s", file.Name(), err)
+		return false, nil
+	}
 
 	if len(storedChecksum) == 0 {
 		return false, storedHooks

--- a/internal/command/lefthook.go
+++ b/internal/command/lefthook.go
@@ -86,6 +86,9 @@ func (l *Lefthook) isLefthookFile(path string) bool {
 			return true
 		}
 	}
+	if err = scanner.Err(); err != nil {
+		log.Warnf("Could not read %s: %s", file.Name(), err)
+	}
 
 	return false
 }

--- a/internal/git/state.go
+++ b/internal/git/state.go
@@ -90,6 +90,9 @@ func (r *Repository) branch() string {
 			return match[1]
 		}
 	}
+	if err = scanner.Err(); err != nil {
+		log.Warnf("Could not read %s: %s", file.Name(), err)
+	}
 
 	return ""
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -303,6 +303,9 @@ func (u *Updater) download(ctx context.Context, name, fileURL, checksumURL, path
 			}
 		}
 	}
+	if err = scanner.Err(); err != nil {
+		return false, fmt.Errorf("scan checksum response body: %w", err)
+	}
 
 	log.Debugf("No matches found for %s %s", name, hashsum)
 


### PR DESCRIPTION

### Context

<!-- Brief description of what problem PR is solving -->

When reading streams using Scanners, errors were not reported.

### Changes

<!-- Summary for changes in the code -->

Check for scanner errors, log or return them.