### PR TITLE
fix: bring back {lefthook_job_name} template

### DIFF
--- a/internal/run/controller/command/build_command.go
+++ b/internal/run/controller/command/build_command.go
@@ -3,6 +3,8 @@ package command
 import (
 	"strings"
 
+	"github.com/alessio/shellescape"
+
 	"github.com/evilmartians/lefthook/v2/internal/config"
 	"github.com/evilmartians/lefthook/v2/internal/run/controller/command/replacer"
 	"github.com/evilmartians/lefthook/v2/internal/run/controller/filter"
@@ -83,14 +85,18 @@ func (b *Builder) buildCommand(params *JobParams) ([]string, []string, error) {
 
 // buildReplacer creates the replacer with all supported templates for files and arguments.
 func (b *Builder) buildReplacer(params *JobParams) replacer.Replacer {
+	var r replacer.Replacer
 	if len(b.opts.ForceFiles) > 0 {
-		return replacer.NewMocked(b.opts.ForceFiles).
-			AddTemplates(b.opts.Templates).
-			AddGitArgs(b.opts.GitArgs)
+		r = replacer.NewMocked(b.opts.ForceFiles)
+	} else {
+		r = replacer.New(b.git, params.Root, params.FilesCmd)
 	}
 
-	return replacer.New(b.git, params.Root, params.FilesCmd).
+	return r.
 		AddTemplates(b.opts.Templates).
+		AddTemplates(map[string]string{
+			"lefthook_job_name": shellescape.Quote(params.Name),
+		}).
 		AddGitArgs(b.opts.GitArgs)
 }
 

--- a/tests/integration/lefthook_job_name_issue_1345.txt
+++ b/tests/integration/lefthook_job_name_issue_1345.txt
@@ -1,0 +1,17 @@
+exec git init
+exec lefthook install
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add -A
+exec git commit -m 'test'
+stderr 'Macbeth'
+
+-- lefthook.yml --
+output:
+  - execution_out
+
+pre-commit:
+  jobs:
+    - name: 'Macbeth'
+      run: echo {lefthook_job_name}
+


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1345

### Context

After some refactoring in Replacer the `lefthook_job_name` was removed. This PR brings it back

### Changes

- [x] Bring back `{lefthook_job_name}` template
- [x] Add in integration test