### PR TITLE
fix: support git debug versions

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -31,7 +31,7 @@ const (
 var (
 	reHeadBranch              = regexp.MustCompile(`HEAD -> (?P<name>.*)$`)
 	reOriginHeadBranch        = regexp.MustCompile(`ref: refs/remotes/origin/(?P<name>.*)$`)
-	reVersion                 = regexp.MustCompile(`\d+\.\d+\.\d+`)
+	reVersion                 = regexp.MustCompile(`\d+\.\d+\.(\d+|\w+)`)
 	cmdPushFilesBase          = []string{"git", "diff", "--name-only", "HEAD", "@{push}"}
 	cmdPushFilesHead          = []string{"git", "diff", "--name-only", "HEAD"}
 	cmdStagedFiles            = []string{"git", "diff", "--name-only", "--cached", "--diff-filter=ACMR"}


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1333

### Context

Do not fail when using debug version of Git (like `2.54.GIT`)