### PR TITLE
Fix issue with restoring stashed code with partially edited files

### DIFF
--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -115,6 +115,148 @@ func Test_guard_wrap(t *testing.T) {
 				{Command: "git stash drop --quiet 1", Output: ""},
 			},
 		},
+		"stashUnstagedChanges=true failOnChanges=true with partially staged and hook changes": {
+			stashUnstagedChanges: true,
+			failOnChanges:        true,
+			commands: []cmdtest.Out{
+				{Command: "git status --short --porcelain -z", Output: "AM file1\x00"},
+				{Command: "git hash-object -- file1", Output: "hash1\n"},
+				{Command: "git status --short --porcelain -z", Output: "AM file1\x00"},
+				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
+					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
+					" -- file1", Output: ""},
+				{Command: "git stash create", Output: "<stash-hash>"},
+				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
+				{Command: "git checkout --force -- file1", Output: ""},
+				{Command: "git status --short --porcelain -z", Output: "A  file1\x00 M file2\x00"},
+				{Command: "git hash-object -- file1 file2", Output: "hash1\nhash2\n"},
+				{Command: "git status --short --porcelain -z", Output: "A  file1\x00 M file2\x00"},
+				{Command: "git hash-object -- file1 file2", Output: "hash1\nhash3\n"},
+				{Command: "git stash list", Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n"},
+				{Command: "git stash drop --quiet 1", Output: ""},
+			},
+			err: ErrFailOnChanges,
+		},
+		"stashUnstagedChanges=true failOnChanges=true with partially staged and hook changes with diff": {
+			stashUnstagedChanges: true,
+			failOnChanges:        true,
+			failOnChangesDiff:    true,
+			commands: []cmdtest.Out{
+				{Command: "git status --short --porcelain -z", Output: "AM file1\x00"},
+				{Command: "git hash-object -- file1", Output: "hash1\n"},
+				{Command: "git status --short --porcelain -z", Output: "AM file1\x00"},
+				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
+					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
+					" -- file1", Output: ""},
+				{Command: "git stash create", Output: "<stash-hash>"},
+				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
+				{Command: "git checkout --force -- file1", Output: ""},
+				{Command: "git status --short --porcelain -z", Output: "A  file1\x00 M file2\x00"},
+				{Command: "git hash-object -- file1 file2", Output: "hash1\nhash2\n"},
+				{Command: "git status --short --porcelain -z", Output: "A  file1\x00 M file2\x00"},
+				{Command: "git hash-object -- file1 file2", Output: "hash1\nhash3\n"},
+				{Command: "git stash list", Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n"},
+				{Command: "git stash drop --quiet 1", Output: ""},
+				{Command: "git diff --color -- file2", Output: "diff --git a/file2 b/file2\n..."},
+			},
+			err: ErrFailOnChanges,
+		},
+		"failOnChanges=true with deleted file no change": {
+			stashUnstagedChanges: false,
+			failOnChanges:        true,
+			commands: []cmdtest.Out{
+				// Deleted file in before and after - same state, no change
+				{Command: "git status --short --porcelain -z", Output: "D  file1\x00"},
+				{Command: "git status --short --porcelain -z", Output: "D  file1\x00"},
+			},
+		},
+		"failOnChanges=true with directory": {
+			stashUnstagedChanges: false,
+			failOnChanges:        true,
+			commands: []cmdtest.Out{
+				// Directory in before() - marked as "directory"
+				{Command: "git status --short --porcelain -z", Output: "?? dir/\x00"},
+				// Directory still there in after() - same state, no change
+				{Command: "git status --short --porcelain -z", Output: "?? dir/\x00"},
+			},
+		},
+		"failOnChanges=true with changeset error in before": {
+			stashUnstagedChanges: false,
+			failOnChanges:        true,
+			commands: []cmdtest.Out{
+				// Changeset() error in before() - empty output simulates error
+				{Command: "git status --short --porcelain -z", Output: ""},
+				{Command: "git status --short --porcelain -z", Output: ""},
+			},
+		},
+		"stashUnstagedChanges=true failOnChanges=true with changeset error after stashing": {
+			stashUnstagedChanges: true,
+			failOnChanges:        true,
+			commands: []cmdtest.Out{
+				// First Changeset() in before() - has file1
+				{Command: "git status --short --porcelain -z", Output: "AM file1\x00"},
+				{Command: "git hash-object -- file1", Output: "hash1\n"},
+				// PartiallyStagedFiles() - uses statusShortOnce
+				{Command: "git status --short --porcelain -z", Output: "AM file1\x00"},
+				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
+					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
+					" -- file1", Output: ""},
+				{Command: "git stash create", Output: "<stash-hash>"},
+				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
+				{Command: "git checkout --force -- file1", Output: ""},
+				// Second Changeset() in before() after stashing - empty (simulates error/no files)
+				{Command: "git status --short --porcelain -z", Output: ""},
+				// Changeset() in after() - also empty, so they match
+				{Command: "git status --short --porcelain -z", Output: ""},
+				{Command: "git stash list", Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n"},
+				{Command: "git stash drop --quiet 1", Output: ""},
+			},
+		},
+		"failOnChanges=true with changeset error in after": {
+			stashUnstagedChanges: false,
+			failOnChanges:        true,
+			commands: []cmdtest.Out{
+				// Changeset() error in before() - empty output, so changesetBefore is empty
+				{Command: "git status --short --porcelain -z", Output: ""},
+				// Changeset() error in after() - empty output, so changesetAfter is empty
+				{Command: "git status --short --porcelain -z", Output: ""},
+			},
+		},
+		"failOnChanges=true failOnChangesDiff=true with no changed files": {
+			stashUnstagedChanges: false,
+			failOnChanges:        true,
+			failOnChangesDiff:    true,
+			commands: []cmdtest.Out{
+				{Command: "git status --short --porcelain -z", Output: ""},
+				{Command: "git status --short --porcelain -z", Output: ""},
+			},
+		},
+		"stashUnstagedChanges=true with drop stash error": {
+			stashUnstagedChanges: true,
+			failOnChanges:        false,
+			commands: []cmdtest.Out{
+				{Command: "git status --short --porcelain -z", Output: "AM file1\x00"},
+				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
+					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
+					" -- file1", Output: ""},
+				{Command: "git stash create", Output: "<stash-hash>"},
+				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
+				{Command: "git checkout --force -- file1", Output: ""},
+				// RestoreUnstaged succeeds (patch file will be created)
+				{Command: "git stash list", Output: ""}, // Empty list - stash not found, drop will fail silently
+			},
+		},
+		"failOnChanges=true with deleted file in changeset": {
+			stashUnstagedChanges: false,
+			failOnChanges:        true,
+			commands: []cmdtest.Out{
+				{Command: "git status --short --porcelain -z", Output: " M file1\x00"},
+				{Command: "git hash-object -- file1", Output: "hash1\n"},
+				{Command: "git status --short --porcelain -z", Output: "D  file1\x00"},
+				// file1 was deleted, so it's in changesetAfter but marked as "deleted"
+			},
+			err: ErrFailOnChanges,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)


### PR DESCRIPTION
Closes #1216

### Context

https://github.com/evilmartians/lefthook/issues/1216 happens because lefthook compares the pre-stash changeset with a post-stash changeset, meaning if you have `fail_on_changes` enabled and a partially updated file, it will fail.

<!-- Brief description of what problem PR is solving -->

### Changes

This PR adds a copy of the `changesetBefore` code after the stashing code so if we make it to stashing (i.e. it doesn't exit earlier) we reset the `changesetBefore` to be accurate.

NOTE: I'm not 100% confident on the test addition. I verified it fails in the current code and passes in the new code, and I've built the binary and manually tested as well. I attempted to match existing code/style.

<!-- Summary for changes in the code -->
