### PR TITLE
docs(output): remove duplicate `config: false` description

### DIFF
--- a/docs/mdbook/configuration/output.md
+++ b/docs/mdbook/configuration/output.md
@@ -7,8 +7,6 @@ By default, all output values are enabled
 
 You can also disable all output with setting `output: false`. In this case only errors will be printed.
 
-This config quiets all outputs except for errors.
-
 **Example**
 
 ```yml


### PR DESCRIPTION
### Context

<!-- Brief description of what problem PR is solving -->

Some duplicate info in config for `output: false`.

### Changes

<!-- Summary for changes in the code -->

Remove the redundant doc line.