### PR TITLE
docs: fix incorrect --verbose usage

### DIFF
--- a/docs/mdbook/configuration/lefthook.md
+++ b/docs/mdbook/configuration/lefthook.md
@@ -60,5 +60,5 @@ pre-commit:
 ```yml
 # lefthook-local.yml
 
-lefthook: lefthook --verbose
+lefthook: LEFTHOOK_VERBOSE=1 lefthook
 ```

--- a/docs/mdbook/usage/envs/LEFTHOOK_VERBOSE.md
+++ b/docs/mdbook/usage/envs/LEFTHOOK_VERBOSE.md
@@ -2,3 +2,9 @@
 
 Set `LEFTHOOK_VERBOSE=1` or `LEFTHOOK_VERBOSE=true` to enable verbose printing.
 
+**Example**
+
+```bash
+LEFTHOOK_VERBOSE=1 lefthook run pre-commit
+```
+


### PR DESCRIPTION
### Context

--verbose isn't a valid flag

### Changes

document proper verbose usage instead
