### PR TITLE
feat: unset core.hookspath in lefthook install

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -19,9 +19,14 @@ func install() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:        "force",
-				Usage:       "overwrite .old files",
+				Usage:       "proceed with installation even if core.hooksPath is configured (overwrite .old files)",
 				Aliases:     []string{"f"},
 				Destination: &args.Force,
+			},
+			&cli.BoolFlag{
+				Name:        "reset-hooks-path",
+				Usage:       "automatically unset core.hooksPath configuration",
+				Destination: &args.ResetHooksPath,
 			},
 			&cli.BoolFlag{
 				Name:        "verbose",


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1248

### Context

See the issue.

Now `lefthook install` fail and warn loudly when either the local or global core.hooksPath is set.
`lefthook install` can unset it automatically using ~~`--force`~~`--reset-hooks-path`.

### Changes

Using `git config` :
<img width="550" src="https://github.com/user-attachments/assets/3b8c4de4-f618-4dc8-af5a-c4282a9f7518" />

Using `--reset-hooks-path` :
<img width="550" src="https://github.com/user-attachments/assets/7edc9f7c-124a-4d8e-b806-ada9a0682cac" />

Using `--force` :
<img width="550" src="https://github.com/user-attachments/assets/3cb8127c-3f72-4a3a-8493-5724811d95fc" />