### PR TITLE
fix: do not warn if local hooks path is equal to default hooks path

### DIFF
--- a/internal/command/install.go
+++ b/internal/command/install.go
@@ -493,8 +493,10 @@ func (l *Lefthook) getHooksPathConfig() (local, global string) {
 // Local hooks make sense only in terms of migratio from other hook managers.
 func (l *Lefthook) ensureHooksPathUnset(force, resetHooksPath bool) error {
 	local, global := l.getHooksPathConfig()
+	defaultHooksPath := filepath.Join(l.repo.RootPath, ".git", "hooks")
 
-	hasLocal := len(local) > 0
+	// Ignore if hooks path is equal to default git hooks path
+	hasLocal := len(local) > 0 && filepath.Clean(local) != filepath.Clean(defaultHooksPath)
 	hasGlobal := len(global) > 0
 
 	if !hasLocal && !hasGlobal {
@@ -503,7 +505,8 @@ func (l *Lefthook) ensureHooksPathUnset(force, resetHooksPath bool) error {
 
 	// If neither force nor resetHooksPath, returns an error with instructions.
 	if !force && !resetHooksPath {
-		return formatHooksPathError(local, global)
+		l.logger.Error(formatHooksPathError(local, global))
+		return errors.New("") // empty error since we already log message
 	}
 
 	if hasLocal {
@@ -528,7 +531,7 @@ func (l *Lefthook) ensureHooksPathUnset(force, resetHooksPath bool) error {
 }
 
 // formatHooksPathError formats an error message for core.hooksPath conflicts.
-func formatHooksPathError(local, global string) error {
+func formatHooksPathError(local, global string) string {
 	var errMsg strings.Builder
 	var hints []string
 	hasLocal := len(local) > 0
@@ -536,27 +539,33 @@ func formatHooksPathError(local, global string) error {
 
 	if hasLocal {
 		fmt.Fprintf(&errMsg, "core.hooksPath is set locally to '%s'\n", local)
-		hints = append(hints, "hint:   git config --unset-all --local core.hooksPath")
+		hints = append(hints, "   git config --unset-all --local core.hooksPath")
 	}
 	if hasGlobal {
 		fmt.Fprintf(&errMsg, "core.hooksPath is set globally to '%s'\n", global)
-		hints = append(hints, "hint:   git config --unset-all --global core.hooksPath")
+		hints = append(hints, "   git config --unset-all --global core.hooksPath")
 	}
+	errMsg.WriteString("Custom hooks paths are not supported by default.\n")
 	errMsg.WriteString("\n")
-	errMsg.WriteString("hint: Unset it:\n")
+	errMsg.WriteString("Reset core.hooksPath automatically:\n")
+	errMsg.WriteString("  lefthook install --reset-hooks-path\n")
+	errMsg.WriteString("\n")
+	errMsg.WriteString("Remove it manually:\n")
 	errMsg.WriteString(strings.Join(hints, "\n"))
-	errMsg.WriteString("\nhint:\n")
-	errMsg.WriteString("hint: Run 'lefthook install --reset-hooks-path' to automatically unset it.\n")
+	errMsg.WriteString("\n\n")
 
 	// Determine path: use global path if only global is defined, otherwise use local path
 	path := local
 	if !hasLocal && hasGlobal {
 		path = global
 	}
-	errMsg.WriteString("hint:\n")
-	fmt.Fprintf(&errMsg, "hint: Run 'lefthook install --force' to install hooks anyway in '%s'.", path)
+	errMsg.WriteString("Force installation into current hooks path:\n")
+	errMsg.WriteString("  lefthook install --force\n\n")
+	errMsg.WriteString("  Target:\n")
+	errMsg.WriteString("  ")
+	errMsg.WriteString(path)
 
-	return errors.New(errMsg.String())
+	return errMsg.String()
 }
 
 // unsetHooksPathConfig removes core.hooksPath configuration.

--- a/internal/command/install_test.go
+++ b/internal/command/install_test.go
@@ -825,7 +825,7 @@ pre-commit:
 				},
 			},
 			wantError:    true,
-			wantErrorMsg: "core.hooksPath",
+			wantErrorMsg: "", // empty
 		},
 		{
 			name:           "with local and global core.hooksPath with --force",
@@ -945,8 +945,8 @@ pre-commit:
 			// Do install
 			err := lefthook.Install(t.Context(), InstallArgs{Force: tt.force, ResetHooksPath: tt.resetHooksPath}, nil)
 			if tt.wantError {
-				if assert.Error(err) && tt.wantErrorMsg != "" {
-					assert.Contains(err.Error(), tt.wantErrorMsg)
+				if assert.Error(err) {
+					assert.Equal(err.Error(), tt.wantErrorMsg)
 				}
 			} else {
 				assert.NoError(err)


### PR DESCRIPTION
### Context

Fix a small edge case when local `core.hooksPath` is equal to the default git hooks path.

### Changes

- [x] Fix error message (make it prettier)
- [x] Do not fail installation if `core.hooksPath` is equal to default git hooks path location
