### PR TITLE
fix: skip termenv OSC 11 probe when stdin is not a TTY

### DIFF
--- a/internal/command/lefthook.go
+++ b/internal/command/lefthook.go
@@ -9,11 +9,14 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/knadh/koanf/parsers/json"
 	"github.com/knadh/koanf/providers/rawbytes"
 	"github.com/knadh/koanf/v2"
+	"github.com/muesli/termenv"
 	"github.com/spf13/afero"
 	"github.com/urfave/cli/v3"
+	"golang.org/x/term"
 
 	"github.com/evilmartians/lefthook/v2/internal/config"
 	"github.com/evilmartians/lefthook/v2/internal/git"
@@ -40,6 +43,8 @@ type Lefthook struct {
 
 // NewLefthook returns an instance of Lefthook.
 func NewLefthook(verbose bool, colors string) (*Lefthook, error) {
+	configureRenderer(os.Stdin)
+
 	fs := afero.NewOsFs()
 
 	if isEnvEnabled(EnvVerbose) {
@@ -175,6 +180,16 @@ func (l *Lefthook) addHook(hook string, args templates.Args) error {
 	return afero.WriteFile(
 		l.fs, hookPath, templates.Hook(hook, args), hookFileMode,
 	)
+}
+
+// configureRenderer pins the lipgloss color profile to ANSI when stdin isn't a
+// TTY. Without this, termenv's OSC 11 probe leaks escape sequences in git hooks.
+func configureRenderer(stdin *os.File) {
+	if !term.IsTerminal(int(stdin.Fd())) {
+		r := lipgloss.DefaultRenderer()
+		r.SetColorProfile(termenv.ANSI)
+		r.SetHasDarkBackground(true)
+	}
 }
 
 func isEnvEnabled(name string) bool {

--- a/internal/command/renderer_test.go
+++ b/internal/command/renderer_test.go
@@ -1,0 +1,30 @@
+package command
+
+import (
+	"os"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+func TestConfigureRenderer(t *testing.T) {
+	t.Run("non-TTY stdin forces ANSI profile", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+		defer w.Close()
+
+		// Reset the default renderer to a known state before testing.
+		lipgloss.SetDefaultRenderer(lipgloss.NewRenderer(os.Stdout))
+
+		configureRenderer(r)
+
+		got := lipgloss.DefaultRenderer().ColorProfile()
+		if got != termenv.ANSI {
+			t.Errorf("expected ANSI profile for non-TTY stdin, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
### Context

In git hook contexts stdin is `/dev/null` or a pipe. termenv's OSC 11 background-color probe writes to stdout (a TTY) but reads the response from the same fd. The terminal sends its reply to the input side, where nothing consumes it, so the raw escape sequence leaks to the screen:

```
┃  snag-filter ❯

^[]11;rgb:2020/2020/2020^[\^[[49;1R
```

`NO_COLOR=1` does not help -- that suppresses color output, not terminal probing. `TERM=dumb` works because termenv skips probing entirely.

This is a known termenv bug (https://github.com/muesli/termenv/issues/189) affecting multiple consumers including `gh` CLI. A termenv-level fix would make this workaround deletable, but lefthook should defend itself regardless.

### Changes

`configureRenderer` in `NewLefthook()` checks whether stdin is a TTY. When it is not, it pins the default lipgloss renderer to `termenv.ANSI` with a dark background assumption, which prevents the OSC probe from firing. Colors still render through `CompleteColor` ANSI fallbacks.

This lives in `NewLefthook()` rather than `log.New()` or an `init()` because `NewLefthook()` already owns color configuration and runs once per invocation. Keeping it here avoids import-time side effects and keeps the function testable (it takes `*os.File` so tests can pass a pipe).
