### PR TITLE
fix: improve separation of options and filenames for more git commands

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -45,7 +45,7 @@ var (
 	}
 	cmdAllFiles     = []string{"git", "ls-files", "--cached"}
 	cmdCreateStash  = []string{"git", "stash", "create"}
-	cmdStageFiles   = []string{"git", "add", "--force"}
+	cmdStageFiles   = []string{"git", "add", "--force", "--"}
 	cmdRemotes      = []string{"git", "branch", "--remotes"}
 	cmdHideUnstaged = []string{"git", "checkout", "--force", "--"}
 	cmdGitVersion   = []string{"git", "version"}
@@ -280,6 +280,7 @@ func (r *Repository) RestoreUnstaged() error {
 		"--whitespace=nowarn",
 		"--recount",
 		"--unidiff-zero",
+		"--",
 		r.unstagedPatchPath,
 	})
 	if err != nil {
@@ -383,7 +384,7 @@ func (r *Repository) Changeset() (map[string]string, error) {
 		return changeset, nil
 	}
 
-	out, err := r.Git.BatchedCmd([]string{"git", "hash-object"}, pathsToHash)
+	out, err := r.Git.BatchedCmd([]string{"git", "hash-object", "--"}, pathsToHash)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -135,7 +135,7 @@ RM old-file -> new-file`,
 			}
 
 			if len(tt.pathsToHash) > 0 {
-				cmd := append([]string{"git", "hash-object"}, tt.pathsToHash...)
+				cmd := append([]string{"git", "hash-object", "--"}, tt.pathsToHash...)
 				gitCmds[strings.Join(cmd, " ")] = tt.gitHashOut
 			}
 

--- a/internal/run/controller/controller_test.go
+++ b/internal/run/controller/controller_test.go
@@ -511,8 +511,8 @@ func TestRunAll(t *testing.T) {
 			gitCommands: []string{
 				"git status --short",
 				"git diff --name-only --cached --diff-filter=ACMR",
-				"git add --force .*script.sh.*README.md",
-				"git add --force .*script.sh.*README.md",
+				"git add --force -- .*script.sh.*README.md",
+				"git add --force -- .*script.sh.*README.md",
 			},
 		},
 		"with pre-commit skip": {
@@ -537,7 +537,7 @@ func TestRunAll(t *testing.T) {
 			gitCommands: []string{
 				"git status --short",
 				"git diff --name-only --cached --diff-filter=ACMR",
-				"git add --force .*README.md",
+				"git add --force -- .*README.md",
 				"git diff --name-only --cached --diff-filter=ACMRD",
 			},
 		},
@@ -565,7 +565,7 @@ func TestRunAll(t *testing.T) {
 			gitCommands: []string{
 				"git status --short",
 				"git diff --name-only --cached --diff-filter=ACMR",
-				"git add --force .*README.md",
+				"git add --force -- .*README.md",
 			},
 		},
 		"with pre-commit and stage_fixed=true under root": {
@@ -586,7 +586,7 @@ func TestRunAll(t *testing.T) {
 			gitCommands: []string{
 				"git status --short",
 				"git diff --name-only --cached --diff-filter=ACMR",
-				"git add --force .*scripts.*script.sh",
+				"git add --force -- .*scripts.*script.sh",
 			},
 		},
 		"with pre-push skip": {

--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -63,9 +63,9 @@ func Test_guard_wrap(t *testing.T) {
 			failOnChanges:        true,
 			commands: [][2]string{
 				{"git status --short --porcelain", " M file1\n M file2"},
-				{"git hash-object file1 file2", "0\n1\n"},
+				{"git hash-object -- file1 file2", "0\n1\n"},
 				{"git status --short --porcelain", " M file1\n M file2"},
-				{"git hash-object file1 file2", "0\n1\n"},
+				{"git hash-object -- file1 file2", "0\n1\n"},
 			},
 		},
 		"failOnChanges=true fail with changeset different": {
@@ -73,9 +73,9 @@ func Test_guard_wrap(t *testing.T) {
 			failOnChanges:        true,
 			commands: [][2]string{
 				{"git status --short --porcelain", " M file1\n M file2"},
-				{"git hash-object file1 file2", "0\n1\n"},
+				{"git hash-object -- file1 file2", "0\n1\n"},
 				{"git status --short --porcelain", " M file1\n M file2"},
-				{"git hash-object file1 file2", "2\n3\n"},
+				{"git hash-object -- file1 file2", "2\n3\n"},
 			},
 			err: ErrFailOnChanges,
 		},
@@ -85,7 +85,7 @@ func Test_guard_wrap(t *testing.T) {
 			commands: [][2]string{
 				{"git status --short --porcelain", ""},
 				{"git status --short --porcelain", " M file1\n M file2"},
-				{"git hash-object file1 file2", "0\n1\n"},
+				{"git hash-object -- file1 file2", "0\n1\n"},
 			},
 			err: ErrFailOnChanges,
 		},


### PR DESCRIPTION

### Context

<!-- Brief description of what problem PR is solving -->

Filenames starting with dashes can be mistaken as options.

### Changes

<!-- Summary for changes in the code -->

SSIA.