### PR TITLE
fix: normalize root option to always include trailing slash

### DIFF
--- a/internal/run/controller/filter/filter.go
+++ b/internal/run/controller/filter/filter.go
@@ -187,10 +187,16 @@ func byRoot(vs []string, matcher string) []string {
 		return vs
 	}
 
+	// Ensure matcher ends with a path separator so that
+	// root: "client" and root: "client/" behave identically.
+	if !strings.HasSuffix(matcher, "/") {
+		matcher += "/"
+	}
+
 	vsf := make([]string, 0)
 	for _, v := range vs {
 		if strings.HasPrefix(v, matcher) {
-			vsf = append(vsf, strings.Replace(v, matcher, "./", 1))
+			vsf = append(vsf, "./"+strings.TrimPrefix(v, matcher))
 		}
 	}
 	return vsf

--- a/internal/run/controller/filter/filter_test.go
+++ b/internal/run/controller/filter/filter_test.go
@@ -198,12 +198,12 @@ func TestByRoot(t *testing.T) {
 		{
 			source: []string{"folder/subfolder/0.rb", "subfolder/1.txt", "folder/2.RB", "3.rbs"},
 			path:   "folder",
-			result: []string{".//subfolder/0.rb", ".//2.RB"},
+			result: []string{"./subfolder/0.rb", "./2.RB"},
 		},
 		{
 			source: []string{"folder/subfolder/0.rb", "folder/1.rbs"},
 			path:   "folder/subfolder",
-			result: []string{".//0.rb"},
+			result: []string{"./0.rb"},
 		},
 		{
 			source: []string{"folder/subfolder/0.rb", "folder/1.rbs"},


### PR DESCRIPTION
Fixes #1380

## Problem

When `root` is set without a trailing slash (e.g. `root: "client"`), `byRoot` produces paths with double slashes:

```
root: "client"  → .//src/index.js  (wrong)
root: "client/" → ./src/index.js   (correct)
```

The `strings.Replace(v, matcher, "./", 1)` replaces `"client"` with `"./"` but leaves the `/` separator after it.

## Fix

Normalize the matcher to always end with `"/"` before filtering. Also switch from `strings.Replace` to `strings.TrimPrefix` for clarity.

Updated existing tests to reflect the corrected behavior (no more double slashes).