### PR TITLE
fix: update hooks path after resetting

### DIFF
--- a/internal/command/install.go
+++ b/internal/command/install.go
@@ -584,6 +584,13 @@ func (l *Lefthook) unsetHooksPathConfig(local, global string) error {
 		l.logger.Warn("global core.hooksPath has been unset.")
 	}
 
+	paths, err := git.Paths(l.repo.Git)
+	if err != nil {
+		return err
+	}
+
+	l.repo.HooksPath = paths.HooksPath
+
 	return nil
 }
 

--- a/internal/command/install_test.go
+++ b/internal/command/install_test.go
@@ -867,6 +867,10 @@ pre-commit:
 				{
 					Command: "git config --global --unset-all core.hooksPath",
 				},
+				{
+					Command: "git rev-parse --path-format=absolute --show-toplevel --git-path hooks --git-path info --git-dir",
+					Output:  "a\n" + filepath.Join(gittest.GitPath(root), "hooks") + "\na\na",
+				},
 			},
 			wantError: false,
 			wantExist: []string{
@@ -911,6 +915,10 @@ pre-commit:
 				},
 				{
 					Command: "git config --local --unset-all core.hooksPath",
+				},
+				{
+					Command: "git rev-parse --path-format=absolute --show-toplevel --git-path hooks --git-path info --git-dir",
+					Output:  "a\n" + filepath.Join(gittest.GitPath(root), "hooks") + "\na\na",
 				},
 			},
 			wantError: false,

--- a/internal/git/paths.go
+++ b/internal/git/paths.go
@@ -1,0 +1,37 @@
+package git
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+var cmdPaths = []string{
+	"git", "rev-parse", "--path-format=absolute",
+	"--show-toplevel",
+	"--git-path", "hooks",
+	"--git-path", "info",
+	"--git-dir",
+}
+
+type GitPaths struct {
+	RootPath  string
+	HooksPath string
+	InfoPath  string
+	GitPath   string
+}
+
+func Paths(commander *Commander) (*GitPaths, error) {
+	paths, err := commander.Cmd(cmdPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	pathsSplit := strings.Split(paths, "\n")
+
+	return &GitPaths{
+		RootPath:  pathsSplit[0],
+		HooksPath: pathsSplit[1],
+		InfoPath:  filepath.Clean(pathsSplit[2]),
+		GitPath:   pathsSplit[3],
+	}, nil
+}

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -38,20 +38,13 @@ var (
 	cmdStagedFilesWithDeleted = []string{"git", "diff", "--name-only", "--cached", "--diff-filter=ACMRD"}
 	cmdStatusShort            = []string{"git", "status", "--short", "--porcelain", "-z"}
 	cmdListStash              = []string{"git", "stash", "list"}
-	cmdPaths                  = []string{
-		"git", "rev-parse", "--path-format=absolute",
-		"--show-toplevel",
-		"--git-path", "hooks",
-		"--git-path", "info",
-		"--git-dir",
-	}
-	cmdAllFiles        = []string{"git", "ls-files", "--cached"}
-	cmdCreateStash     = []string{"git", "stash", "create"}
-	cmdStageFiles      = []string{"git", "add", "--force", "--"}
-	cmdRemotes         = []string{"git", "branch", "--remotes"}
-	cmdHideUnstaged    = []string{"git", "checkout", "--force", "--"}
-	cmdHideAllUnstaged = []string{"git", "checkout", "."}
-	cmdGitVersion      = []string{"git", "version"}
+	cmdAllFiles               = []string{"git", "ls-files", "--cached"}
+	cmdCreateStash            = []string{"git", "stash", "create"}
+	cmdStageFiles             = []string{"git", "add", "--force", "--"}
+	cmdRemotes                = []string{"git", "branch", "--remotes"}
+	cmdHideUnstaged           = []string{"git", "checkout", "--force", "--"}
+	cmdHideAllUnstaged        = []string{"git", "checkout", "."}
+	cmdGitVersion             = []string{"git", "version"}
 )
 
 // Repo represents a git repository.
@@ -92,16 +85,15 @@ func NewRepo(
 		}
 	}
 
-	paths, err := commander.Cmd(cmdPaths)
+	paths, err := Paths(commander)
 	if err != nil {
 		return nil, err
 	}
 
-	pathsSplit := strings.Split(paths, "\n")
-	rootPath := pathsSplit[0]
-	hooksPath := pathsSplit[1]
-	infoPath := filepath.Clean(pathsSplit[2])
-	gitPath := pathsSplit[3]
+	rootPath := paths.RootPath
+	hooksPath := paths.HooksPath
+	infoPath := paths.InfoPath
+	gitPath := paths.GitPath
 
 	if exists, _ := afero.DirExists(fs, infoPath); !exists {
 		err = fs.Mkdir(infoPath, infoDirMode)

--- a/tests/integration/install_reset_hooks_path_issue_1429.txt
+++ b/tests/integration/install_reset_hooks_path_issue_1429.txt
@@ -1,0 +1,15 @@
+exec git init
+
+exec git config --local core.hooksPath /different-path
+
+! exec lefthook install
+exec lefthook install --reset-hooks-path
+! stderr .
+
+exists .git/hooks/pre-commit
+! exists .git/hooks/pre-push
+
+-- lefthook.yml --
+pre-commit:
+  jobs:
+    - run: echo


### PR DESCRIPTION
Closes https://github.com/evilmartians/lefthook/issues/1429

### Context

Lefthook resets hooks path, but doesn't cleanup the cache after that and installs hooks to the wrong place.

### Changes

Requery hooks path and reset the cached value.