### PR TITLE
docs: quote template run examples

### DIFF
--- a/docs/configuration/templates.md
+++ b/docs/configuration/templates.md
@@ -23,7 +23,7 @@ templates:
 pre-commit:
   jobs:
     # Will run: `bundle exec rubocop -- file1 file2 file3 ...`
-    - run: {dip} bundle exec rubocop -- {staged_files}
+    - run: "{dip} bundle exec rubocop -- {staged_files}"
 ```
 
 ```yml
@@ -43,7 +43,7 @@ templates:
 
 pre-commit:
   jobs:
-    - run: {wrapper} yarn format
-    - run: {wrapper} yarn lint
-    - run: {wrapper} yarn test
+    - run: "{wrapper} yarn format"
+    - run: "{wrapper} yarn lint"
+    - run: "{wrapper} yarn test"
 ```


### PR DESCRIPTION
Closes #1467

### Context

YAML treats a leading `{` in an unquoted value as the start of a flow mapping, so the documented commands fail to parse before template substitution.

### Changes

Quote the four `run` examples that begin with `{dip}` or `{wrapper}`.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the documentation examples now parse correctly without altering the commands users intend to run.

YAML removes the delimiting quotes when decoding these values, so the examples retain the intended template commands while avoiding the invalid unquoted leading-brace form.

<sub>Reviews (1): Last reviewed commit: ["docs: quote template run examples"](https://github.com/evilmartians/lefthook/commit/61d3e421500168324e75e69c0173ebd6d4ac6ce1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47692583)</sub>

<!-- /greptile_comment -->