### PR TITLE
feat: more rudimentary shell completions

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -47,5 +47,9 @@ func add() *cli.Command {
 			args.Hook = cmd.Args().Get(0)
 			return l.Add(ctx, args)
 		},
+		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+			command.ShellCompleteFlags(cmd)
+			command.ShellCompleteHookNames()
+		},
 	}
 }

--- a/cmd/check_install.go
+++ b/cmd/check_install.go
@@ -31,5 +31,8 @@ func checkInstall() *cli.Command {
 
 			return l.CheckInstall(ctx)
 		},
+		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+			command.ShellCompleteFlags(cmd)
+		},
 	}
 }

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -46,5 +46,8 @@ func dump() *cli.Command {
 
 			return l.Dump(ctx, args)
 		},
+		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+			command.ShellCompleteFlags(cmd)
+		},
 	}
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -37,5 +37,9 @@ func install() *cli.Command {
 
 			return l.Install(ctx, args, cmd.Args().Slice())
 		},
+		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+			command.ShellCompleteFlags(cmd)
+			command.ShellCompleteHookNames()
+		},
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/urfave/cli/v3"
 
@@ -117,19 +116,8 @@ func run() *cli.Command {
 			return l.Run(ctx, args)
 		},
 		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
-			l, err := command.NewLefthook(args.Verbose, colors)
-			if err != nil {
-				return
-			}
-
-			cfg, err := l.LoadConfig()
-			if err != nil {
-				return
-			}
-
-			for hook := range cfg.Hooks {
-				fmt.Println(hook) //nolint:forbidigo
-			}
+			command.ShellCompleteFlags(cmd)
+			command.ShellCompleteHookNames()
 		},
 	}
 }

--- a/cmd/self_update.go
+++ b/cmd/self_update.go
@@ -61,5 +61,8 @@ func selfUpdate() *cli.Command {
 				ExePath: exePath,
 			})
 		},
+		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+			command.ShellCompleteFlags(cmd)
+		},
 	}
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -41,5 +41,8 @@ func uninstall() *cli.Command {
 
 			return l.Uninstall(ctx, args)
 		},
+		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+			command.ShellCompleteFlags(cmd)
+		},
 	}
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -30,5 +30,8 @@ func validate() *cli.Command {
 
 			return l.Validate(ctx, args)
 		},
+		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+			command.ShellCompleteFlags(cmd)
+		},
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/evilmartians/lefthook/v2/internal/command"
 	"github.com/evilmartians/lefthook/v2/internal/log"
 	ver "github.com/evilmartians/lefthook/v2/internal/version"
 )
@@ -30,6 +31,9 @@ func version() *cli.Command {
 		Action: func(_ctx context.Context, cmd *cli.Command) error {
 			log.Println(ver.Version(verbose))
 			return nil
+		},
+		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+			command.ShellCompleteFlags(cmd)
 		},
 	}
 }


### PR DESCRIPTION
Refs https://github.com/evilmartians/lefthook/pull/1155#issuecomment-3424871549

### Context

<!-- Brief description of what problem PR is solving -->

Since Lefthook 2.0.0, shell completions have regressed significantly due to change of the CLI library.

### Changes

<!-- Summary for changes in the code -->

Bring back more hook completions, as well as flag completions. Completions in general continue to be worse than they were in 1.x (lack of context), but I suppose this is borderline as far as they can be taken them without landing significant custom work (which would be better placed in the CLI lib).