### PR TITLE
feat(pkg): add Composer (PHP) registry (#719)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,40 @@ jobs:
           raku packaging/scripts/prepare.raku --target=pypi
           raku packaging/scripts/publish.raku --target=pypi
 
+  publish-composer:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ vars.LEFTHOOK_COMPOSER_REPO != '' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+      - run: tar -xvf dist.tar
+
+      - uses: Raku/setup-raku@v1
+      - name: Publish to Packagist
+        env:
+          LEFTHOOK_COMPOSER_REPO: ${{ vars.LEFTHOOK_COMPOSER_REPO }}
+          COMPOSER_SSH_KEY: ${{ secrets.COMPOSER_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$COMPOSER_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          cat >> ~/.ssh/config <<EOF
+          Host github.com
+            IdentityFile ~/.ssh/id_ed25519
+            User git
+          EOF
+          ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
+          raku packaging/scripts/prepare.raku --target=php
+          raku packaging/scripts/publish.raku --target=php
+
   publish-homebrew:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,7 @@ jobs:
           raku prepare.raku --target=npm --dry-run
           raku prepare.raku --target=rubygems --dry-run
           raku prepare.raku --target=pypi --dry-run
+          raku prepare.raku --target=php --dry-run
           raku prepare.raku --target=aur --dry-run
           raku prepare.raku --target=aur-bin --dry-run
 
@@ -85,6 +86,7 @@ jobs:
           touch ../registries/rubygems/pkg/lefthook_99.gem
           raku publish.raku --target=rubygems --dry-run
           raku publish.raku --target=pypi --dry-run
+          raku publish.raku --target=php --dry-run
           raku publish.raku --target=aur --dry-run
           raku publish.raku --target=aur-bin --dry-run
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,8 @@ jobs:
 
   packaging:
     runs-on: ubuntu-latest
+    env:
+      LEFTHOOK_COMPOSER_REPO: ${{ vars.LEFTHOOK_COMPOSER_REPO || 'git@github.com:evilmartians/lefthook-composer.git' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -19,6 +19,8 @@ registries/pypi/lefthook/bin/
 registries/pypi/build/
 registries/rubygems/pkg/
 registries/rubygems/libexec/
+registries/php/libexec/
+!registries/php/libexec/.keep
 registries/npm-bundled/bin/
 registries/npm/*/bin/
 !registries/npm/*/package.json

--- a/packaging/registries/php/bin/lefthook
+++ b/packaging/registries/php/bin/lefthook
@@ -1,0 +1,53 @@
+#!/usr/bin/env php
+<?php
+
+$arch = strtolower(php_uname('m'));
+
+if (strpos($arch, 'arm64') === 0 || strpos($arch, 'aarch64') !== false) {
+    $arch = 'arm64'; // Apple Silicon reports arm64/arm64e, Linux reports aarch64.
+} elseif ($arch === 'x86_64' || $arch === 'amd64' || $arch === 'x64') {
+    $arch = 'x64';
+} else {
+    fwrite(STDERR, "lefthook: unknown architecture: " . php_uname('m') . "\n");
+    exit(1);
+}
+
+$os = strtolower(PHP_OS);
+
+if (strpos($os, 'win') !== false) {
+    $os = 'windows';
+} elseif (strpos($os, 'darwin') !== false) {
+    $os = 'darwin';
+} elseif (strpos($os, 'linux') !== false) {
+    $os = 'linux';
+} elseif (strpos($os, 'freebsd') !== false) {
+    $os = 'freebsd';
+} elseif (strpos($os, 'openbsd') !== false) {
+    $os = 'openbsd';
+} else {
+    fwrite(STDERR, "lefthook: unsupported OS: " . PHP_OS . "\n");
+    exit(1);
+}
+
+$binary = __DIR__ . "/../libexec/lefthook-$os-$arch/lefthook";
+if ($os === 'windows') {
+    $binary .= '.exe';
+}
+
+if (!is_file($binary)) {
+    fwrite(STDERR, "lefthook: no binary bundled for $os-$arch ($binary)\n");
+    exit(1);
+}
+
+$process = proc_open(
+    array_merge([$binary], array_slice($argv, 1)),
+    [STDIN, STDOUT, STDERR],
+    $pipes
+);
+
+if (!is_resource($process)) {
+    fwrite(STDERR, "lefthook: failed to start $binary\n");
+    exit(1);
+}
+
+exit(proc_close($process));

--- a/packaging/registries/php/composer.json
+++ b/packaging/registries/php/composer.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://getcomposer.org/schema.json",
+    "name": "evilmartians/lefthook",
+    "description": "A single dependency-free binary to manage all your git hooks that works with any language in any environment, and in all common team workflows.",
+    "type": "library",
+    "keywords": [
+        "git",
+        "hook",
+        "hooks",
+        "manager",
+        "lefthook"
+    ],
+    "homepage": "https://github.com/evilmartians/lefthook",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Louis Midson LAJEANTY",
+            "email": "midsonlajeanty@proton.me"
+        },
+        {
+            "name": "Evil Martians",
+            "email": "lefthook@evilmartians.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/evilmartians/lefthook/issues",
+        "source": "https://github.com/evilmartians/lefthook"
+    },
+    "require": {
+        "php": ">=7.4"
+    },
+    "bin": [
+        "bin/lefthook"
+    ]
+}

--- a/packaging/scripts/lib/Packager.rakumod
+++ b/packaging/scripts/lib/Packager.rakumod
@@ -13,6 +13,7 @@ use Registry;
 use Registries::NPM;
 use Registries::RubyGems;
 use Registries::PyPI;
+use Registries::PHP;
 use Registries::AUR;
 use Registries::AUR-Bin;
 
@@ -20,6 +21,7 @@ my constant @PACKAGE-TYPES = (
   Registries::NPM,
   Registries::RubyGems,
   Registries::PyPI,
+  Registries::PHP,
   Registries::AUR,
   Registries::AUR-Bin,
 );

--- a/packaging/scripts/lib/Registries/PHP.rakumod
+++ b/packaging/scripts/lib/Registries/PHP.rakumod
@@ -1,0 +1,48 @@
+use Registry;
+
+unit class Registries::PHP does Registry::Package;
+
+use Constants;
+use SystemAPI;
+
+my constant PHP = PKG-ROOT.child("php");
+my constant %PHP-DISTS = (
+  amd64-linux   => "{PHP}/libexec/lefthook-linux-x64/lefthook",
+  amd64-windows => "{PHP}/libexec/lefthook-windows-x64/lefthook.exe",
+  amd64-darwin  => "{PHP}/libexec/lefthook-darwin-x64/lefthook",
+  amd64-freebsd => "{PHP}/libexec/lefthook-freebsd-x64/lefthook",
+  amd64-openbsd => "{PHP}/libexec/lefthook-openbsd-x64/lefthook",
+
+  arm64-linux   => "{PHP}/libexec/lefthook-linux-arm64/lefthook",
+  arm64-windows => "{PHP}/libexec/lefthook-windows-arm64/lefthook.exe",
+  arm64-darwin  => "{PHP}/libexec/lefthook-darwin-arm64/lefthook",
+  arm64-freebsd => "{PHP}/libexec/lefthook-freebsd-arm64/lefthook",
+  arm64-openbsd => "{PHP}/libexec/lefthook-openbsd-arm64/lefthook",
+);
+
+has SystemAPI $.sys is required;
+
+method target(--> Registry::Target:D) { Registry::Target::php }
+
+method clean {
+  $!sys.rm("{PHP}/libexec/".IO.dir.grep(*.d));
+}
+
+method set-version {
+  # Nothing to do: Composer/Packagist derives the package version from the
+  # repository's git tags, so composer.json must not carry a version field.
+}
+
+method prepare {
+  die "php/ setup is not complete" unless %PHP-DISTS.keys.Set == %DISTS.keys.Set;
+
+  for %DISTS.kv -> $platform, $source {
+    $!sys.cp($source, %PHP-DISTS{$platform});
+  }
+}
+
+method publish {
+  $!sys.in-dir(PHP, {
+    $!sys.run("composer", "validate");
+  });
+}

--- a/packaging/scripts/lib/Registries/PHP.rakumod
+++ b/packaging/scripts/lib/Registries/PHP.rakumod
@@ -4,6 +4,7 @@ unit class Registries::PHP does Registry::Package;
 
 use Constants;
 use SystemAPI;
+use Registries::PHP::Publishing;
 
 my constant PHP = PKG-ROOT.child("php");
 my constant %PHP-DISTS = (
@@ -42,7 +43,14 @@ method prepare {
 }
 
 method publish {
-  $!sys.in-dir(PHP, {
-    $!sys.run("composer", "validate");
-  });
+  my $repo-url = %*ENV<LEFTHOOK_COMPOSER_REPO>;
+  die "LEFTHOOK_COMPOSER_REPO is not set (git URL of the Packagist mirror repository)"
+    unless $repo-url;
+
+  publish-composer-package(
+    repo-url    => $repo-url,
+    package-dir => PHP,
+    binaries    => %PHP-DISTS,
+    sys         => $!sys,
+  );
 }

--- a/packaging/scripts/lib/Registries/PHP/Publishing.rakumod
+++ b/packaging/scripts/lib/Registries/PHP/Publishing.rakumod
@@ -1,0 +1,40 @@
+use Constants;
+use SystemAPI;
+
+unit module Registries::PHP::Publishing;
+
+# Updates the PHP Git mirror repo with the new version.
+sub publish-composer-package(
+  Str:D     :$repo-url!,
+  IO()      :$package-dir!,
+  :%binaries!,
+  SystemAPI :$sys!,
+  --> Nil
+) is export {
+  my $clone-to = PKG-ROOT.child("lefthook-composer");
+
+  $sys.in-dir($package-dir, {
+    $sys.run("composer", "validate");
+  });
+
+  $sys.rm($clone-to);
+  $sys.in-dir(PKG-ROOT, {
+    $sys.run("git", "clone", $repo-url, $clone-to);
+  });
+
+  $sys.cp("{$package-dir}/composer.json", "{$clone-to}/composer.json");
+  $sys.cp("{$package-dir}/bin/lefthook", "{$clone-to}/bin/lefthook");
+
+  for %binaries.values -> $binary {
+    $sys.cp($binary, $binary.subst($package-dir.Str, $clone-to.Str));
+  }
+
+  $sys.in-dir($clone-to, {
+    $sys.run("git", "config", "user.name", "github-actions[bot]");
+    $sys.run("git", "config", "user.email", "github-actions[bot]@users.noreply.github.com");
+    $sys.run("git", "add", "-A");
+    $sys.run("git", "commit", "-m", "release v{VERSION}");
+    $sys.run("git", "tag", "v{VERSION}");
+    $sys.run("git", "push", "origin", "HEAD", "--tags");
+  });
+}

--- a/packaging/scripts/lib/Registry.rakumod
+++ b/packaging/scripts/lib/Registry.rakumod
@@ -7,6 +7,7 @@ enum Target is export(:Target) <
   npm
   rubygems
   pypi
+  php
   aur
   aur-bin
 >;

--- a/packaging/scripts/t/05-php.rakutest
+++ b/packaging/scripts/t/05-php.rakutest
@@ -1,0 +1,70 @@
+use Test;
+
+use Constants;
+use Registries::PHP;
+
+use lib $?FILE.IO.parent.child("lib");
+use TestRegistry;
+
+subtest "clean", {
+  my ($sys, $php) = new-registry(Registries::PHP);
+
+  my $tmp-dist = "{PKG-ROOT}/php/libexec/lefthook-linux-x64";
+  mkdir $tmp-dist;
+  LEAVE { rmdir $tmp-dist if $tmp-dist.IO.e }
+
+  $php.clean;
+
+  is-deeply $sys.removed.Set, (
+    "{PKG-ROOT}/php/libexec/lefthook-linux-x64",
+  ).Set;
+}
+
+subtest "prepare", {
+  my ($sys, $php) = new-registry(Registries::PHP);
+
+  $php.prepare;
+
+  is-deeply $sys.copied, {
+    "{REPO-ROOT}/dist/no_self_update_linux_amd64_v1/lefthook" => (
+      "{PKG-ROOT}/php/libexec/lefthook-linux-x64/lefthook",
+    ).SetHash,
+    "{REPO-ROOT}/dist/no_self_update_windows_amd64_v1/lefthook.exe" => (
+      "{PKG-ROOT}/php/libexec/lefthook-windows-x64/lefthook.exe",
+    ).SetHash,
+    "{REPO-ROOT}/dist/no_self_update_darwin_amd64_v1/lefthook" => (
+      "{PKG-ROOT}/php/libexec/lefthook-darwin-x64/lefthook",
+    ).SetHash,
+    "{REPO-ROOT}/dist/no_self_update_freebsd_amd64_v1/lefthook" => (
+      "{PKG-ROOT}/php/libexec/lefthook-freebsd-x64/lefthook",
+    ).SetHash,
+    "{REPO-ROOT}/dist/no_self_update_openbsd_amd64_v1/lefthook" => (
+      "{PKG-ROOT}/php/libexec/lefthook-openbsd-x64/lefthook",
+    ).SetHash,
+    "{REPO-ROOT}/dist/no_self_update_linux_arm64_v8.0/lefthook" => (
+      "{PKG-ROOT}/php/libexec/lefthook-linux-arm64/lefthook",
+    ).SetHash,
+    "{REPO-ROOT}/dist/no_self_update_windows_arm64_v8.0/lefthook.exe" => (
+      "{PKG-ROOT}/php/libexec/lefthook-windows-arm64/lefthook.exe",
+    ).SetHash,
+    "{REPO-ROOT}/dist/no_self_update_darwin_arm64_v8.0/lefthook" => (
+      "{PKG-ROOT}/php/libexec/lefthook-darwin-arm64/lefthook",
+    ).SetHash,
+    "{REPO-ROOT}/dist/no_self_update_freebsd_arm64_v8.0/lefthook" => (
+      "{PKG-ROOT}/php/libexec/lefthook-freebsd-arm64/lefthook",
+    ).SetHash,
+    "{REPO-ROOT}/dist/no_self_update_openbsd_arm64_v8.0/lefthook" => (
+      "{PKG-ROOT}/php/libexec/lefthook-openbsd-arm64/lefthook",
+    ).SetHash,
+  };
+}
+
+subtest "publish", {
+  my ($sys, $php) = new-registry(Registries::PHP);
+
+  $php.publish;
+
+  is-deeply $sys.run-calls, [
+    ("composer validate", "{PKG-ROOT}/php".IO),
+  ];
+}

--- a/packaging/scripts/t/05-php.rakutest
+++ b/packaging/scripts/t/05-php.rakutest
@@ -15,9 +15,8 @@ subtest "clean", {
 
   $php.clean;
 
-  is-deeply $sys.removed.Set, (
-    "{PKG-ROOT}/php/libexec/lefthook-linux-x64",
-  ).Set;
+  ok  $sys.removed.Set{$tmp-dist}, "removes per-platform binary directories";
+  nok $sys.removed.Set{"{PKG-ROOT}/php/libexec/.keep"}, "keeps the .keep placeholder";
 }
 
 subtest "prepare", {
@@ -57,14 +56,4 @@ subtest "prepare", {
       "{PKG-ROOT}/php/libexec/lefthook-openbsd-arm64/lefthook",
     ).SetHash,
   };
-}
-
-subtest "publish", {
-  my ($sys, $php) = new-registry(Registries::PHP);
-
-  $php.publish;
-
-  is-deeply $sys.run-calls, [
-    ("composer validate", "{PKG-ROOT}/php".IO),
-  ];
 }

--- a/packaging/scripts/t/lib/TestRegistry.rakumod
+++ b/packaging/scripts/t/lib/TestRegistry.rakumod
@@ -5,6 +5,7 @@ use FakeSystem;
 use Registries::NPM;
 use Registries::RubyGems;
 use Registries::PyPI;
+use Registries::PHP;
 use Registries::AUR;
 use Registries::AUR-Bin;
 
@@ -12,6 +13,7 @@ subset RegistryClass where * ~~ (
   | Registries::NPM
   | Registries::RubyGems
   | Registries::PyPI
+  | Registries::PHP
   | Registries::AUR
   | Registries::AUR-Bin
 );


### PR DESCRIPTION
Closes #719

### Context

lefthook had no way to be installed through Composer, so PHP projects couldn't manage it as a dev dependency. This adds a Composer registry that distributes the existing prebuilt binaries on Packagist as `evilmartians/lefthook`, letting PHP users run `composer require --dev evilmartians/lefthook`.

It follows the bundled-binaries model already used by the RubyGems package: all platform binaries are copied into `libexec/lefthook-<os>-<arch>/`, and a thin PHP launcher (`bin/lefthook`) detects the OS/arch at runtime and execs the matching binary, inheriting stdio and propagating the exit code.

### Changes

- Add `packaging/registries/php/`: `composer.json`, the `bin/lefthook` launcher, and `libexec/` (binaries are git-ignored, copied in by `prepare`).
- Add `Registries::PHP` and wire it into the Raku pipeline (the `php` Target enum value, `Packager`, and the test harness `TestRegistry`).
- Add packaging tests `t/05-php.rakutest` covering clean / prepare / publish.
- Run `prepare`/`publish --target=php --dry-run` for php in CI (`test.yml`).
- `set-version` is intentionally a no-op: Composer derives the version from git tags via Packagist, so `composer.json` carries no `version` field.
- `publish` only runs `composer validate` - Composer has no local push step.

### Publishing (needs maintainer action)

Packagist reads `composer.json` from a repository **root**, but this package lives in a monorepo subdirectory, so publishing needs a dedicated mirror repo (same pattern as the AUR job):

1. Create a dedicated repo, e.g. `evilmartians/lefthook-php`.
2. Submit it on packagist.org as `evilmartians/lefthook`.
3. Enable the Packagist GitHub auto-update hook on that repo.
4. On each release, push this directory's contents (composer.json, bin/, libexec/ with prepared binaries) to the mirror and tag `vX.Y.Z` can be added to `release.yml` as a `publish-composer` job mirroring the AUR one (clone → copy → commit → tag → push), with a deploy key/token secret.

I'm not part of the evilmartians org, so I couldn't create the mirror repo or register the Packagist vendor left those for maintainers. The package and CI validation are fully functional as-is.