### PR TITLE
docs: clarify remote script folders

### DIFF
--- a/docs/configuration/remotes.md
+++ b/docs/configuration/remotes.md
@@ -8,7 +8,7 @@ You can provide multiple remote configs if you want to share yours lefthook conf
 
 You can use [`extends`](./extends.md) but the paths must be relative to the remote repository root.
 
-If you provide [`scripts`](./scripts.md) in a remote config file, the [scripts](./source_dir.md) folder must also be in the **root of the repository**.
+If you provide [`scripts`](./scripts.md) in a remote config file, the [script `source_dir`](./source_dir.md) must also be in the **root of the remote repository**.
 
 ::: callout info Note
 Configs are merged in this order: `lefthook.yml` → `remotes` → `lefthook-local.yml`. For simplicity, keep jobs in remote configs independent from other steps.


### PR DESCRIPTION
Closes # (issue)

### Context

<!-- Brief description of what problem PR is solving -->

### Changes

<!-- Summary for changes in the code -->

Note that the folders need to be in the root of the _remote_ repository, and reword to avoid confusing two meanings of the word "scripts".

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

The PR is safe to merge, though the new wording should describe `source_dir` as relative to the remote repository root to avoid implying that nested paths are invalid.

The documentation correctly distinguishes the remote repository from the consuming repository, but its location wording is narrower than the implementation’s relative-path behavior.

**Files Needing Attention:** docs/configuration/remotes.md

<sub>Reviews (1): Last reviewed commit: ["docs: clarify remote script folders"](https://github.com/evilmartians/lefthook/commit/b2d9b5819da93565f4791d58cccaafa54c82e135) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48665907)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->