### PR TITLE
chore(ci): switch artifact attestations gen to actions/attest v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
 
       - name: Generate artifact attestations
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-checksums: dist/lefthook_checksums.txt
 


### PR DESCRIPTION

### Context

<!-- Brief description of what problem PR is solving -->

Ref https://github.com/actions/attest-build-provenance#usage

> As of version 4, actions/attest-build-provenance is simply a wrapper
> on top of actions/attest.

### Changes

<!-- Summary for changes in the code -->

N/A, CI config chores.