### PR TITLE
fix: make test suite stable when `NO_COLOR` is set

### DIFF
--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -179,6 +179,42 @@ func TestChangeset(t *testing.T) {
 	}
 }
 
+func TestPrintDiff(t *testing.T) {
+	for name, tt := range map[string]struct {
+		colors  bool
+		files   []string
+		command string
+	}{
+		"with colors enabled appends --color": {
+			colors:  true,
+			files:   []string{"file2", "file1"},
+			command: "git diff --color -- file1 file2",
+		},
+		"with colors disabled omits --color": {
+			colors:  false,
+			files:   []string{"file2", "file1"},
+			command: "git diff -- file1 file2",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log := loggertest.New()
+			if tt.colors {
+				log = loggertest.NewWithColors()
+			}
+
+			repository := &Repo{
+				logger: log,
+				Git: NewCommander(
+					cmdtest.NewOrdered(t, []cmdtest.Out{{Command: tt.command, Output: "diff output"}}),
+					log,
+				),
+			}
+
+			repository.PrintDiff(tt.files)
+		})
+	}
+}
+
 func TestPushFiles(t *testing.T) {
 	t.Run("falls back to ls-tree for initial push without upstream", func(t *testing.T) {
 		fs := afero.NewMemMapFs()

--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -52,7 +52,7 @@ func Test_guard_wrap(t *testing.T) {
 				{Command: "git hash-object -- file1 file2", Output: "0\n1\n"},
 				{Command: "git status --short --porcelain -z", Output: " M file1\x00 M file2\x00"},
 				{Command: "git hash-object -- file1 file2", Output: "2\n3\n"},
-				{Command: "git diff --color -- file1 file2", Output: "diff --git a/file1 b/file1\n..."},
+				{Command: "git diff -- file1 file2", Output: "diff --git a/file1 b/file1\n..."},
 			},
 			err: &FailOnChangesError{[]string{"file1", "file2"}},
 		},
@@ -130,7 +130,7 @@ func Test_guard_wrap(t *testing.T) {
 				// job run
 				{Command: "git status --short --porcelain -z", Output: "AM file1\x00"},
 				{Command: "git hash-object -- file1", Output: "hash2\n"},
-				{Command: "git diff --color -- file1", Output: "diff --git a/file1 b/file1\n..."},
+				{Command: "git diff -- file1", Output: "diff --git a/file1 b/file1\n..."},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git stash list", Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n"},
 				{Command: "git stash drop --quiet -- 1", Output: ""},

--- a/tests/helpers/loggertest/loggertest.go
+++ b/tests/helpers/loggertest/loggertest.go
@@ -7,9 +7,19 @@ import (
 )
 
 func New() *logger.Logger {
-	return logger.New(io.Discard)
+	// Disable colors by default so test output is deterministic
+	// regardless of environment variables such as `NO_COLOR`.
+	l := logger.New(io.Discard)
+	l.DisableColors()
+	return l
+}
+
+func NewWithColors() *logger.Logger {
+	l := logger.New(io.Discard)
+	l.EnableColors()
+	return l
 }
 
 func NewExecution() *logger.ExecutionLogger {
-	return logger.New(io.Discard).NewExecutionLogger()
+	return New().NewExecutionLogger()
 }


### PR DESCRIPTION
```shell
$ env NO_COLOR=1 make test
go test -cpu 24 -race -count=1 -timeout=30s ./...
?   	github.com/evilmartians/lefthook/v2	[no test files]
?   	github.com/evilmartians/lefthook/v2/cmd	[no test files]
?   	github.com/evilmartians/lefthook/v2/gen	[no test files]
ok  	github.com/evilmartians/lefthook/v2/internal/command	1.081s
ok  	github.com/evilmartians/lefthook/v2/internal/config	1.050s
ok  	github.com/evilmartians/lefthook/v2/internal/git	1.018s
?   	github.com/evilmartians/lefthook/v2/internal/logger	[no test files]
?   	github.com/evilmartians/lefthook/v2/internal/run	[no test files]
--- FAIL: Test_guard_wrap (0.00s)
    --- FAIL: Test_guard_wrap/stashUnstagedChanges=true_failOnChanges=true_with_partially_staged_and_hook_changes_with_diff (0.00s)
        commander.go:122: 9) expected: 'git diff --color -- file1', called: 'git diff -- file1'
    --- FAIL: Test_guard_wrap/failOnChanges=true_fail_with_changeset_different_with_diff (0.00s)
        commander.go:122: 4) expected: 'git diff --color -- file1 file2', called: 'git diff -- file1 file2'
FAIL
FAIL	github.com/evilmartians/lefthook/v2/internal/run/controller	0.039s
?   	github.com/evilmartians/lefthook/v2/internal/run/controller/command	[no test files]
ok  	github.com/evilmartians/lefthook/v2/internal/run/controller/command/replacer	1.016s
ok  	github.com/evilmartians/lefthook/v2/internal/run/controller/exec	1.658s
ok  	github.com/evilmartians/lefthook/v2/internal/run/controller/filter	1.015s
ok  	github.com/evilmartians/lefthook/v2/internal/run/controller/utils	1.010s
ok  	github.com/evilmartians/lefthook/v2/internal/run/result	1.020s
ok  	github.com/evilmartians/lefthook/v2/internal/system	1.012s
?   	github.com/evilmartians/lefthook/v2/internal/templates	[no test files]
ok  	github.com/evilmartians/lefthook/v2/internal/updater	1.028s
ok  	github.com/evilmartians/lefthook/v2/internal/version	1.016s
ok  	github.com/evilmartians/lefthook/v2/tests/helpers/cmdtest	1.014s
ok  	github.com/evilmartians/lefthook/v2/tests/helpers/configtest	1.016s
ok  	github.com/evilmartians/lefthook/v2/tests/helpers/gittest	1.017s
?   	github.com/evilmartians/lefthook/v2/tests/helpers/loggertest	[no test files]
FAIL
make: *** [Makefile:25: test] Error 1
```

