### PR TITLE
fix: separate more commands' non-option args with --

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -25,7 +25,7 @@ pre-commit:
 
     - name: check links
       tags: docs
-      run: lychee --max-concurrency 3 {staged_files}
+      run: lychee --max-concurrency 3 -- {staged_files}
       glob: '*.md'
       exclude:
         - CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ pre-commit:
       run: yarn eslint {staged_files}
 
     - name: lint backend
-      run: bundle exec rubocop --force-exclusion {all_files}
+      run: bundle exec rubocop --force-exclusion -- {all_files}
 
     - name: stylelint frontend
       files: git diff --name-only HEAD @{push}
@@ -113,7 +113,7 @@ pre-commit:
       exclude:
         - "*/application.rb"
         - "*/routes.rb"
-      run: bundle exec rubocop --force-exclusion {all_files}
+      run: bundle exec rubocop --force-exclusion -- {all_files}
 ```
 
 * ### **Execute in sub-directory**
@@ -125,7 +125,7 @@ pre-commit:
     - name: lint backend
       root: "api/" # Careful to have only trailing slash
       glob: "*.rb" # glob filter
-      run: bundle exec rubocop {all_files}
+      run: bundle exec rubocop -- {all_files}
 ```
 
 * ### **Run scripts**
@@ -198,7 +198,7 @@ If you want to run specific group of commands directly.
 ```yml
 fixer:
   jobs:
-    - run: bundle exec rubocop --force-exclusion --safe-auto-correct {staged_files}
+    - run: bundle exec rubocop --force-exclusion --safe-auto-correct -- {staged_files}
     - run: yarn eslint --fix {staged_files}
 ```
 ```bash

--- a/docs/configuration/exclude.md
+++ b/docs/configuration/exclude.md
@@ -26,7 +26,7 @@ pre-commit:
         - config/application.rb
         - config/initializers/*.rb
         - spec/rails_helper.rb
-      run: bundle exec rubocop --force-exclusion {staged_files}
+      run: bundle exec rubocop --force-exclusion -- {staged_files}
 ```
 
 If you've specified `exclude` but don't have a files template in [`run`](./run.md) option, lefthook will check `{staged_files}` for `pre-commit` hook and `{push_files}` for `pre-push` hook and apply filtering. If no files left, the command will be skipped.

--- a/docs/configuration/file_types.md
+++ b/docs/configuration/file_types.md
@@ -6,7 +6,7 @@ title: "file_types"
 
 Filter files in a [`run`](./run.md) templates by their type. Special file types and MIME types are supported[^1]:
 
-|File type| Exlanation|
+|File type| Explanation|
 |---------|-----------|
 |`text`   | Any file that contains text. Symlinks are not followed. |
 |`binary` | Any file that contains non-text bytes. Symlinks are not followed. |
@@ -87,7 +87,7 @@ Check typos in scripts.
 
 pre-commit:
   jobs:
-    - run: typos -w {staged_files}
+    - run: typos -w -- {staged_files}
       file_types:
         - text/x-perl
         - text/x-python

--- a/docs/configuration/files.md
+++ b/docs/configuration/files.md
@@ -39,5 +39,5 @@ pre-push:
       tags: backend
       glob: "**/*.rb"
       files: node ./lefthook-scripts/ls-files.js # you can call your own scripts
-      run: bundle exec rubocop --force-exclusion --parallel {files}
+      run: bundle exec rubocop --force-exclusion --parallel -- {files}
 ```

--- a/docs/configuration/glob_matcher.md
+++ b/docs/configuration/glob_matcher.md
@@ -60,12 +60,12 @@ glob_matcher: gobwas  # or omit this line
 
 pre-commit:
   jobs:
-    - run: eslint {staged_files}
+    - run: eslint -- {staged_files}
       glob: "**/*.js"
       # Matches: src/app.js, lib/util.js
       # Does NOT match: app.js
 
-    - run: eslint {staged_files}
+    - run: eslint -- {staged_files}
       glob: "*.js"
       # Matches: app.js
       # Does NOT match: src/app.js
@@ -77,7 +77,7 @@ glob_matcher: doublestar
 
 pre-commit:
   jobs:
-    - run: eslint {staged_files}
+    - run: eslint -- {staged_files}
       glob: "**/*.js"
       # Matches: app.js, src/app.js, lib/util.js
 ```

--- a/docs/configuration/lefthook.md
+++ b/docs/configuration/lefthook.md
@@ -58,7 +58,7 @@ lefthook: bundle exec lefthook
 
 pre-commit:
   jobs:
-    - run: bundle exec rubocop {staged_files}
+    - run: bundle exec rubocop -- {staged_files}
 ```
 
 #### Enable debug logs

--- a/docs/configuration/run.md
+++ b/docs/configuration/run.md
@@ -46,7 +46,7 @@ pre-commit:
     govet:
       files: git ls-files -m
       glob: "*.go"
-      run: go vet {files}
+      run: go vet -- {files}
 ```
 
 #### `{staged_files}`
@@ -98,7 +98,7 @@ pre-commit:
       exclude:
         - config/application.rb
         - config/routes.rb
-      run: bundle exec rubocop --force-exclusion {all_files}
+      run: bundle exec rubocop --force-exclusion -- {all_files}
 ```
 
 #### `{cmd}`

--- a/docs/configuration/setup.md
+++ b/docs/configuration/setup.md
@@ -26,6 +26,6 @@ pre-commit:
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
         fi
   jobs:
-    - run: golangci-lint {staged_files}
+    - run: golangci-lint -- {staged_files}
       glob: "*.go"
 ```

--- a/docs/configuration/templates.md
+++ b/docs/configuration/templates.md
@@ -24,15 +24,15 @@ templates:
 
 pre-commit:
   jobs:
-    # Will run: `bundle exec rubocop file1 file2 file3 ...`
-    - run: {dip} bundle exec rubocop {staged_files}
+    # Will run: `bundle exec rubocop -- file1 file2 file3 ...`
+    - run: {dip} bundle exec rubocop -- {staged_files}
 ```
 
 ```yml
 # lefthook-local.yml
 
 templates:
-  dip: dip # Will run: `dip bundle exec rubocop file1 file2 file3 ...`
+  dip: dip # Will run: `dip bundle exec rubocop -- file1 file2 file3 ...`
 ```
 
 ### Reduce redundancy

--- a/docs/examples/lefthook-local.md
+++ b/docs/examples/lefthook-local.md
@@ -12,10 +12,10 @@ You can put `lefthook-local.yml` into your `~/.gitignore`, so in every project y
 pre-commit:
   commands:
     lint:
-      run: bundle exec rubocop {staged_files}
+      run: bundle exec rubocop -- {staged_files}
       glob: "*.rb"
     check-links:
-      run: lychee {staged_files}
+      run: lychee -- {staged_files}
 ```
 
 ```yml
@@ -48,10 +48,10 @@ pre-commit:
   parallel: true
   commands:
     lint:
-      run: docker-compose run backend bundle exec rubocop {staged_files}
+      run: docker-compose run backend bundle exec rubocop -- {staged_files}
       glob: "*.rb"
     check-links:
-      run: lychee {staged_files}
+      run: lychee -- {staged_files}
       skip: true
 
 post-merge:

--- a/docs/examples/wrap-commands.md
+++ b/docs/examples/wrap-commands.md
@@ -8,7 +8,7 @@ Wrapping some commands defined in a main config with `dip`[^1].
 pre-commit:
   jobs:
     - name: rubocop
-      run: bundle exec rubocop -A {staged_files}
+      run: bundle exec rubocop -A -- {staged_files}
 ```
 
 ```yml

--- a/examples/complete/lefthook.yml
+++ b/examples/complete/lefthook.yml
@@ -16,7 +16,7 @@ pre-commit:
       exclude:
         - "*/application.rb"
         - "*/routes.rb"
-      run: bundle exec rubocop --force-exclusion {all_files}
+      run: bundle exec rubocop --force-exclusion -- {all_files}
       stage_fixed: true
   scripts:
     "good_job.js":
@@ -34,7 +34,7 @@ pre-push:
       tags: backend style
       files: git diff --name-only master
       glob: "*.rb"
-      run: bundle exec rubocop --force-exclusion {files}
+      run: bundle exec rubocop --force-exclusion -- {files}
   scripts:
     "verify":
       runner: sh

--- a/examples/verbose/lefthook.yml
+++ b/examples/verbose/lefthook.yml
@@ -10,7 +10,7 @@ pre-commit:
     # If there are no files left after filtering, this command will be skipped
     js-lint:
       glob: "*.{js,ts}"
-      run: npx eslint --fix {staged_files} && git add {staged_files}
+      run: npx eslint --fix -- {staged_files} && git add -- {staged_files}
 
     # `ruby-test` will skip execution only when in a merging or rebasing state.
     ruby-test:
@@ -31,7 +31,7 @@ pre-commit:
     ruby-lint:
       glob: "*.rb"
       files: git diff-tree -r --name-only --diff-filter=CDMR HEAD origin/master
-      run: bundle exec rubocop --force-exclusion --parallel '{files}'
+      run: bundle exec rubocop --force-exclusion --parallel -- '{files}'
 
 # You can provide more hooks.
 pre-push:
@@ -39,4 +39,4 @@ pre-push:
     spelling:
       files: git diff --name-only HEAD @{push}
       glob: "*.md"
-      run: npx yaspeller {files}
+      run: npx yaspeller -- {files}

--- a/internal/command/install_test.go
+++ b/internal/command/install_test.go
@@ -304,7 +304,7 @@ remotes:
 					Command: "git -C " + filepath.Join(root, ".git", "info", "lefthook-remotes") + " clone --quiet --origin origin --depth 1 --branch v2.0.0 https://github.com/evilmartians/lefthook lefthook-v2.0.0",
 				},
 				{
-					Command: "git -C " + filepath.Join(root, ".git", "info", "lefthook-remotes", "lefthook-v2.0.0") + " fetch --quiet --depth 1 origin v2.0.0",
+					Command: "git -C " + filepath.Join(root, ".git", "info", "lefthook-remotes", "lefthook-v2.0.0") + " fetch --quiet --depth 1 origin -- v2.0.0",
 				},
 				{
 					Command: "git -C " + filepath.Join(root, ".git", "info", "lefthook-remotes", "lefthook-v2.0.0") + " checkout FETCH_HEAD",
@@ -550,7 +550,7 @@ remotes:
 					Command: "git -C " + filepath.Join(root, ".git", "info", "lefthook-remotes") + " clone --quiet --origin origin --depth 1 --branch v2.0.0 https://github.com/evilmartians/lefthook lefthook-v2.0.0",
 				},
 				{
-					Command: "git -C " + filepath.Join(root, ".git", "info", "lefthook-remotes", "lefthook-v2.0.0") + " fetch --quiet --depth 1 origin v2.0.0",
+					Command: "git -C " + filepath.Join(root, ".git", "info", "lefthook-remotes", "lefthook-v2.0.0") + " fetch --quiet --depth 1 origin -- v2.0.0",
 				},
 				{
 					Command: "git -C " + filepath.Join(root, ".git", "info", "lefthook-remotes", "lefthook-v2.0.0") + " checkout FETCH_HEAD",

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -71,7 +71,7 @@ func (r *Repository) updateRemote(path, ref string) error {
 	if len(ref) != 0 {
 		_, err := git.Cmd([]string{
 			"git", "-C", path, "fetch", "--quiet", "--depth", "1",
-			"origin", ref,
+			"origin", "--", ref,
 		})
 		if err != nil {
 			return err
@@ -112,7 +112,7 @@ func (r *Repository) cloneRemote(dest, directoryName, url, ref string) error {
 	if len(ref) != 0 {
 		_, err := git.Cmd([]string{
 			"git", "-C", path, "fetch", "--quiet", "--depth", "1",
-			"origin", ref,
+			"origin", "--", ref,
 		})
 		if err != nil {
 			return err

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -348,6 +348,7 @@ func (r *Repository) DropUnstagedStash() error {
 				"stash",
 				"drop",
 				"--quiet",
+				"--",
 				matches[stashID],
 			})
 			if err != nil {

--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -91,7 +91,7 @@ func Test_guard_wrap(t *testing.T) {
 				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git stash list", Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n"},
-				{Command: "git stash drop --quiet 1", Output: ""},
+				{Command: "git stash drop --quiet -- 1", Output: ""},
 			},
 		},
 		"stashUnstagedChanges=true failOnChanges=true with partially staged no hook changes": {
@@ -109,7 +109,7 @@ func Test_guard_wrap(t *testing.T) {
 				// job run
 				{Command: "git status --short --porcelain -z", Output: "A file1\x00"},
 				{Command: "git stash list", Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n"},
-				{Command: "git stash drop --quiet 1", Output: ""},
+				{Command: "git stash drop --quiet -- 1", Output: ""},
 			},
 		},
 		"stashUnstagedChanges=true failOnChanges=true with partially staged and hook changes with diff": {
@@ -132,7 +132,7 @@ func Test_guard_wrap(t *testing.T) {
 				{Command: "git diff --color -- file1", Output: "diff --git a/file1 b/file1\n..."},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git stash list", Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n"},
-				{Command: "git stash drop --quiet 1", Output: ""},
+				{Command: "git stash drop --quiet -- 1", Output: ""},
 			},
 			err: &FailOnChangesError{[]string{"file2"}},
 		},

--- a/internal/templates/config.tmpl
+++ b/internal/templates/config.tmpl
@@ -28,12 +28,12 @@
 #       exclude:
 #         - config/application.rb
 #         - config/routes.rb
-#       run: bundle exec rubocop --force-exclusion {all_files}
+#       run: bundle exec rubocop --force-exclusion -- {all_files}
 #
 #     - name: govet
 #       files: git ls-files -m
 #       glob: "*.go"
-#       run: go vet {files}
+#       run: go vet -- {files}
 #
 #     - script: "hello.js"
 #       runner: node

--- a/tests/integration/remotes.txt
+++ b/tests/integration/remotes.txt
@@ -22,13 +22,13 @@ pre-commit:
   parallel: true
   commands:
     js-lint:
-      run: npx eslint --fix {staged_files} && git add {staged_files}
+      run: npx eslint --fix -- {staged_files} && git add -- {staged_files}
       glob:
         - '*.{js,ts}'
     ping:
       run: echo pong
     ruby-lint:
-      run: bundle exec rubocop --force-exclusion --parallel '{files}'
+      run: bundle exec rubocop --force-exclusion --parallel -- '{files}'
       files: git diff-tree -r --name-only --diff-filter=CDMR HEAD origin/master
       glob:
         - '*.rb'
@@ -44,7 +44,7 @@ pre-commit:
 pre-push:
   commands:
     spelling:
-      run: npx yaspeller {files}
+      run: npx yaspeller -- {files}
       files: git diff --name-only HEAD @{push}
       glob:
         - '*.md'


### PR DESCRIPTION

### Context

<!-- Brief description of what problem PR is solving -->

Protects e.g. filename arguments (inadvertently?) beginning with a -. Some of these are quite theoretical in nature, but why not.

### Changes

<!-- Summary for changes in the code -->

SSIA.