### PR TITLE
fix: apply stage_fixed only if it is safe

### DIFF
--- a/internal/run/controller/controller.go
+++ b/internal/run/controller/controller.go
@@ -19,12 +19,13 @@ import (
 )
 
 type Controller struct {
-	git         *git.Repo
-	logger      *logger.ExecutionLogger
-	cachedStdin io.Reader
-	executor    exec.Executor
-	cmd         system.CommandWithContext
-	skipChecker *config.SkipChecker
+	git             *git.Repo
+	logger          *logger.ExecutionLogger
+	cachedStdin     io.Reader
+	executor        exec.Executor
+	cmd             system.CommandWithContext
+	skipChecker     *config.SkipChecker
+	stageFixedFiles *stageFixedFiles
 }
 
 type Options struct {
@@ -59,7 +60,8 @@ func NewController(repo *git.Repo, logger *logger.ExecutionLogger) *Controller {
 		// Command interface (for LFS hooks)
 		cmd: system.Cmd,
 
-		skipChecker: config.NewSkipChecker(logger, system.Cmd),
+		skipChecker:     config.NewSkipChecker(logger, system.Cmd),
+		stageFixedFiles: newStageFixedFiles(),
 	}
 }
 
@@ -89,6 +91,7 @@ func (c *Controller) RunHook(ctx context.Context, opts Options, hook *config.Hoo
 	guard := newGuard(
 		c.git,
 		c.logger,
+		c.stageFixedFiles,
 		!opts.NoStageFixed && config.HookUsesStagedFiles(hook.Name),
 		opts.FailOnChanges,
 		opts.FailOnChangesDiff,

--- a/internal/run/controller/controller.go
+++ b/internal/run/controller/controller.go
@@ -19,13 +19,13 @@ import (
 )
 
 type Controller struct {
-	git             *git.Repo
-	logger          *logger.ExecutionLogger
-	cachedStdin     io.Reader
-	executor        exec.Executor
-	cmd             system.CommandWithContext
-	skipChecker     *config.SkipChecker
-	stageFixedFiles *stageFixedFiles
+	git          *git.Repo
+	logger       *logger.ExecutionLogger
+	cachedStdin  io.Reader
+	executor     exec.Executor
+	cmd          system.CommandWithContext
+	skipChecker  *config.SkipChecker
+	filesToStage *stageFilesList
 }
 
 type Options struct {
@@ -60,8 +60,8 @@ func NewController(repo *git.Repo, logger *logger.ExecutionLogger) *Controller {
 		// Command interface (for LFS hooks)
 		cmd: system.Cmd,
 
-		skipChecker:     config.NewSkipChecker(logger, system.Cmd),
-		stageFixedFiles: newStageFixedFiles(),
+		skipChecker:  config.NewSkipChecker(logger, system.Cmd),
+		filesToStage: newStageFilesList(),
 	}
 }
 
@@ -91,7 +91,7 @@ func (c *Controller) RunHook(ctx context.Context, opts Options, hook *config.Hoo
 	guard := newGuard(
 		c.git,
 		c.logger,
-		c.stageFixedFiles,
+		c.filesToStage,
 		!opts.NoStageFixed && config.HookUsesStagedFiles(hook.Name),
 		opts.FailOnChanges,
 		opts.FailOnChangesDiff,

--- a/internal/run/controller/controller_test.go
+++ b/internal/run/controller/controller_test.go
@@ -469,8 +469,7 @@ func TestRunAll(t *testing.T) {
 			gitCommands: []string{
 				"git status --short",
 				"git diff --name-only --cached --diff-filter=ACMR",
-				"git add --force -- .*script.sh.*README.md",
-				"git add --force -- .*script.sh.*README.md",
+				"git add --force -- (.*README.md.*script.sh|.*script.sh.*README.md)",
 			},
 		},
 		"with pre-commit skip": {
@@ -495,8 +494,8 @@ func TestRunAll(t *testing.T) {
 			gitCommands: []string{
 				"git status --short",
 				"git diff --name-only --cached --diff-filter=ACMR",
-				"git add --force -- .*README.md",
 				"git diff --name-only --cached --diff-filter=ACMRD",
+				"git add --force -- .*README.md",
 			},
 		},
 		"with pre-commit skip but forced": {
@@ -610,10 +609,11 @@ func TestRunAll(t *testing.T) {
 			Fs(fs).
 			Build()
 		controller := &Controller{
-			logger:   loggertest.NewExecution(),
-			git:      repo,
-			executor: executor{},
-			cmd:      cmdtest.NewTracking(nil), // lfs hooks ignored in this test
+			logger:          loggertest.NewExecution(),
+			stageFixedFiles: newStageFixedFiles(),
+			git:             repo,
+			executor:        executor{},
+			cmd:             cmdtest.NewTracking(nil), // lfs hooks ignored in this test
 		}
 		cmdExecutor.Reset()
 

--- a/internal/run/controller/controller_test.go
+++ b/internal/run/controller/controller_test.go
@@ -609,11 +609,11 @@ func TestRunAll(t *testing.T) {
 			Fs(fs).
 			Build()
 		controller := &Controller{
-			logger:          loggertest.NewExecution(),
-			stageFixedFiles: newStageFixedFiles(),
-			git:             repo,
-			executor:        executor{},
-			cmd:             cmdtest.NewTracking(nil), // lfs hooks ignored in this test
+			logger:       loggertest.NewExecution(),
+			filesToStage: newStageFilesList(),
+			git:          repo,
+			executor:     executor{},
+			cmd:          cmdtest.NewTracking(nil), // lfs hooks ignored in this test
 		}
 		cmdExecutor.Reset()
 

--- a/internal/run/controller/guard.go
+++ b/internal/run/controller/guard.go
@@ -20,8 +20,9 @@ func (e *FailOnChangesError) Error() string {
 }
 
 type guard struct {
-	git    *git.Repo
-	logger *logger.ExecutionLogger
+	git             *git.Repo
+	logger          *logger.ExecutionLogger
+	stageFixedFiles *stageFixedFiles
 
 	stashUnstagedChanges bool
 	failOnChanges        bool
@@ -31,6 +32,7 @@ type guard struct {
 func newGuard(
 	repo *git.Repo,
 	logger *logger.ExecutionLogger,
+	stageFixedFiles *stageFixedFiles,
 	stashUnstagedChanges bool,
 	failOnChanges bool,
 	failOnChangesDiff bool,
@@ -39,6 +41,7 @@ func newGuard(
 		git:                  repo,
 		logger:               logger,
 		stashUnstagedChanges: stashUnstagedChanges,
+		stageFixedFiles:      stageFixedFiles,
 		failOnChanges:        failOnChanges,
 		failOnChangesDiff:    failOnChangesDiff,
 	}
@@ -70,7 +73,13 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 	}
 
 	if len(partiallyStagedFiles) == 0 {
-		return fn()
+		resErr := fn()
+
+		if err := g.git.AddFiles(g.stageFixedFiles.Files()); err != nil {
+			g.logger.Warn("Couldn't stage fixed files:", err)
+		}
+
+		return resErr
 	}
 
 	g.logger.Debug("[lefthook] saving partially staged files")
@@ -101,7 +110,11 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 		}
 	}
 
-	if !g.git.CanRestoreUnstagedChanges() {
+	if g.git.CanRestoreUnstagedChanges() {
+		if err := g.git.AddFiles(g.stageFixedFiles.Files()); err != nil {
+			g.logger.Warn("Couldn't stage fixed files:", err)
+		}
+	} else {
 		if wrappedErr != nil {
 			g.logger.Error("Error: ", wrappedErr)
 		}

--- a/internal/run/controller/guard.go
+++ b/internal/run/controller/guard.go
@@ -20,9 +20,9 @@ func (e *FailOnChangesError) Error() string {
 }
 
 type guard struct {
-	git             *git.Repo
-	logger          *logger.ExecutionLogger
-	stageFixedFiles *stageFixedFiles
+	git          *git.Repo
+	logger       *logger.ExecutionLogger
+	filesToStage *stageFilesList
 
 	stashUnstagedChanges bool
 	failOnChanges        bool
@@ -32,7 +32,7 @@ type guard struct {
 func newGuard(
 	repo *git.Repo,
 	logger *logger.ExecutionLogger,
-	stageFixedFiles *stageFixedFiles,
+	filesToStage *stageFilesList,
 	stashUnstagedChanges bool,
 	failOnChanges bool,
 	failOnChangesDiff bool,
@@ -41,7 +41,7 @@ func newGuard(
 		git:                  repo,
 		logger:               logger,
 		stashUnstagedChanges: stashUnstagedChanges,
-		stageFixedFiles:      stageFixedFiles,
+		filesToStage:         filesToStage,
 		failOnChanges:        failOnChanges,
 		failOnChangesDiff:    failOnChangesDiff,
 	}
@@ -61,6 +61,10 @@ func (g *guard) wrap(fn func()) error {
 	)
 }
 
+// withHiddenUnstagedChanges hides unstaged changes, runs `fn()`, then restores them.
+//
+// If the changes can't be restored, the hook changes are reverted and you'll be
+// prompted to stage your changes first — to avoid any risk of losing them.
 func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 	if !g.stashUnstagedChanges {
 		return fn()
@@ -75,7 +79,7 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 	if len(partiallyStagedFiles) == 0 {
 		resErr := fn()
 
-		if err := g.git.AddFiles(g.stageFixedFiles.Files()); err != nil {
+		if err := g.git.AddFiles(g.filesToStage.Files()); err != nil {
 			g.logger.Warn("Couldn't stage fixed files:", err)
 		}
 
@@ -111,7 +115,7 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 	}
 
 	if g.git.CanRestoreUnstagedChanges() {
-		if err := g.git.AddFiles(g.stageFixedFiles.Files()); err != nil {
+		if err := g.git.AddFiles(g.filesToStage.Files()); err != nil {
 			g.logger.Warn("Couldn't stage fixed files:", err)
 		}
 	} else {

--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -195,7 +195,14 @@ func Test_guard_wrap(t *testing.T) {
 				Root("root").
 				Build()
 			repo.ResetCache()
-			g := newGuard(repo, loggertest.NewExecution(), tt.stashUnstagedChanges, tt.failOnChanges, tt.failOnChangesDiff)
+			g := newGuard(
+				repo,
+				loggertest.NewExecution(),
+				newStageFixedFiles(),
+				tt.stashUnstagedChanges,
+				tt.failOnChanges,
+				tt.failOnChangesDiff,
+			)
 
 			var beenCalled bool
 			err := g.wrap(func() { beenCalled = true })

--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -198,7 +198,7 @@ func Test_guard_wrap(t *testing.T) {
 			g := newGuard(
 				repo,
 				loggertest.NewExecution(),
-				newStageFixedFiles(),
+				newStageFilesList(),
 				tt.stashUnstagedChanges,
 				tt.failOnChanges,
 				tt.failOnChangesDiff,

--- a/internal/run/controller/job.go
+++ b/internal/run/controller/job.go
@@ -183,7 +183,7 @@ func (c *Controller) runSingleJob(ctx context.Context, scope *scope, id string, 
 }
 
 func (c *Controller) addStagedFiles(files []string) {
-	c.stageFixedFiles.Add(files)
+	c.filesToStage.Add(files)
 }
 
 func (c *Controller) skipReason(scope *scope, job *config.Job, name string) string {

--- a/internal/run/controller/job.go
+++ b/internal/run/controller/job.go
@@ -183,9 +183,7 @@ func (c *Controller) runSingleJob(ctx context.Context, scope *scope, id string, 
 }
 
 func (c *Controller) addStagedFiles(files []string) {
-	if err := c.git.AddFiles(files); err != nil {
-		c.logger.Warn("Couldn't stage fixed files:", err)
-	}
+	c.stageFixedFiles.Add(files)
 }
 
 func (c *Controller) skipReason(scope *scope, job *config.Job, name string) string {

--- a/internal/run/controller/stage_files_list.go
+++ b/internal/run/controller/stage_files_list.go
@@ -2,18 +2,18 @@ package controller
 
 import "sync"
 
-type stageFixedFiles struct {
+type stageFilesList struct {
 	mu    sync.Mutex
 	files map[string]struct{}
 }
 
-func newStageFixedFiles() *stageFixedFiles {
-	return &stageFixedFiles{
+func newStageFilesList() *stageFilesList {
+	return &stageFilesList{
 		files: make(map[string]struct{}),
 	}
 }
 
-func (f *stageFixedFiles) Add(files []string) {
+func (f *stageFilesList) Add(files []string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -22,7 +22,7 @@ func (f *stageFixedFiles) Add(files []string) {
 	}
 }
 
-func (f *stageFixedFiles) Files() []string {
+func (f *stageFilesList) Files() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/internal/run/controller/stage_fixed.go
+++ b/internal/run/controller/stage_fixed.go
@@ -1,0 +1,36 @@
+package controller
+
+import "sync"
+
+type stageFixedFiles struct {
+	mu    sync.Mutex
+	files map[string]struct{}
+}
+
+func newStageFixedFiles() *stageFixedFiles {
+	return &stageFixedFiles{
+		files: make(map[string]struct{}),
+	}
+}
+
+func (f *stageFixedFiles) Add(files []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for _, file := range files {
+		f.files[file] = struct{}{}
+	}
+}
+
+func (f *stageFixedFiles) Files() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	result := make([]string, 0, len(f.files))
+
+	for file := range f.files {
+		result = append(result, file)
+	}
+
+	return result
+}

--- a/tests/integration/restore_unstaged_on_conflict_with_stage_fixed.txt
+++ b/tests/integration/restore_unstaged_on_conflict_with_stage_fixed.txt
@@ -1,0 +1,49 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec lefthook install
+exec git add -A
+exec git commit -m 'initial'
+
+# Stage first change
+exec echo "line1\nlineStaged\nline3\n"
+cp stdout a.txt
+grep lineStaged a.txt
+exec git add a.txt
+
+# Add unstaged change on same line
+exec echo "line1\nlineUnstaged\nline3\n"
+cp stdout a.txt
+grep lineUnstaged a.txt
+
+# Change that line in the hook
+! exec git commit -m 'test'
+
+# Must restore the state before running the hook
+grep lineUnstaged a.txt
+! grep line42 a.txt
+
+# Not restoring files that were changed accidentally
+grep line42 b.txt
+
+stderr '\s*conflict while merging unstaged changes\s*'
+
+-- lefthook.yml --
+pre-commit:
+  parallel: true
+  jobs:
+    - run: echo "line1\nline42\nline3\n" > a.txt
+      stage_fixed: true
+    - run: echo "line1\nline42\nline3\n" > b.txt
+      stage_fixed: true
+
+-- a.txt --
+line1
+line2
+line3
+
+-- b.txt --
+line1
+lineCommitted
+line3
+


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1400

### Context

Before adding files due to `stage_fixed: true` we must check if restoring unstaged changes is applicable. If not – revert the state to what it was before the hook and fail.

### Changes

- [x] Implement applying only if it's safe to restore unstaged changes
- [x] Add tests
- [x] Find a better name for `stageFixedFiles` type
