### PR TITLE
docs: document script args

### DIFF
--- a/docs/configuration/Scripts.md
+++ b/docs/configuration/Scripts.md
@@ -47,3 +47,15 @@ commit-msg:
 ```
 
 When you try to commit `git commit -m "bad commit text"` script `template_checker` will be executed. Since commit text doesn't match the described pattern the commit process will be interrupted.
+
+Use [`args`](./args.md) to append arguments to a script. Arguments passed by
+Git are omitted when `args` is configured, so use the `{0}` template if they
+should be preserved.
+
+```yml
+commit-msg:
+  scripts:
+    "template_checker":
+      runner: bash
+      args: "{0}"
+```

--- a/docs/configuration/script.md
+++ b/docs/configuration/script.md
@@ -6,6 +6,9 @@ title: "script"
 
 Name of a script to execute. The rules are the same as for [`scripts`](./Scripts.md)
 
+Use [`args`](./args.md) to append arguments to the script. Configuring `args`
+replaces arguments passed by Git unless the `{0}` template is included.
+
 #### Example
 
 ```yml
@@ -15,6 +18,7 @@ pre-commit:
   jobs:
     - script: linter.sh
       runner: bash
+      args: "{staged_files}"
 ```
 
 ```bash


### PR DESCRIPTION
Closes #1476

### Context

The script-specific documentation did not mention the supported `args` option or explain how it interacts with arguments supplied by Git.

### Changes

- Link both script documentation pages to the `args` reference.
- Show `{0}` for preserving Git arguments.
- Add a staged-files example for job-style scripts.

Validation: `git diff --check`.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The documentation changes appear safe to merge.

Configured script arguments suppress automatic Git-argument appending, `{0}` restores those arguments, and `{staged_files}` is supported and safely expanded for job-style scripts as documented.

<sub>Reviews (1): Last reviewed commit: ["docs: document script args"](https://github.com/evilmartians/lefthook/commit/f8a8bc3bf80e8bb77c95c47d8f30fd54999f5b18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49153210)</sub>

<!-- /greptile_comment -->