### PR TITLE
fix: don't install custom hooks to hooks dir

### DIFF
--- a/internal/command/install.go
+++ b/internal/command/install.go
@@ -298,11 +298,15 @@ func (l *Lefthook) createHooksIfNeeded(cfg *config.Config, hooks []string, force
 			continue
 		}
 
-		hookNames = append(hookNames, hook)
-
 		if err = l.cleanHook(hook, force); err != nil {
 			return fmt.Errorf("could not replace the hook: %w", err)
 		}
+
+		if _, ok := config.AvailableHooks[hook]; !ok {
+			continue
+		}
+
+		hookNames = append(hookNames, hook)
 
 		templateArgs := templates.Args{
 			Rc:                      cfg.Rc,

--- a/internal/command/install_test.go
+++ b/internal/command/install_test.go
@@ -214,6 +214,36 @@ post-commit:
 			},
 		},
 		{
+			name: "with custom hook",
+			config: `
+my-custom-hook:
+  commands:
+    custom:
+      run: echo 'Hello from custom!'
+`,
+			wantNotExist: []string{
+				hookPath("my-custom-hook"),
+			},
+		},
+		{
+			name: "with custom existing hook",
+			config: `
+my-custom-hook:
+  commands:
+    custom:
+      run: echo 'Hello from custom!'
+`,
+			existingFiles: map[string]string{
+				hookPath("my-custom-hook"): "",
+			},
+			wantExist: []string{
+				hookPath("my-custom-hook.old"),
+			},
+			wantNotExist: []string{
+				hookPath("my-custom-hook"),
+			},
+		},
+		{
 			name: "with unfetched remote",
 			config: `
 remotes:


### PR DESCRIPTION

### Context

<!-- Brief description of what problem PR is solving -->

There is no benefit to my knowledge from installing custom hooks to the git hooks dir. If that's true, we could avoid doing that and keep it a bit cleaner.

### Changes

<!-- Summary for changes in the code -->

Install only "real" hooks, rename existing "non-real" ones we may have installed earlier to `.old` on sync.