### PR TITLE
fix: set extends to empty slice after loading remotes

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -256,7 +256,7 @@ func loadRemotes(k *koanf.Koanf, filesystem afero.Fs, repo *git.Repository, remo
 		}
 
 		// Reset extends to omit issues when extending with remote extends.
-		if err := k.Set("extends", nil); err != nil {
+		if err := k.Set("extends", []string(nil)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1252

### Context

Setting `extends` to `nil` breaks validations

### Changes

Set `extends` to empty slice after loading the remotes.