### PR TITLE
fix: preserve quoting of run commands and forwarded script args

### DIFF
--- a/internal/run/controller/command/build_script.go
+++ b/internal/run/controller/command/build_script.go
@@ -85,7 +85,11 @@ func (b *Builder) buildScript(params *JobParams) ([]string, []string, error) {
 			commands, _ := replacer.ReplaceAndSplit(command, system.MaxCmdLen())
 			execs = append(execs, commands...)
 		} else {
-			args = append(args, b.opts.GitArgs...)
+			// Quote the args to pass them to the script as-is, even if they contain
+			// spaces or shell special characters.
+			for _, gitArg := range b.opts.GitArgs {
+				args = append(args, shellescape.Quote(gitArg))
+			}
 			execs = append(execs, strings.Join(args, " "))
 		}
 	}

--- a/internal/run/controller/command/build_script_test.go
+++ b/internal/run/controller/command/build_script_test.go
@@ -1,0 +1,79 @@
+package command
+
+import (
+	"path/filepath"
+	"testing"
+
+	"al.essio.dev/pkg/shellescape"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/evilmartians/lefthook/v2/tests/helpers/gittest"
+	"github.com/evilmartians/lefthook/v2/tests/helpers/loggertest"
+)
+
+func TestBuildScript(t *testing.T) {
+	root, err := filepath.Abs("src")
+	assert.NoError(t, err)
+
+	hookName := "echo-args"
+	sourceDir := filepath.Join(root, ".lefthook")
+	scriptPath := filepath.Join(sourceDir, hookName, "echo.sh")
+	quotedScript := shellescape.Quote(scriptPath)
+
+	for name, tt := range map[string]struct {
+		runner  string
+		gitArgs []string
+		exec    string
+	}{
+		"no args": {
+			runner: "sh",
+			exec:   "sh " + quotedScript,
+		},
+		"simple args are passed as-is": {
+			runner:  "sh",
+			gitArgs: []string{"-Apply", "file.txt"},
+			exec:    "sh " + quotedScript + " -Apply file.txt",
+		},
+		"args with spaces are kept intact": {
+			runner:  "powershell",
+			gitArgs: []string{"path with spaces.yml", "file (1).txt"},
+			exec:    "powershell " + quotedScript + " 'path with spaces.yml' 'file (1).txt'",
+		},
+		"args with shell special characters are escaped": {
+			runner:  "sh",
+			gitArgs: []string{"a$b", "c`d", "e&f;g", "h\"i"},
+			exec:    "sh " + quotedScript + " 'a$b' 'c`d' 'e&f;g' 'h\"i'",
+		},
+		"args with single quotes are escaped": {
+			runner:  "sh",
+			gitArgs: []string{"it's"},
+			exec:    "sh " + quotedScript + ` 'it'"'"'s'`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			fs := afero.NewMemMapFs()
+			assert.NoError(fs.MkdirAll(filepath.Dir(scriptPath), 0o755))
+			assert.NoError(afero.WriteFile(fs, scriptPath, []byte("#!/bin/sh\n"), 0o755))
+
+			repo := gittest.NewRepositoryBuilder().Root(root).Fs(fs).Build()
+			builder := NewBuilder(repo, loggertest.NewExecution(), BuilderOptions{
+				HookName:   hookName,
+				SourceDirs: []string{sourceDir},
+				GitArgs:    tt.gitArgs,
+			})
+
+			execs, files, err := builder.BuildCommands(&JobParams{
+				Name:   "echo.sh",
+				Script: "echo.sh",
+				Runner: tt.runner,
+			})
+
+			assert.NoError(err)
+			assert.Empty(files)
+			assert.Equal([]string{tt.exec}, execs)
+		})
+	}
+}

--- a/internal/run/controller/exec/exec_windows.go
+++ b/internal/run/controller/exec/exec_windows.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 
 	"github.com/evilmartians/lefthook/v2/internal/logger"
 	"github.com/evilmartians/lefthook/v2/internal/system"
@@ -73,16 +72,11 @@ func (e CommandExecutor) execute(ctx context.Context, cmdstr string, args *execu
 		return err
 	}
 
-	// This change is breaking but might be useful. Consider quoting if it fixes all possible
-	// options for {staged_files}, '{staged_files}', and "{staged_files}".
-	// cmdStrQuoted := strings.ReplaceAll(strings.ReplaceAll(cmdstr, "\\", "\\\\"), "\"", "\\\"")
-	cmdLine := "\"" + sh + "\"" + " -c " + "\"" + cmdstr + "\""
-	e.logger.Debug("[lefthook] run: ", cmdLine)
+	e.logger.Debug("[lefthook] run: ", cmdstr)
 
-	command := exec.CommandContext(ctx, sh)
-	command.SysProcAttr = &syscall.SysProcAttr{
-		CmdLine: cmdLine,
-	}
+	// Passing the command string as a regular argument lets os/exec quote it
+	// so that sh receives it verbatim, the same way it does on other platforms.
+	command := exec.CommandContext(ctx, sh, "-c", cmdstr)
 	command.Dir = args.root
 	command.Env = append(os.Environ(), args.envs...)
 

--- a/tests/integration/run_script_forwarded_args.txt
+++ b/tests/integration/run_script_forwarded_args.txt
@@ -12,14 +12,10 @@ stdout 'ARG: \[amp&ersand\]'
 stdout 'ARG: \[back`tick\]'
 stdout 'ARG: \[-Flag\]'
 
-# Args containing quotes survive on POSIX systems. On Windows the wrapper
-# command line built in internal/run/controller/exec/exec_windows.go doesn't
-# escape embedded double quotes, so they get mangled by the msys sh argument
-# parsing — a separate pre-existing issue not related to arg forwarding.
-[!windows] exec lefthook run echo-args -- 'it''s' 'double"quote'
-[!windows] stdout 'ARGC: 2'
-[!windows] stdout 'ARG: \[it''s\]'
-[!windows] stdout 'ARG: \[double"quote\]'
+exec lefthook run echo-args -- 'it''s' 'double"quote'
+stdout 'ARGC: 2'
+stdout 'ARG: \[it''s\]'
+stdout 'ARG: \[double"quote\]'
 
 -- lefthook.yml --
 output:

--- a/tests/integration/run_script_forwarded_args.txt
+++ b/tests/integration/run_script_forwarded_args.txt
@@ -1,0 +1,39 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+
+exec lefthook run echo-args -- 'a b' 'paren (x).txt' 'dollar $HOME' 'semi;colon' 'amp&ersand' 'back`tick' -Flag
+stdout 'ARGC: 7'
+stdout 'ARG: \[a b\]'
+stdout 'ARG: \[paren \(x\)\.txt\]'
+stdout 'ARG: \[dollar \$HOME\]'
+stdout 'ARG: \[semi;colon\]'
+stdout 'ARG: \[amp&ersand\]'
+stdout 'ARG: \[back`tick\]'
+stdout 'ARG: \[-Flag\]'
+
+# Args containing quotes survive on POSIX systems. On Windows the wrapper
+# command line built in internal/run/controller/exec/exec_windows.go doesn't
+# escape embedded double quotes, so they get mangled by the msys sh argument
+# parsing — a separate pre-existing issue not related to arg forwarding.
+[!windows] exec lefthook run echo-args -- 'it''s' 'double"quote'
+[!windows] stdout 'ARGC: 2'
+[!windows] stdout 'ARG: \[it''s\]'
+[!windows] stdout 'ARG: \[double"quote\]'
+
+-- lefthook.yml --
+output:
+  - execution_out
+
+echo-args:
+  jobs:
+    - script: echo.sh
+      runner: sh
+
+-- .lefthook/echo-args/echo.sh --
+#!/usr/bin/env sh
+
+echo "ARGC: $#"
+for arg in "$@"; do
+  echo "ARG: [$arg]"
+done

--- a/tests/integration/run_sh_quotes.txt
+++ b/tests/integration/run_sh_quotes.txt
@@ -1,0 +1,32 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+
+exec lefthook run quotes
+stdout '<hello world>'
+stdout '<it''s>'
+stdout '<quote"double>'
+stdout '<v a l>'
+stdout 'NO CI'
+
+-- lefthook.yml --
+output:
+  - execution_out
+
+quotes:
+  jobs:
+    - name: double quotes keep words together
+      run: printf '<%s>' "hello world"
+    - name: single quote inside double quotes
+      run: printf '<%s>' "it's"
+    - name: double quote inside single quotes
+      run: printf '<%s>' 'quote"double'
+    - name: quoted variable expansion
+      run: X='v a l'; printf '<%s>' "$X"
+    - name: multiline run with quotes
+      run: |
+        if [ -z "$LEFTHOOK_TEST_UNSET_VAR" ]; then
+          echo "NO CI"
+        else
+          echo "CI"
+        fi


### PR DESCRIPTION
Closes #1167

### Context

Two related quoting bugs mangle command strings on their way to `sh`:

1. **Forwarded args lose their quoting (all platforms).** `lefthook run <hook> -- <args...>` joins the args into the script command string without escaping: args with spaces arrive split, and `lefthook run my-hook -- "file (1).txt"` fails with ``sh: syntax error near unexpected token `(` ``.

2. **The Windows executor mangles any command containing a double quote (#1167).** It hand-builds the raw process command line as `"sh" -c "cmdstr"` without escaping, so the msys argument parser corrupts the command before `sh` sees it:

| command string | today on Windows | with this fix (= Linux/macOS) |
|---|---|---|
| `echo "hello world"` | `hello` | `hello world` |
| `printf '<%s>' "$VAR"` | splits on spaces | verbatim |
| multi-line `run:` with quotes (#1167) | syntax error | works |

Since even `echo "hello world"` mis-executes today, no config can rely on the old behavior — the fix restores parity with other platforms and matches how the `skip`/`only` check executor already invokes `sh`.

### Changes

- `build_script.go` — quote each forwarded arg with `shellescape.Quote`, like the script path and files templates already are. Args without special characters stay untouched, so `-- -Apply`-style flag forwarding is unchanged.
- `exec_windows.go` — drop the hand-built `SysProcAttr.CmdLine`; pass `-c cmdstr` as regular arguments and let `os/exec` quote it, same as the unix executor. Also resolves the "consider quoting" comment in that file.
- New unit test for built script commands, plus two integration tests (`run_script_forwarded_args`, `run_sh_quotes`) that fail on `master` and pass with this change.

Verified on Windows 11 (Git for Windows) and Ubuntu: `go test ./...`, the full integration suite, and end-to-end runs with `sh` and `powershell -File` scripts receiving filenames with spaces, parentheses, and quotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Both changes are minimal, targeted, and verified by new tests; the Windows path now matches the Unix executor exactly.

The forwarded-arg fix is a straightforward one-liner wrapped in a loop, confined to the already-quoted else-branch. The Windows executor change removes a hand-rolled quoting scheme that was provably broken and replaces it with the same exec.CommandContext call the Unix executor has used all along. Both directions of the fix are covered by a new unit test and two integration tests that reproduce the original bugs. No behaviour is changed on paths that already worked.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: pass the command to sh verbatim on ..."](https://github.com/evilmartians/lefthook/commit/042e48326f8f95e7ca82adaf870eb81dd1880886) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42707052)</sub>

<!-- /greptile_comment -->