### PR TITLE
fix(npm) don't force past `core.hooksPath` guard in npm postinstall

### DIFF
--- a/packaging/registries/npm-bundled/postinstall.js
+++ b/packaging/registries/npm-bundled/postinstall.js
@@ -4,7 +4,7 @@ if (!isEnabled(process.env.CI) || isEnabled(process.env.LEFTHOOK)) {
   const { getExePath } = require('./get-exe');
 
   // run install
-  spawnSync(getExePath(), ['install', '-f'], {
+  spawnSync(getExePath(), ['install'], {
     cwd: process.env.INIT_CWD || process.cwd(),
     stdio: 'inherit',
   });

--- a/packaging/registries/npm-installer/install.js
+++ b/packaging/registries/npm-installer/install.js
@@ -20,7 +20,7 @@ async function install() {
     fs.chmodSync(exePath, "755")
   }
   // run install
-  chp.spawnSync(exePath, ['install',  '-f'], {
+  chp.spawnSync(exePath, ['install'], {
     cwd: process.env.INIT_CWD || process.cwd(),
     stdio: 'inherit',
   })

--- a/packaging/registries/npm/lefthook/postinstall.js
+++ b/packaging/registries/npm/lefthook/postinstall.js
@@ -7,7 +7,7 @@ function install() {
     return
   }
 
-  spawnSync(getExePath(), ["install", "-f"], {
+  spawnSync(getExePath(), ["install"], {
     cwd: process.env.INIT_CWD || process.cwd(),
     stdio: "inherit",
   });


### PR DESCRIPTION
### Context

The npm `postinstall` scripts hardcode `lefthook install -f`. Passing `--force` makes `ensureHooksPathUnset` skip the `core.hooksPath` guard added in #1292 and install hooks into a non-default hooks path anyway. Because postinstall runs on every `npm install`, the guard is silently defeated there, the one place it can't be interactively acknowledged.

Concrete impact: teams migrating from Husky. Husky leaves `core.hooksPath=.husky/_` in each developer's local git config, and that setting persists after the repo switches to lefthook. Every `npm install` then force-writes lefthook hooks into `.husky/_` instead of `.git/hooks`, silently regenerating stale Husky hook files. The guard designed to catch exactly this never fires.

Worth noting: runtime auto-sync already behaves the "safe" way. On `lefthook run`, `syncHooks` [calls `installHooks` with `force=false`](https://github.com/evilmartians/lefthook/blob/8d9cfec5f52367af6374a5430b4e9568844856e5/internal/command/install.go#L227), so a custom `core.hooksPath` already gets no automatic re-sync today (the guard applies and sync is skipped). Dropping `-f` from postinstall simply makes the install path consistent with that existing auto-sync behavior—it does not newly break a supported workflow.

### Changes

Drop `-f` from the three npm packaging install scripts:

- `packaging/registries/npm/lefthook/postinstall.js`
- `packaging/registries/npm-bundled/postinstall.js`
- `packaging/registries/npm-installer/install.js`

When a non-default `core.hooksPath` is set, postinstall now surfaces lefthook's existing guidance (`lefthook install --reset-hooks-path` or `--force`) instead of silently forcing past it. The documented `lefthook install --force` escape hatch is unchanged for users who intentionally want a custom hooks path.

### Possible follow-up (not required by this PR)

Users who *intentionally* use a custom `core.hooksPath` will need to run `lefthook install --force` manually after config changes. Since auto-sync already doesn't serve custom paths, this PR introduces no regression there, but if maintainers want to better support that workflow, a persistent opt-in (e.g. a `lefthook.yml` setting or an env var pre-approving the custom path) could let postinstall install with `--force` each time instead.

<!-- greptile_comment -->

<h3>Confidence Score: 3/5</h3>

The PR should not merge until postinstall can enable the `core.hooksPath` guard without silently failing installations that encounter an existing `.old` hook backup.

Removing the broad force flag activates more than the targeted hooks-path check; a reachable backup collision now aborts hook creation while all three npm launchers ignore the failed child status.

**Files Needing Attention:** packaging/registries/npm-bundled/postinstall.js, packaging/registries/npm-installer/install.js, packaging/registries/npm/lefthook/postinstall.js

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t force past core.hooksPath gua..."](https://github.com/evilmartians/lefthook/commit/07e7a224d70be3f38d1ae7fb9c098c5a1306df55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48477276)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->