### PR TITLE
fix: log full scoped name for skipped jobs

### DIFF
--- a/internal/run/controller/job.go
+++ b/internal/run/controller/job.go
@@ -85,9 +85,10 @@ func (c *Controller) runSingleJob(ctx context.Context, scope *scope, id string, 
 
 	name := job.PrintableName(id)
 	scope = scope.extend(job)
+	logName := strings.Join(append(scope.names, name), " ❯ ")
 
 	if reason := c.skipReason(scope, job, name); len(reason) > 0 {
-		log.Skip(name, reason)
+		log.Skip(logName, reason)
 
 		return result.Skip(name)
 	}
@@ -117,7 +118,7 @@ func (c *Controller) runSingleJob(ctx context.Context, scope *scope, id string, 
 		ExcludeFiles: scope.excludeFiles,
 	})
 	if err != nil {
-		log.Skip(name, err.Error())
+		log.Skip(logName, err.Error())
 
 		var skipErr command.SkipError
 		if errors.As(err, &skipErr) {
@@ -135,7 +136,7 @@ func (c *Controller) runSingleJob(ctx context.Context, scope *scope, id string, 
 		ctx, cancel = context.WithTimeout(ctx, job.Timeout)
 		defer cancel()
 	}
-	err = c.run(ctx, strings.Join(append(scope.names, name), " ❯ "), scope.follow, exec.Options{
+	err = c.run(ctx, logName, scope.follow, exec.Options{
 		Root:        filepath.Join(c.git.RootPath, scope.root),
 		Commands:    commands,
 		Interactive: job.Interactive && !scope.opts.DisableTTY,


### PR DESCRIPTION

### Context

<!-- Brief description of what problem PR is solving -->

When some jobs are skipped, only their "base" name is logged, in contrast with jobs that are not skipped whose full scoped name is logged.

### Changes

<!-- Summary for changes in the code -->

Log full scoped name for skipped jobs, too.