### PR TITLE
chore(golangci-lint): upgrade to 2.8.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.7.1
+          version: v2.8.0

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint: bin/golangci-lint
 	bin/golangci-lint run --fix
 
 bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b bin/ v2.7.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b bin/ v2.8.0
 
 .ONESHELL:
 version:


### PR DESCRIPTION

### Context

<!-- Brief description of what problem PR is solving -->

New golangci-lint is out.

### Changes

<!-- Summary for changes in the code -->

Update to 2.8.0. No new findings to address.