### PR TITLE
chore(golangci-lint): upgrade to 2.11.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golangci-lint 2.10.1
+golangci-lint 2.11.4


### PR DESCRIPTION


### Context

For proper Go 1.26 support.

No new findings to address.

### Changes

<!-- Summary for changes in the code -->

Just the bump.