### PR TITLE
fix(git): make short status parser more robust

### DIFF
--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -54,17 +54,17 @@ func Test_guard_wrap(t *testing.T) {
 			stashUnstagedChanges: false,
 			failOnChanges:        true,
 			commands: [][2]string{
-				{"git status --short --porcelain", ""},
-				{"git status --short --porcelain", ""},
+				{"git status --short --porcelain -z", ""},
+				{"git status --short --porcelain -z", ""},
 			},
 		},
 		"failOnChanges=true no fail": {
 			stashUnstagedChanges: false,
 			failOnChanges:        true,
 			commands: [][2]string{
-				{"git status --short --porcelain", " M file1\n M file2"},
+				{"git status --short --porcelain -z", " M file1\x00 M file2\x00"},
 				{"git hash-object -- file1 file2", "0\n1\n"},
-				{"git status --short --porcelain", " M file1\n M file2"},
+				{"git status --short --porcelain -z", " M file1\x00 M file2\x00"},
 				{"git hash-object -- file1 file2", "0\n1\n"},
 			},
 		},
@@ -72,9 +72,9 @@ func Test_guard_wrap(t *testing.T) {
 			stashUnstagedChanges: false,
 			failOnChanges:        true,
 			commands: [][2]string{
-				{"git status --short --porcelain", " M file1\n M file2"},
+				{"git status --short --porcelain -z", " M file1\x00 M file2\x00"},
 				{"git hash-object -- file1 file2", "0\n1\n"},
-				{"git status --short --porcelain", " M file1\n M file2"},
+				{"git status --short --porcelain -z", " M file1\x00 M file2\x00"},
 				{"git hash-object -- file1 file2", "2\n3\n"},
 			},
 			err: ErrFailOnChanges,
@@ -83,8 +83,8 @@ func Test_guard_wrap(t *testing.T) {
 			stashUnstagedChanges: false,
 			failOnChanges:        true,
 			commands: [][2]string{
-				{"git status --short --porcelain", ""},
-				{"git status --short --porcelain", " M file1\n M file2"},
+				{"git status --short --porcelain -z", ""},
+				{"git status --short --porcelain -z", " M file1\x00 M file2\x00"},
 				{"git hash-object -- file1 file2", "0\n1\n"},
 			},
 			err: ErrFailOnChanges,
@@ -93,21 +93,21 @@ func Test_guard_wrap(t *testing.T) {
 			stashUnstagedChanges: true,
 			failOnChanges:        false,
 			commands: [][2]string{
-				{"git status --short --porcelain", ""},
+				{"git status --short --porcelain -z", ""},
 			},
 		},
 		"stashUnstagedChanges=true no unstaged": {
 			stashUnstagedChanges: true,
 			failOnChanges:        false,
 			commands: [][2]string{
-				{"git status --short --porcelain", "M  file1\nM  file2\nM  file3"},
+				{"git status --short --porcelain -z", "M  file1\x00M  file2\x00M  file3\x00"},
 			},
 		},
 		"stashUnstagedChanges=true with partially staged": {
 			stashUnstagedChanges: true,
 			failOnChanges:        false,
 			commands: [][2]string{
-				{"git status --short --porcelain", "AM file1\n M file2\n A file3\n"},
+				{"git status --short --porcelain -z", "AM file1\x00 M file2\x00 A file3\x00"},
 				{"git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", ""},


### PR DESCRIPTION

Ref https://git-scm.com/docs/git-status#_short_format

### Context

<!-- Brief description of what problem PR is solving -->

The current git short status parser has a number of problems with filenames containing spaces and other cases for which the "plain" porcelain format outputs as quoted (the surrounding quotes are not removed, nor are the backslash escaped characters within quotes unescaled), as well as pathological cases like ones containing ` -> ` (which are mistreated as renames, losing the latter half of the filename), etc.

### Changes

<!-- Summary for changes in the code -->

Switch to the NUL separated -z porcelain format recommended for machine parsing to make it easier to avoid hitting the mentioned issues. 

A downside is that parsing this format is stateful and we need to "know" the cases for which two filenames are output, currently copy (C) and rename (R).

Caveat: I have not found a way to produce a "C" state file locally, so I'm just assuming that it will produce two file entries like "R" does, based on https://git-scm.com/docs/git-status#_output
> where ORIG_PATH is where the renamed/copied contents came from