### PR TITLE
fix: allow custom hooks in JSON schema by updating generator

### DIFF
--- a/gen/jsonschema.go
+++ b/gen/jsonschema.go
@@ -54,6 +54,9 @@ func main() {
 		return []reflect.StructField{}
 	}
 	schema := r.Reflect(&config.Config{})
+	if hookDef, ok := schema.Definitions["Hook"]; ok {
+		schema.AdditionalProperties = hookDef
+	}
 	schema.ID = "https://json.schemastore.org/lefthook.json"
 	schema.Comments = "Last updated on " + time.Now().Format("2006.01.02") + "."
 	dumped, err := json.MarshalIndent(schema, "", "  ")

--- a/internal/config/jsonschema.json
+++ b/internal/config/jsonschema.json
@@ -442,7 +442,7 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.12.10.",
+  "$comment": "Last updated on 2025.12.19.",
   "properties": {
     "min_version": {
       "type": "string",
@@ -621,6 +621,89 @@
       "$ref": "#/$defs/Hook"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": {
+    "properties": {
+      "parallel": {
+        "type": "boolean"
+      },
+      "piped": {
+        "type": "boolean"
+      },
+      "follow": {
+        "type": "boolean"
+      },
+      "fail_on_changes": {
+        "type": "string",
+        "enum": [
+          "true",
+          "1",
+          "0",
+          "false",
+          "never",
+          "always",
+          "ci",
+          "non-ci"
+        ]
+      },
+      "fail_on_changes_diff": {
+        "type": "boolean"
+      },
+      "files": {
+        "type": "string"
+      },
+      "exclude_tags": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "exclude": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "skip": {
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "array"
+          }
+        ]
+      },
+      "only": {
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "array"
+          }
+        ]
+      },
+      "jobs": {
+        "items": {
+          "$ref": "#/$defs/Job"
+        },
+        "type": "array"
+      },
+      "commands": {
+        "additionalProperties": {
+          "$ref": "#/$defs/Command"
+        },
+        "type": "object"
+      },
+      "scripts": {
+        "additionalProperties": {
+          "$ref": "#/$defs/Script"
+        },
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "type": "object"
+  },
   "type": "object"
 }

--- a/schema.json
+++ b/schema.json
@@ -442,7 +442,7 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.12.10.",
+  "$comment": "Last updated on 2025.12.19.",
   "properties": {
     "min_version": {
       "type": "string",
@@ -621,6 +621,89 @@
       "$ref": "#/$defs/Hook"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": {
+    "properties": {
+      "parallel": {
+        "type": "boolean"
+      },
+      "piped": {
+        "type": "boolean"
+      },
+      "follow": {
+        "type": "boolean"
+      },
+      "fail_on_changes": {
+        "type": "string",
+        "enum": [
+          "true",
+          "1",
+          "0",
+          "false",
+          "never",
+          "always",
+          "ci",
+          "non-ci"
+        ]
+      },
+      "fail_on_changes_diff": {
+        "type": "boolean"
+      },
+      "files": {
+        "type": "string"
+      },
+      "exclude_tags": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "exclude": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "skip": {
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "array"
+          }
+        ]
+      },
+      "only": {
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "array"
+          }
+        ]
+      },
+      "jobs": {
+        "items": {
+          "$ref": "#/$defs/Job"
+        },
+        "type": "array"
+      },
+      "commands": {
+        "additionalProperties": {
+          "$ref": "#/$defs/Command"
+        },
+        "type": "object"
+      },
+      "scripts": {
+        "additionalProperties": {
+          "$ref": "#/$defs/Script"
+        },
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "type": "object"
+  },
   "type": "object"
 }


### PR DESCRIPTION
Closes #1249 

### Context
The current JSON schema for Lefthook sets `additionalProperties: false` at the root level. This prevents users from defining custom hooks that are intended to be executed via the `lefthook run <custom-hook>` command. When a custom hook is added to `lefthook.yml`, the validation fails with a message stating that no values are allowed for that key.

This PR resolves the issue by allowing the root object to accept additional properties, provided they conform to the `Hook` definition.

<!-- Brief description of what problem PR is solving -->

### Changes
Schema Generator Update: Modified `gen/jsonschema.go` to programmatically assign the `Hook` definition to the root-level `AdditionalProperties`. This ensures that any custom key in the configuration is validated against the standard hook schema.

Schema Re-generation: Updated both the public-facing `schema.json` and the embedded `internal/config/jsonschema.json` by running the updated generator.

Manual Validation: Verified the fix by running `./lefthook validate` with a configuration file containing a custom hook, which now returns "All good".

<!-- Summary for changes in the code -->
