### PR TITLE
fix: skip if empty files template

### DIFF
--- a/internal/run/controller/command/build_command.go
+++ b/internal/run/controller/command/build_command.go
@@ -55,7 +55,7 @@ func (b *Builder) buildCommand(params *JobParams) ([]string, []string, error) {
 		}
 
 		if len(files) == 0 {
-			if !replacer.Empty(config.SubStagedFiles) {
+			if replacer.Cached(config.SubStagedFiles) {
 				return nil, nil, SkipError{"no matching staged files"}
 			}
 

--- a/internal/run/controller/command/replacer/replacer.go
+++ b/internal/run/controller/command/replacer/replacer.go
@@ -105,9 +105,19 @@ func (r Replacer) Discover(source string, filter *filter.Filter) error {
 	return nil
 }
 
-func (r Replacer) Empty(key string) bool {
+func (r Replacer) Cached(key string) bool {
 	_, ok := r.cache[key]
-	return !ok
+
+	return ok
+}
+
+func (r Replacer) Empty(key string) bool {
+	entry, ok := r.cache[key]
+	if !ok {
+		return true
+	}
+
+	return len(entry.items) == 0
 }
 
 func (r Replacer) Files(template string, filter *filter.Filter) ([]string, error) {

--- a/tests/integration/files_skip_if_empty.txt
+++ b/tests/integration/files_skip_if_empty.txt
@@ -1,0 +1,19 @@
+# https://github.com/evilmartians/lefthook/issues/1232
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec lefthook run test
+! stdout 'FILES DETECTED'
+
+-- lefthook.yml --
+output:
+  - execution_out
+
+test:
+  jobs:
+    - run: echo FILES DETECTED {files}
+      files: echo
+
+    - run: echo FILES DETECTED
+      files: echo
+


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1232

### Context

When `{files}` template resolves empty list, the command execution must be skipped. Even if the `{files}` template is in the `run` string.

### Changes

Check not only if files were cached, but also if there were actually any file.