### PR TITLE
ci: support npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,14 +71,18 @@ jobs:
           name: dist
       - run: tar -xvf dist.tar
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Publish to NPM
         env:
           NPM_API_KEY: ${{ secrets.NPM_API_KEY }}
         run: |
-          cat << EOF > ~/.npmrc
-          //registry.npmjs.org/:_authToken=${NPM_API_KEY}
-          EOF
-          chmod 0600 ~/.npmrc
           cd packaging/
           ruby pack.rb prepare
           ruby pack.rb publish_npm


### PR DESCRIPTION
### Context

NPM policy has changed slightly https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/
