### PR TITLE
fix(jsonschema): accept string in file_types

### DIFF
--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -18,10 +18,10 @@ type Command struct {
 	Skip any `json:"skip,omitempty" jsonschema:"oneof_type=boolean;array" mapstructure:"skip" toml:"skip,omitempty,inline" yaml:",omitempty"`
 	Only any `json:"only,omitempty" jsonschema:"oneof_type=boolean;array" mapstructure:"only" toml:"only,omitempty,inline" yaml:",omitempty"`
 
-	Tags      []string `json:"tags,omitempty"       jsonschema:"oneof_type=string;array" mapstructure:"tags"       toml:"tags,omitempty"       yaml:",omitempty"`
-	FileTypes []string `json:"file_types,omitempty" koanf:"file_types"                   mapstructure:"file_types" toml:"file_types,omitempty" yaml:"file_types,omitempty"`
-	Glob      []string `json:"glob,omitempty"       jsonschema:"oneof_type=string;array" mapstructure:"glob"       toml:"glob,omitempty"       yaml:",omitempty"`
-	Exclude   []string `json:"exclude,omitempty"    jsonschema:"oneof_type=string;array" mapstructure:"exclude"    toml:"exclude,omitempty"    yaml:",omitempty"`
+	Tags      []string `json:"tags,omitempty"       jsonschema:"oneof_type=string;array" mapstructure:"tags"    toml:"tags,omitempty"     yaml:",omitempty"`
+	FileTypes []string `json:"file_types,omitempty" jsonschema:"oneof_type=string;array" koanf:"file_types"     mapstructure:"file_types" toml:"file_types,omitempty" yaml:"file_types,omitempty"`
+	Glob      []string `json:"glob,omitempty"       jsonschema:"oneof_type=string;array" mapstructure:"glob"    toml:"glob,omitempty"     yaml:",omitempty"`
+	Exclude   []string `json:"exclude,omitempty"    jsonschema:"oneof_type=string;array" mapstructure:"exclude" toml:"exclude,omitempty"  yaml:",omitempty"`
 
 	Env map[string]string `json:"env,omitempty" mapstructure:"env" toml:"env,omitempty" yaml:",omitempty"`
 

--- a/internal/config/job.go
+++ b/internal/config/job.go
@@ -10,10 +10,10 @@ type Job struct {
 	Files    string `json:"files,omitempty"     mapstructure:"files"                      toml:"files,omitempty"   yaml:",omitempty"`
 	FailText string `json:"fail_text,omitempty" koanf:"fail_text"                         mapstructure:"fail_text" toml:"fail_text,omitempty" yaml:"fail_text,omitempty"`
 
-	Glob      []string `json:"glob,omitempty"       jsonschema:"oneof_type=string;array" mapstructure:"glob"       toml:"glob,omitempty"       yaml:",omitempty"`
-	Exclude   []string `json:"exclude,omitempty"    jsonschema:"oneof_type=string;array" mapstructure:"exclude"    toml:"exclude,omitempty"    yaml:",omitempty"`
-	Tags      []string `json:"tags,omitempty"       mapstructure:"tags"                  toml:"tags,omitempty"     yaml:",omitempty"`
-	FileTypes []string `json:"file_types,omitempty" koanf:"file_types"                   mapstructure:"file_types" toml:"file_types,omitempty" yaml:"file_types,omitempty"`
+	Glob      []string `json:"glob,omitempty"       jsonschema:"oneof_type=string;array" mapstructure:"glob"    toml:"glob,omitempty"     yaml:",omitempty"`
+	Exclude   []string `json:"exclude,omitempty"    jsonschema:"oneof_type=string;array" mapstructure:"exclude" toml:"exclude,omitempty"  yaml:",omitempty"`
+	Tags      []string `json:"tags,omitempty"       mapstructure:"tags"                  toml:"tags,omitempty"  yaml:",omitempty"`
+	FileTypes []string `json:"file_types,omitempty" jsonschema:"oneof_type=string;array" koanf:"file_types"     mapstructure:"file_types" toml:"file_types,omitempty" yaml:"file_types,omitempty"`
 
 	Env map[string]string `json:"env,omitempty" mapstructure:"env" toml:"env,omitempty" yaml:",omitempty"`
 

--- a/internal/config/jsonschema.json
+++ b/internal/config/jsonschema.json
@@ -50,10 +50,17 @@
           }
         },
         "file_types": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ],
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "glob": {
           "oneOf": [
@@ -293,10 +300,17 @@
           "type": "array"
         },
         "file_types": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ],
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "env": {
           "additionalProperties": {
@@ -442,7 +456,7 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.12.19.",
+  "$comment": "Last updated on 2026.01.20.",
   "properties": {
     "min_version": {
       "type": "string",

--- a/schema.json
+++ b/schema.json
@@ -50,10 +50,17 @@
           }
         },
         "file_types": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ],
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "glob": {
           "oneOf": [
@@ -293,10 +300,17 @@
           "type": "array"
         },
         "file_types": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ],
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "env": {
           "additionalProperties": {
@@ -442,7 +456,7 @@
       "type": "object"
     }
   },
-  "$comment": "Last updated on 2025.12.19.",
+  "$comment": "Last updated on 2026.01.20.",
   "properties": {
     "min_version": {
       "type": "string",


### PR DESCRIPTION

### Context

<!-- Brief description of what problem PR is solving -->

The config JSON schema does not allow setting file_types as a simple string, although that works fine.

### Changes

<!-- Summary for changes in the code -->

Emit an oneOf array/string in the schema.