### PR TITLE
fix: preserve unrelated unstaged changes on conflict

### DIFF
--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -315,8 +315,11 @@ func (r *Repo) saveAllUnstaged() error {
 		r.unstagedAllPatchPath,
 		"--",
 	})
+	if err != nil {
+		return fmt.Errorf("failed to save all unstaged changes: %w", err)
+	}
 
-	return err
+	return nil
 }
 
 func (r *Repo) RevertUnstagedChanges(files []string) error {
@@ -373,7 +376,11 @@ func (r *Repo) RestoreAllUnstagedChanges() error {
 }
 
 func (r *Repo) restoreUnstagedChanges(patchPath string) error {
-	if ok, _ := afero.Exists(r.Fs, patchPath); !ok {
+	exists, err := afero.Exists(r.Fs, patchPath)
+	if err != nil {
+		return fmt.Errorf("failed to inspect the patch %s: %w", patchPath, err)
+	}
+	if !exists {
 		return nil
 	}
 
@@ -399,7 +406,11 @@ func (r *Repo) restoreUnstagedChanges(patchPath string) error {
 	}
 
 	for _, path := range []string{r.unstagedPatchPath, r.unstagedAllPatchPath} {
-		if ok, _ := afero.Exists(r.Fs, path); !ok {
+		exists, existsErr := afero.Exists(r.Fs, path)
+		if existsErr != nil {
+			return fmt.Errorf("failed to inspect the patch %s: %w", path, existsErr)
+		}
+		if !exists {
 			continue
 		}
 		if err = r.Fs.Remove(path); err != nil {

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -20,10 +20,11 @@ import (
 )
 
 const (
-	minGitVersion     = "2.31.0"
-	stashMessage      = "lefthook auto backup"
-	unstagedPatchName = "lefthook-unstaged.patch"
-	infoDirMode       = 0o775
+	minGitVersion        = "2.31.0"
+	stashMessage         = "lefthook auto backup"
+	unstagedPatchName    = "lefthook-unstaged.patch"
+	unstagedAllPatchName = "lefthook-unstaged-all.patch"
+	infoDirMode          = 0o775
 )
 
 var (
@@ -58,8 +59,9 @@ type Repo struct {
 	GitPath   string
 	InfoPath  string
 
-	unstagedPatchPath string
-	headBranch        string
+	unstagedPatchPath    string
+	unstagedAllPatchPath string
+	headBranch           string
 
 	stagedFilesOnce            func() ([]string, error)
 	stagedFilesWithDeletedOnce func() ([]string, error)
@@ -168,6 +170,7 @@ func (r *Repo) ResetCache() {
 	})
 
 	r.unstagedPatchPath = filepath.Join(r.InfoPath, unstagedPatchName)
+	r.unstagedAllPatchPath = filepath.Join(r.InfoPath, unstagedAllPatchName)
 }
 
 // StagedFiles returns a list of staged files which exist on file system.
@@ -255,6 +258,10 @@ func (r *Repo) SaveUnstagedChanges(files []string) error {
 		return err
 	}
 
+	if err = r.saveAllUnstaged(); err != nil {
+		return err
+	}
+
 	_, err = r.Git.Cmd([]string{
 		"git",
 		"stash",
@@ -288,6 +295,26 @@ func (r *Repo) saveUnstaged(files []string) error {
 			r.unstagedPatchPath,
 			"--",
 		}, files)
+
+	return err
+}
+
+func (r *Repo) saveAllUnstaged() error {
+	_, err := r.Git.Cmd([]string{
+		"git",
+		"diff",
+		"--binary",
+		"--unified=0",
+		"--no-color",
+		"--no-ext-diff",
+		"--src-prefix=a/",
+		"--dst-prefix=b/",
+		"--patch",
+		"--submodule=short",
+		"--output",
+		r.unstagedAllPatchPath,
+		"--",
+	})
 
 	return err
 }
@@ -337,41 +364,47 @@ func (r *Repo) CanRestoreUnstagedChanges() bool {
 
 // RestoreUnstagedChanges applies the patch with previously unstaged changes.
 func (r *Repo) RestoreUnstagedChanges() error {
-	if ok, _ := afero.Exists(r.Fs, r.unstagedPatchPath); !ok {
+	return r.restoreUnstagedChanges(r.unstagedPatchPath)
+}
+
+// RestoreAllUnstagedChanges applies all unstaged changes saved before running hooks.
+func (r *Repo) RestoreAllUnstagedChanges() error {
+	return r.restoreUnstagedChanges(r.unstagedAllPatchPath)
+}
+
+func (r *Repo) restoreUnstagedChanges(patchPath string) error {
+	if ok, _ := afero.Exists(r.Fs, patchPath); !ok {
 		return nil
 	}
 
-	stat, err := r.Fs.Stat(r.unstagedPatchPath)
+	stat, err := r.Fs.Stat(patchPath)
 	if err != nil {
 		return err
 	}
 
-	if stat.Size() == 0 {
-		err = r.Fs.Remove(r.unstagedPatchPath)
+	if stat.Size() > 0 {
+		_, err = r.Git.Cmd([]string{
+			"git",
+			"apply",
+			"-v",
+			"--whitespace=nowarn",
+			"--recount",
+			"--unidiff-zero",
+			"--",
+			patchPath,
+		})
 		if err != nil {
-			return fmt.Errorf("failed to remove the patch %s: %w", r.unstagedPatchPath, err)
+			return fmt.Errorf("failed to apply the patch %s: %w", patchPath, err)
 		}
-
-		return nil
 	}
 
-	_, err = r.Git.Cmd([]string{
-		"git",
-		"apply",
-		"-v",
-		"--whitespace=nowarn",
-		"--recount",
-		"--unidiff-zero",
-		"--",
-		r.unstagedPatchPath,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to apply the patch %s: %w", r.unstagedPatchPath, err)
-	}
-
-	err = r.Fs.Remove(r.unstagedPatchPath)
-	if err != nil {
-		return fmt.Errorf("failed to remove the patch %s: %w", r.unstagedPatchPath, err)
+	for _, path := range []string{r.unstagedPatchPath, r.unstagedAllPatchPath} {
+		if ok, _ := afero.Exists(r.Fs, path); !ok {
+			continue
+		}
+		if err = r.Fs.Remove(path); err != nil {
+			return fmt.Errorf("failed to remove the patch %s: %w", path, err)
+		}
 	}
 
 	if err = r.dropUnstagedStash(); err != nil {

--- a/internal/run/controller/guard.go
+++ b/internal/run/controller/guard.go
@@ -114,6 +114,7 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 		}
 	}
 
+	restoreAllUnstagedChanges := false
 	if g.git.CanRestoreUnstagedChanges() {
 		if err := g.git.AddFiles(g.filesToStage.Files()); err != nil {
 			g.logger.Warn("Couldn't stage fixed files:", err)
@@ -128,6 +129,7 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 			g.logger.Warnf("Failed to restore initial worktree state: %s", err)
 			return err
 		}
+		restoreAllUnstagedChanges = true
 
 		logger.NewBuilder(g.logger).
 			WithLevel(logger.LevelWarn).
@@ -137,9 +139,15 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 			Log()
 	}
 
-	if err := g.git.RestoreUnstagedChanges(); err != nil {
-		g.logger.Warnf("Failed to restore unstaged files: %s", err)
-		return err
+	var restoreErr error
+	if restoreAllUnstagedChanges {
+		restoreErr = g.git.RestoreAllUnstagedChanges()
+	} else {
+		restoreErr = g.git.RestoreUnstagedChanges()
+	}
+	if restoreErr != nil {
+		g.logger.Warnf("Failed to restore unstaged files: %s", restoreErr)
+		return restoreErr
 	}
 
 	return wrappedErr

--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -89,6 +89,9 @@ func Test_guard_wrap(t *testing.T) {
 				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", Output: ""},
+				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
+					filepath.Join("root", ".git", "info", "lefthook-unstaged-all.patch") +
+					" --", Output: ""},
 				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git stash list", Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n"},
@@ -104,6 +107,9 @@ func Test_guard_wrap(t *testing.T) {
 				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", Output: ""},
+				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
+					filepath.Join("root", ".git", "info", "lefthook-unstaged-all.patch") +
+					" --", Output: ""},
 				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git status --short --porcelain -z", Output: "A file1\x00"},
@@ -123,6 +129,9 @@ func Test_guard_wrap(t *testing.T) {
 				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", Output: ""},
+				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
+					filepath.Join("root", ".git", "info", "lefthook-unstaged-all.patch") +
+					" --", Output: ""},
 				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git status --short --porcelain -z", Output: "A  file1\x00"},

--- a/tests/integration/restore_unstaged_on_conflict.txt
+++ b/tests/integration/restore_unstaged_on_conflict.txt
@@ -3,7 +3,12 @@ exec git config user.email "you@example.com"
 exec git config user.name "Your Name"
 exec lefthook install
 exec git add -A
-exec git commit -m 'initial'
+exec git commit --no-verify -m 'initial'
+
+# Keep an unrelated unstaged change in the worktree
+exec echo "unrelated unstaged change\n"
+cp stdout c.txt
+grep 'unrelated unstaged change' c.txt
 
 # Stage first change
 exec echo "line1\nlineStaged\nline3\n"
@@ -18,13 +23,17 @@ grep lineUnstaged a.txt
 
 # Change that line in the hook
 ! exec git commit -m 'test'
+stderr '\s*conflict while merging unstaged changes\s*'
 
 # Must restore the state before running the hook
 grep lineUnstaged a.txt
 ! grep line42 a.txt
 grep lineCommitted b.txt
-
-stderr '\s*conflict while merging unstaged changes\s*'
+grep 'unrelated unstaged change' c.txt
+! exists .git/info/lefthook-unstaged.patch
+! exists .git/info/lefthook-unstaged-all.patch
+exec git stash list
+! stdout 'lefthook auto backup'
 
 -- lefthook.yml --
 pre-commit:
@@ -42,3 +51,5 @@ line1
 lineCommitted
 line3
 
+-- c.txt --
+committed content


### PR DESCRIPTION
Closes #1480

### Context

When the hidden patch for a partially staged file conflicts with hook output, Lefthook resets the whole tracked worktree before replaying only the partial-file patch. That restores the conflicting file, but silently discards pre-existing unstaged changes in unrelated tracked files.

### Changes

- Save a full pre-hook unstaged patch alongside the partial-file patch.
- Keep the existing partial patch on the normal successful restore path.
- After conflict recovery resets hook output, replay the full patch so every pre-existing unstaged change is restored.
- Remove both temporary patches and the auto-backup stash after a successful restore.
- Add a real-Git regression covering a partially staged conflict plus an unrelated unstaged tracked file.

### Validation

- make test
- affected restore integration scenarios with the race detector
- all integration scripts except the timing-sensitive run_interrupt script in one race-enabled batch
- run_interrupt separately with the race detector
- make lint (0 issues)

### AI usage

Prepared with Codex; the behavior is covered by the fail-first integration regression and repository test commands listed above.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["fix: preserve recovery error context"](https://github.com/evilmartians/lefthook/commit/1bd758e8cd31639be31a4378864eb81a0bf7ef44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51011858)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/evilmartians/lefthook/blob/master/AGENTS.md))

<!-- /greptile_comment -->