### PR TITLE
fix: use contrast colors

### DIFF
--- a/internal/logger/colors.go
+++ b/internal/logger/colors.go
@@ -64,6 +64,10 @@ var NoColors ColorsSetting = ColorsSetting{
 }
 
 func (l *Logger) SetColors(colors map[Color]color.Color) {
+	if l.colorsForced {
+		return
+	}
+
 	for color, existingValue := range l.colors.colors {
 		if _, ok := colors[color]; !ok {
 			colors[color] = existingValue
@@ -74,14 +78,25 @@ func (l *Logger) SetColors(colors map[Color]color.Color) {
 		kind:   colorsCustom,
 		colors: colors,
 	}
+	l.colorsForced = true
 }
 
 func (l *Logger) EnableColors() {
+	if l.colorsForced {
+		return
+	}
+
 	l.colors = DefaultColors
+	l.colorsForced = true
 }
 
 func (l *Logger) DisableColors() {
+	if l.colorsForced {
+		return
+	}
+
 	l.colors = NoColors
+	l.colorsForced = true
 }
 
 func (l *Logger) Paint(color Color, s string) string {

--- a/internal/logger/colors.go
+++ b/internal/logger/colors.go
@@ -48,7 +48,7 @@ var DefaultColors ColorsSetting = ColorsSetting{
 		ColorGray:   complete(lipgloss.Color("8"), lipgloss.Color("102"), lipgloss.Color("#878787")),
 		ColorGreen:  complete(lipgloss.Color("2"), lipgloss.Color("34"), lipgloss.Color("#00AF00")),
 		ColorRed:    complete(lipgloss.Color("9"), lipgloss.Color("203"), lipgloss.Color("#FF5F5F")),
-		ColorYellow: complete(lipgloss.Color("11"), lipgloss.Color("220"), lipgloss.Color("#FFD700")),
+		ColorYellow: complete(lipgloss.Color("3"), lipgloss.Color("3"), lipgloss.Color("#808000")),
 	},
 }
 

--- a/internal/logger/execution_logger.go
+++ b/internal/logger/execution_logger.go
@@ -99,7 +99,7 @@ func (el *ExecutionLogger) LogSkipped(name, reason string) {
 			BorderForeground(el.Logger.colors.get(ColorCyan)).
 			PaddingLeft(padding).
 			Render(
-				el.Paint(ColorCyan, lipgloss.NewStyle().Bold(true).Render(name)) + " " +
+				el.Paint(ColorCyan, name) + " " +
 					el.Paint(ColorGray, "(skip)") + " " +
 					el.Paint(ColorYellow, reason),
 			),
@@ -172,7 +172,7 @@ func (el *ExecutionLogger) LogSetup(r io.Reader) {
 				BorderStyle(lipgloss.ThickBorder()).
 				BorderLeft(true).
 				BorderForeground(el.Logger.colors.get(ColorYellow)).
-				Padding(padding).
+				PaddingLeft(padding).
 				Render(el.Paint(ColorYellow, "setup ❯ ")),
 		)
 

--- a/internal/logger/execution_logger.go
+++ b/internal/logger/execution_logger.go
@@ -95,7 +95,7 @@ func (el *ExecutionLogger) LogSkipped(name, reason string) {
 	el.Info(
 		lipgloss.NewStyle().
 			BorderLeft(true).
-			BorderStyle(lipgloss.ThickBorder()).
+			BorderStyle(lipgloss.NormalBorder()).
 			BorderForeground(el.Logger.colors.get(ColorCyan)).
 			PaddingLeft(padding).
 			Render(
@@ -109,12 +109,8 @@ func (el *ExecutionLogger) LogSkipped(name, reason string) {
 func (el *ExecutionLogger) LogSeparator() {
 	el.log(LevelInfo,
 		lipgloss.NewStyle().
-			BorderStyle(lipgloss.NormalBorder()).
-			BorderTop(true).
-			BorderForeground(colorBorder).
-			Width(separatorWidth).
-			MarginLeft(separatorMargin).
-			Render(""),
+			Foreground(colorBorder).
+			Render("  "+strings.Repeat("─", separatorWidth)),
 	)
 }
 
@@ -156,7 +152,7 @@ func (el *ExecutionLogger) LogExecution(name string, err error, out io.Reader) {
 	}
 
 	if err != nil {
-		el.Infof("%s", err)
+		el.Info(el.Paint(ColorRed, err.Error()))
 	}
 }
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -32,10 +32,11 @@ var border = lipgloss.NewStyle().
 	PaddingLeft(2) //nolint:mnd
 
 type Logger struct {
-	mu     sync.Mutex
-	level  Level
-	out    io.Writer
-	colors ColorsSetting
+	mu           sync.Mutex
+	level        Level
+	out          io.Writer
+	colors       ColorsSetting
+	colorsForced bool
 
 	Spinner *Spinner
 }


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1404

### Changes

- Use simple ANSI colors with high contrast, not too bright.
- Remove extra whitespaces
