### PR TITLE
deps: migrate shellescape to al.essio.dev/pkg/shellescape

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 )
 
 require (
-	github.com/alessio/shellescape v1.4.1
+	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
+al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
+al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
-github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
-github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=

--- a/internal/run/controller/command/build_command.go
+++ b/internal/run/controller/command/build_command.go
@@ -3,7 +3,7 @@ package command
 import (
 	"strings"
 
-	"github.com/alessio/shellescape"
+	"al.essio.dev/pkg/shellescape"
 
 	"github.com/evilmartians/lefthook/v2/internal/config"
 	"github.com/evilmartians/lefthook/v2/internal/run/controller/command/replacer"

--- a/internal/run/controller/command/build_script.go
+++ b/internal/run/controller/command/build_script.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/alessio/shellescape"
+	"al.essio.dev/pkg/shellescape"
 
 	"github.com/evilmartians/lefthook/v2/internal/run/controller/command/replacer"
 	"github.com/evilmartians/lefthook/v2/internal/system"

--- a/internal/run/controller/command/replacer/replacer.go
+++ b/internal/run/controller/command/replacer/replacer.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/alessio/shellescape"
+	"al.essio.dev/pkg/shellescape"
 
 	"github.com/evilmartians/lefthook/v2/internal/config"
 	"github.com/evilmartians/lefthook/v2/internal/git"


### PR DESCRIPTION
Title: deps: migrate shellescape to al.essio.dev/pkg/shellescape

---

## Why

The `shellescape` module was renamed from `github.com/alessio/shellescape` to `al.essio.dev/pkg/shellescape` starting with v1.5.0 (see https://github.com/alessio/shellescape/releases).

Lefthook itself builds fine because its graph pins the old path at v1.4.1. However, downstream projects that pull lefthook in as a Go tool dependency and resolve a fresh module graph can end up selecting a post-rename version of the old path, which fails with:

```
github.com/alessio/shellescape@v1.6.0: parsing go.mod:
        module declares its path as: al.essio.dev/pkg/shellescape
                but was required as: github.com/alessio/shellescape
```

Other projects hit the same issue with this dependency, e.g. kubernetes-sigs/kind#3840.

## What

- Switch the three import sites (`build_command.go`, `build_script.go`, `replacer/replacer.go`) to the new canonical path
- Bump the dependency to v1.6.0 in `go.mod` / `go.sum`

Package name is unchanged (`shellescape`), so no code changes are needed. `go mod tidy`, `go build ./...` and `go test ./...` pass locally.
