### PR TITLE
fix: try to always restore unstaged changes

### DIFF
--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -45,12 +45,13 @@ var (
 		"--git-path", "info",
 		"--git-dir",
 	}
-	cmdAllFiles     = []string{"git", "ls-files", "--cached"}
-	cmdCreateStash  = []string{"git", "stash", "create"}
-	cmdStageFiles   = []string{"git", "add", "--force", "--"}
-	cmdRemotes      = []string{"git", "branch", "--remotes"}
-	cmdHideUnstaged = []string{"git", "checkout", "--force", "--"}
-	cmdGitVersion   = []string{"git", "version"}
+	cmdAllFiles        = []string{"git", "ls-files", "--cached"}
+	cmdCreateStash     = []string{"git", "stash", "create"}
+	cmdStageFiles      = []string{"git", "add", "--force", "--"}
+	cmdRemotes         = []string{"git", "branch", "--remotes"}
+	cmdHideUnstaged    = []string{"git", "checkout", "--force", "--"}
+	cmdHideAllUnstaged = []string{"git", "checkout", "."}
+	cmdGitVersion      = []string{"git", "version"}
 )
 
 // Repo represents a git repository.
@@ -305,6 +306,44 @@ func (r *Repo) RevertUnstagedChanges(files []string) error {
 	return err
 }
 
+func (r *Repo) RevertAllUnstagedChanges() error {
+	_, err := r.Git.Cmd(cmdHideAllUnstaged)
+
+	return err
+}
+
+// CanRestoreUnstagedChanges checks is a patch with previously unstaged changes
+// can be applied to the current worktree.
+func (r *Repo) CanRestoreUnstagedChanges() bool {
+	if ok, _ := afero.Exists(r.Fs, r.unstagedPatchPath); !ok {
+		return true
+	}
+
+	stat, err := r.Fs.Stat(r.unstagedPatchPath)
+	if err != nil {
+		return true
+	}
+
+	if stat.Size() == 0 {
+		return true
+	}
+
+	_, err = r.Git.Cmd([]string{
+		"git",
+		"apply",
+		"-v",
+		"--whitespace=nowarn",
+		"--recount",
+		"--unidiff-zero",
+		"--check",
+		"--",
+		r.unstagedPatchPath,
+	})
+
+	return err == nil
+}
+
+// RestoreUnstagedChanges applies the patch with previously unstaged changes.
 func (r *Repo) RestoreUnstagedChanges() error {
 	if ok, _ := afero.Exists(r.Fs, r.unstagedPatchPath); !ok {
 		return nil

--- a/internal/run/controller/guard.go
+++ b/internal/run/controller/guard.go
@@ -9,6 +9,8 @@ import (
 	"github.com/evilmartians/lefthook/v2/internal/logger"
 )
 
+var errRestorationConflict = errors.New("conflict while merging unstaged changes")
+
 type FailOnChangesError struct {
 	changedFiles []string
 }
@@ -85,25 +87,42 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 		Log()
 
 	if err := g.git.RevertUnstagedChanges(partiallyStagedFiles); err != nil {
-		g.logger.Warnf("Failed to hide unstaged files: %s\n", err)
+		g.logger.Warnf("Failed to hide unstaged files: %s", err)
 		return err
 	}
-
-	defer func() {
-		if err := g.git.RestoreUnstagedChanges(); err != nil {
-			g.logger.Warnf("Failed to restore unstaged files: %s\n", err)
-			return
-		}
-	}()
 
 	wrappedErr := fn()
 
 	var failOnChangesErr *FailOnChangesError
 	if errors.As(wrappedErr, &failOnChangesErr) {
 		if err := g.git.RevertUnstagedChanges(failOnChangesErr.changedFiles); err != nil {
-			g.logger.Warnf("Failed to hide unstaged files: %s\n", err)
+			g.logger.Warnf("Failed to revert file changes: %s", err)
 			return wrappedErr
 		}
+	}
+
+	if !g.git.CanRestoreUnstagedChanges() {
+		if wrappedErr != nil {
+			g.logger.Error("Error: ", wrappedErr)
+		}
+		wrappedErr = errRestorationConflict
+
+		if err := g.git.RevertAllUnstagedChanges(); err != nil {
+			g.logger.Warnf("Failed to restore initial worktree state: %s", err)
+			return err
+		}
+
+		logger.NewBuilder(g.logger).
+			WithLevel(logger.LevelWarn).
+			WriteLines("", "Unable to restore previously hidden unstaged changes.").
+			WriteLines("", "This may happen when changes introduced by the hook conflict with your unstaged changes.").
+			WriteLines("", "Stage all changes with `git add -A` and try again.").
+			Log()
+	}
+
+	if err := g.git.RestoreUnstagedChanges(); err != nil {
+		g.logger.Warnf("Failed to restore unstaged files: %s", err)
+		return err
 	}
 
 	return wrappedErr

--- a/tests/integration/restore_unstaged.txt
+++ b/tests/integration/restore_unstaged.txt
@@ -1,0 +1,35 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec lefthook install
+exec git add -A
+exec git commit -m 'initial'
+
+# Stage first change
+exec echo lineStaged
+cp stdout a.txt
+exec git add -A
+exec echo lineUnstaged
+cp stdout a.txt
+
+# Change that line in the hook
+exec git commit -m 'test'
+
+# Must successfully apply the hook
+! grep lineStaged a.txt
+grep lineUnstaged a.txt
+grep lineNew a.txt
+grep lineNew b.txt
+
+-- lefthook.yml --
+pre-commit:
+  jobs:
+    - run: echo "lineNew" >> a.txt
+    - run: echo "lineNew" > b.txt
+
+-- a.txt --
+line
+
+-- b.txt --
+lineCommitted
+

--- a/tests/integration/restore_unstaged_on_conflict.txt
+++ b/tests/integration/restore_unstaged_on_conflict.txt
@@ -1,0 +1,44 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec lefthook install
+exec git add -A
+exec git commit -m 'initial'
+
+# Stage first change
+exec echo "line1\nlineStaged\nline3\n"
+cp stdout a.txt
+grep lineStaged a.txt
+exec git add a.txt
+
+# Add unstaged change on same line
+exec echo "line1\nlineUnstaged\nline3\n"
+cp stdout a.txt
+grep lineUnstaged a.txt
+
+# Change that line in the hook
+! exec git commit -m 'test'
+
+# Must restore the state before running the hook
+grep lineUnstaged a.txt
+! grep line42 a.txt
+grep lineCommitted b.txt
+
+stderr '\s*conflict while merging unstaged changes\s*'
+
+-- lefthook.yml --
+pre-commit:
+  jobs:
+    - run: sed -i '' 's/lineStaged/line42/' a.txt
+    - run: sed -i '' 's/lineCommited/line42/' b.txt
+
+-- a.txt --
+line1
+line2
+line3
+
+-- b.txt --
+line1
+lineCommitted
+line3
+

--- a/tests/integration/restore_unstaged_on_conflict.txt
+++ b/tests/integration/restore_unstaged_on_conflict.txt
@@ -29,8 +29,8 @@ stderr '\s*conflict while merging unstaged changes\s*'
 -- lefthook.yml --
 pre-commit:
   jobs:
-    - run: sed -i '' 's/lineStaged/line42/' a.txt
-    - run: sed -i '' 's/lineCommited/line42/' b.txt
+    - run: echo "line1\nline42\nline3\n" > a.txt
+    - run: echo "line1\nline42\nline3\n" > b.txt
 
 -- a.txt --
 line1


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1369 https://github.com/evilmartians/lefthook/issues/1400

### Context

If we can't restore previously unstaged files – we must try to revert the current changes and bring back the state that was before running the hook. 

There can be issues if `staged_fixed: true` is enabled, since it auto-adds the changes.

### Changes

Show warning and fail the hook when can't restore previously hidden unstaged changes

```
│  Unable to restore previously hidden unstaged changes.
│  This may happen when changes introduced by the hook conflict with your unstaged changes.
│  Stage all changes with `git add -A` and try again.
Error: failed to run the hook: conflict while merging unstaged changes
```
