### PR TITLE
perf: skip ghost hook when hooks are already configured

### DIFF
--- a/internal/command/install.go
+++ b/internal/command/install.go
@@ -315,7 +315,7 @@ func (l *Lefthook) createHooksIfNeeded(cfg *config.Config, hooks []string, force
 		}
 	}
 
-	if len(onlyHooks) == 0 {
+	if len(onlyHooks) == 0 && len(cfg.Hooks) == 0 {
 		templateArgs := templates.Args{
 			Rc:                      cfg.Rc,
 			AssertLefthookInstalled: cfg.AssertLefthookInstalled,

--- a/internal/command/install_test.go
+++ b/internal/command/install_test.go
@@ -58,8 +58,10 @@ post-commit:
 				configPath,
 				hookPath("pre-commit"),
 				hookPath("post-commit"),
-				hookPath(config.GhostHookName),
 				infoPath(config.ChecksumFileName),
+			},
+			wantNotExist: []string{
+				hookPath(config.GhostHookName),
 			},
 		},
 		{
@@ -107,8 +109,10 @@ post-commit:
 				hookPath("pre-commit"),
 				hookPath("pre-commit.old"),
 				hookPath("post-commit"),
-				hookPath(config.GhostHookName),
 				infoPath(config.ChecksumFileName),
+			},
+			wantNotExist: []string{
+				hookPath(config.GhostHookName),
 			},
 		},
 		{
@@ -131,11 +135,11 @@ post-commit:
 				configPath,
 				hookPath("pre-commit"),
 				hookPath("post-commit"),
-				hookPath(config.GhostHookName),
 				infoPath(config.ChecksumFileName),
 			},
 			wantNotExist: []string{
 				hookPath("pre-commit.old"),
+				hookPath(config.GhostHookName),
 			},
 		},
 		{
@@ -156,8 +160,10 @@ post-commit:
 				configPath,
 				hookPath("pre-commit"),
 				hookPath("post-commit"),
-				hookPath(config.GhostHookName),
 				infoPath(config.ChecksumFileName),
+			},
+			wantNotExist: []string{
+				hookPath(config.GhostHookName),
 			},
 		},
 		{
@@ -402,9 +408,10 @@ commit-msg:
 				hookPath("post-commit"),
 				hookPath("commit-msg"),
 				infoPath(config.ChecksumFileName),
+			},
+			wantNotExist: []string{
 				hookPath(config.GhostHookName),
 			},
-			wantNotExist: []string{},
 		},
 		{
 			name: "unsynchronized with selected hooks",


### PR DESCRIPTION
- Closes #1254 

### Context

As far as I understand, the ghost hook (prepare-commit-msg) is installed to enable seamless synchronization of hooks with the config. However, when there are already configured hooks in the lefthook config, this ghost hook adds unnecessary overhead on every commit.

  Every hook that runs already triggers syncHooks(), which checks if hooks are synchronized with the config and reinstalls them if needed. Therefore, the ghost hook is only needed when there are no configured hooks — it provides a sync mechanism when no other hooks would run.

### Changes

  - Only install ghost hook when there are no existing hooks
  - Updated tests accordingly

