### PR TITLE
docs(install): add missing /v2 suffix for go get -tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ go install github.com/evilmartians/lefthook/v2@v2.1.0
 * or as a go tool
 
 ```bash
-go get -tool github.com/evilmartians/lefthook
+go get -tool github.com/evilmartians/lefthook/v2@v2.1.0
 ```
 
 With **NPM**:


### PR DESCRIPTION
Closes # (issue)

### Context

The installation instruction for `go get -tool` were missing the `v2@v2.1.0` suffix. It is correctly mentioned for the `go install` method.

### Changes

Added the `v2@v2.1.0` suffix in `go get -tool` instructions.
