### PR TITLE
docs: update docmd

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup docmd
-        run: npm install -g @docmd/core@0.8.6
+        run: npm install -g @docmd/core@0.8.17
 
       - run: docmd build
 


### PR DESCRIPTION
Update docmd version

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The workflow retains its existing build and deployment flow, and the updated docmd version is compatible with the repository’s current configuration.

<sub>Reviews (1): Last reviewed commit: ["docs: update docmd"](https://github.com/evilmartians/lefthook/commit/f4d528de6ef23265242c4fff4fc9174607e9a8c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49620829)</sub>

<!-- /greptile_comment -->