### PR TITLE
docs: change logo to point to landing page istead of itself

### DIFF
--- a/docmd.config.js
+++ b/docmd.config.js
@@ -5,7 +5,7 @@ module.exports = {
     light: "/assets/lefthook.png",
     dark: "/assets/lefthook.png",
     alt: "Logo",
-    href: "./"
+    href: "/"
   },
   favicon: "/assets/favicon.svg",
   srcDir: "docs",


### PR DESCRIPTION
On the website currently there's no way to go back to https://lefthook.dev/. On any page logo is self referencing.