### PR TITLE
chore: move golangci-lint version to .tool-versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.10.1
+          version-file: .tool-versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+golangci-lint 2.10.1

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint: bin/golangci-lint
 	bin/golangci-lint run --fix
 
 bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b bin/ v2.10.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b bin/ v$$(awk '/^golangci-lint[[:space:]]/ { print $2 }' .tool-versions)
 
 .ONESHELL:
 version:


### PR DESCRIPTION
### Context

<!-- Brief description of what problem PR is solving -->

Currently there are multiple places where one needs to keep the golangci-lint up to date / in sync.

The way it's done in this PR there's only one source of truth, and it's available for local setups using mise, asdf, or the like too.

### Changes

<!-- Summary for changes in the code -->

Move golangci-lint version to .tool-versions.