### PR TITLE
fix: always restore unstaged changes

### DIFF
--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -252,7 +252,33 @@ func (r *Repo) PartiallyStagedFiles() ([]string, error) {
 	return partiallyStaged, nil
 }
 
-func (r *Repo) SaveUnstaged(files []string) error {
+func (r *Repo) SaveUnstagedChanges(files []string) error {
+	stashHash, err := r.Git.Cmd(cmdCreateStash)
+	if err != nil {
+		return err
+	}
+
+	if err = r.saveUnstaged(files); err != nil {
+		return err
+	}
+
+	_, err = r.Git.Cmd([]string{
+		"git",
+		"stash",
+		"store",
+		"--quiet",
+		"--message",
+		stashMessage,
+		stashHash,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Repo) saveUnstaged(files []string) error {
 	_, err := r.Git.BatchedCmd(
 		[]string{
 			"git",
@@ -279,7 +305,7 @@ func (r *Repo) RevertUnstagedChanges(files []string) error {
 	return err
 }
 
-func (r *Repo) RestoreUnstaged() error {
+func (r *Repo) RestoreUnstagedChanges() error {
 	if ok, _ := afero.Exists(r.Fs, r.unstagedPatchPath); !ok {
 		return nil
 	}
@@ -292,7 +318,7 @@ func (r *Repo) RestoreUnstaged() error {
 	if stat.Size() == 0 {
 		err = r.Fs.Remove(r.unstagedPatchPath)
 		if err != nil {
-			return fmt.Errorf("couldn't remove the patch %s: %w", r.unstagedPatchPath, err)
+			return fmt.Errorf("failed to remove the patch %s: %w", r.unstagedPatchPath, err)
 		}
 
 		return nil
@@ -309,40 +335,22 @@ func (r *Repo) RestoreUnstaged() error {
 		r.unstagedPatchPath,
 	})
 	if err != nil {
-		return fmt.Errorf("couldn't apply the patch %s: %w", r.unstagedPatchPath, err)
+		return fmt.Errorf("failed to apply the patch %s: %w", r.unstagedPatchPath, err)
 	}
 
 	err = r.Fs.Remove(r.unstagedPatchPath)
 	if err != nil {
-		return fmt.Errorf("couldn't remove the patch %s: %w", r.unstagedPatchPath, err)
+		return fmt.Errorf("failed to remove the patch %s: %w", r.unstagedPatchPath, err)
+	}
+
+	if err = r.dropUnstagedStash(); err != nil {
+		return fmt.Errorf("failed to remove unstaged files backup: %w", err)
 	}
 
 	return nil
 }
 
-func (r *Repo) StashUnstaged() error {
-	stashHash, err := r.Git.Cmd(cmdCreateStash)
-	if err != nil {
-		return err
-	}
-
-	_, err = r.Git.Cmd([]string{
-		"git",
-		"stash",
-		"store",
-		"--quiet",
-		"--message",
-		stashMessage,
-		stashHash,
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (r *Repo) DropUnstagedStash() error {
+func (r *Repo) dropUnstagedStash() error {
 	lines, err := r.Git.CmdLines(cmdListStash)
 	if err != nil {
 		return err
@@ -437,7 +445,7 @@ func (r *Repo) PrintDiff(files []string) {
 	diffCmd = append(diffCmd, "--")
 	diff, err := r.Git.BatchedCmd(diffCmd, files)
 	if err != nil {
-		r.logger.Warnf("Couldn't diff changed files: %s", err)
+		r.logger.Warnf("Failed to diff changed files: %s", err)
 		return
 	}
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -103,7 +103,7 @@ func (l *Logger) log(level Level, args ...any) {
 	case LevelError:
 		strArgs := make([]string, 0, len(args))
 		for _, arg := range args {
-			strArgs = append(strArgs, fmt.Sprintf("%v", arg))
+			strArgs = append(strArgs, l.Paint(ColorRed, fmt.Sprintf("%v", arg)))
 		}
 
 		message = border.BorderForeground(l.colors.get(ColorRed)).Render(strArgs...)

--- a/internal/run/controller/guard.go
+++ b/internal/run/controller/guard.go
@@ -63,7 +63,7 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 
 	partiallyStagedFiles, err := g.git.PartiallyStagedFiles()
 	if err != nil {
-		g.logger.Warnf("Couldn't find partially staged files: %s\n", err)
+		g.logger.Warnf("Failed to find partially staged files: %s\n", err)
 		return err
 	}
 
@@ -73,13 +73,8 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 
 	g.logger.Debug("[lefthook] saving partially staged files")
 
-	if err := g.git.SaveUnstaged(partiallyStagedFiles); err != nil {
-		g.logger.Warnf("Couldn't save unstaged changes: %s\n", err)
-		return err
-	}
-
-	if err := g.git.StashUnstaged(); err != nil {
-		g.logger.Warnf("Couldn't stash partially staged files: %s\n", err)
+	if err := g.git.SaveUnstagedChanges(partiallyStagedFiles); err != nil {
+		g.logger.Warnf("Failed to save unstaged changes: %s\n", err)
 		return err
 	}
 
@@ -90,28 +85,25 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 		Log()
 
 	if err := g.git.RevertUnstagedChanges(partiallyStagedFiles); err != nil {
-		g.logger.Warnf("Couldn't hide unstaged files: %s\n", err)
+		g.logger.Warnf("Failed to hide unstaged files: %s\n", err)
 		return err
 	}
+
+	defer func() {
+		if err := g.git.RestoreUnstagedChanges(); err != nil {
+			g.logger.Warnf("Failed to restore unstaged files: %s\n", err)
+			return
+		}
+	}()
 
 	wrappedErr := fn()
 
 	var failOnChangesErr *FailOnChangesError
 	if errors.As(wrappedErr, &failOnChangesErr) {
 		if err := g.git.RevertUnstagedChanges(failOnChangesErr.changedFiles); err != nil {
-			g.logger.Warnf("Couldn't hide unstaged files: %s\n", err)
+			g.logger.Warnf("Failed to hide unstaged files: %s\n", err)
 			return wrappedErr
 		}
-	}
-
-	if err := g.git.RestoreUnstaged(); err != nil {
-		g.logger.Warnf("Couldn't restore unstaged files: %s\n", err)
-		return wrappedErr
-	}
-
-	if err := g.git.DropUnstagedStash(); err != nil {
-		g.logger.Warnf("Couldn't remove unstaged files backup: %s\n", err)
-		return wrappedErr
 	}
 
 	return wrappedErr
@@ -125,14 +117,14 @@ func (g *guard) withFailOnChanges(fn func()) error {
 
 	changesetBefore, err := g.git.Changeset()
 	if err != nil {
-		return fmt.Errorf("couldn't calculate changeset: %w", err)
+		return fmt.Errorf("changeset calculation failed: %w", err)
 	}
 
 	fn()
 
 	changesetAfter, err := g.git.Changeset()
 	if err != nil {
-		return fmt.Errorf("couldn't calculate changeset: %w", err)
+		return fmt.Errorf("changeset calculation failed: %w", err)
 	}
 	if !maps.Equal(changesetBefore, changesetAfter) {
 		changedFiles := g.printDiff(changesetBefore, changesetAfter)

--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -85,10 +85,10 @@ func Test_guard_wrap(t *testing.T) {
 			failOnChanges:        false,
 			commands: []cmdtest.Out{
 				{Command: "git status --short --porcelain -z", Output: "AM file1\x00 M file2\x00 A file3\x00"},
+				{Command: "git stash create", Output: "<stash-hash>"},
 				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", Output: ""},
-				{Command: "git stash create", Output: "<stash-hash>"},
 				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git stash list", Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n"},
@@ -100,10 +100,10 @@ func Test_guard_wrap(t *testing.T) {
 			failOnChanges:        true,
 			commands: []cmdtest.Out{
 				{Command: "git status --short --porcelain -z", Output: "AM file1\x00 M file2\x00"},
+				{Command: "git stash create", Output: "<stash-hash>"},
 				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", Output: ""},
-				{Command: "git stash create", Output: "<stash-hash>"},
 				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git status --short --porcelain -z", Output: "A file1\x00"},
@@ -119,10 +119,10 @@ func Test_guard_wrap(t *testing.T) {
 			failOnChangesDiff:    true,
 			commands: []cmdtest.Out{
 				{Command: "git status --short --porcelain -z", Output: "AM file1\x00"},
+				{Command: "git stash create", Output: "<stash-hash>"},
 				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", Output: ""},
-				{Command: "git stash create", Output: "<stash-hash>"},
 				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git status --short --porcelain -z", Output: "A  file1\x00"},


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1369 https://github.com/evilmartians/lefthook/issues/1400

### Context

- Creating a stash when no commit yet fails with bad state of partially staged files.
- Interrupting with Ctrl+c leaves the directory with bad state of partially staged and unstaged files

### Changes

- Ensure restorations are called on interruption (or any other error)
- Try creating the stash first before creating the unstaged diff
