### PR TITLE
fix: fail the hook when staging fixed files errors

### DIFF
--- a/docs/configuration/stage_fixed.md
+++ b/docs/configuration/stage_fixed.md
@@ -12,6 +12,8 @@ Works **only** for the `pre-commit` hook.
 
 When set to `true` lefthook will automatically call `git add` on files after running the command or script. For a command if [`files`](./files.md) option was specified, the specified command will be used to retrieve files for `git add`. For scripts and commands without [`files`](./files.md) option `{staged_files}` template will be used. All filters ([`glob`](./glob.md), [`exclude`](./exclude.md)) will be applied if specified.
 
+If the `git add` call fails, the hook fails too. Otherwise the commit would silently go through with the unfixed content.
+
 #### Example
 
 ```yml

--- a/internal/run/controller/guard.go
+++ b/internal/run/controller/guard.go
@@ -81,7 +81,7 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 
 		if err := g.git.AddFiles(g.filesToStage.Files()); err != nil {
 			g.logger.Warn("Couldn't stage fixed files:", err)
-			resErr = errors.Join(resErr, err)
+			resErr = errors.Join(resErr, fmt.Errorf("couldn't stage fixed files: %w", err))
 		}
 
 		return resErr
@@ -118,7 +118,7 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 	if g.git.CanRestoreUnstagedChanges() {
 		if err := g.git.AddFiles(g.filesToStage.Files()); err != nil {
 			g.logger.Warn("Couldn't stage fixed files:", err)
-			wrappedErr = errors.Join(wrappedErr, err)
+			wrappedErr = errors.Join(wrappedErr, fmt.Errorf("couldn't stage fixed files: %w", err))
 		}
 	} else {
 		if wrappedErr != nil {

--- a/internal/run/controller/guard.go
+++ b/internal/run/controller/guard.go
@@ -81,6 +81,7 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 
 		if err := g.git.AddFiles(g.filesToStage.Files()); err != nil {
 			g.logger.Warn("Couldn't stage fixed files:", err)
+			resErr = errors.Join(resErr, err)
 		}
 
 		return resErr
@@ -117,6 +118,7 @@ func (g *guard) withHiddenUnstagedChanges(fn func() error) error {
 	if g.git.CanRestoreUnstagedChanges() {
 		if err := g.git.AddFiles(g.filesToStage.Files()); err != nil {
 			g.logger.Warn("Couldn't stage fixed files:", err)
+			wrappedErr = errors.Join(wrappedErr, err)
 		}
 	} else {
 		if wrappedErr != nil {

--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -208,6 +209,86 @@ func Test_guard_wrap(t *testing.T) {
 			err := g.wrap(func() { beenCalled = true })
 			if tt.err != nil {
 				assert.ErrorAs(tt.err, &err)
+			} else {
+				assert.NoError(err)
+			}
+
+			assert.Equal(true, beenCalled)
+		})
+	}
+}
+
+// Staging the files fixed by a hook must not fail silently: if `git add` fails, the
+// commit would proceed with the unfixed content while the summary stays green.
+func Test_guard_wrap_stageFixed(t *testing.T) {
+	errStaging := errors.New("exit status 128")
+
+	for name, tt := range map[string]struct {
+		filesToStage []string
+		commands     []cmdtest.Out
+		err          error
+	}{
+		"no files to stage": {
+			commands: []cmdtest.Out{
+				{Command: "git status --short --porcelain -z", Output: "M  file1\x00"},
+			},
+		},
+		"fixed files staged": {
+			filesToStage: []string{"file1"},
+			commands: []cmdtest.Out{
+				{Command: "git status --short --porcelain -z", Output: "M  file1\x00"},
+				{Command: "git add --force -- file1", Output: ""},
+			},
+		},
+		"staging fixed files fails": {
+			filesToStage: []string{"file1"},
+			commands: []cmdtest.Out{
+				{Command: "git status --short --porcelain -z", Output: "M  file1\x00"},
+				{Command: "git add --force -- file1", Err: errStaging},
+			},
+			err: errStaging,
+		},
+		"staging fixed files fails with partially staged": {
+			filesToStage: []string{"file2"},
+			commands: []cmdtest.Out{
+				{Command: "git status --short --porcelain -z", Output: "AM file1\x00"},
+				{Command: "git stash create", Output: "<stash-hash>"},
+				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
+					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
+					" -- file1", Output: ""},
+				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
+				{Command: "git checkout --force -- file1", Output: ""},
+				{Command: "git add --force -- file2", Err: errStaging},
+			},
+			err: errStaging,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			repo := gittest.NewRepositoryBuilder().
+				Cmd(cmdtest.NewOrdered(t, tt.commands)).
+				Fs(afero.NewMemMapFs()).
+				Root("root").
+				Build()
+			repo.ResetCache()
+
+			filesToStage := newStageFilesList()
+			filesToStage.Add(tt.filesToStage)
+
+			g := newGuard(
+				repo,
+				loggertest.NewExecution(),
+				filesToStage,
+				true,
+				false,
+				false,
+			)
+
+			var beenCalled bool
+			err := g.wrap(func() { beenCalled = true })
+			if tt.err != nil {
+				assert.ErrorIs(err, tt.err)
 			} else {
 				assert.NoError(err)
 			}

--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -289,6 +289,7 @@ func Test_guard_wrap_stageFixed(t *testing.T) {
 			err := g.wrap(func() { beenCalled = true })
 			if tt.err != nil {
 				assert.ErrorIs(err, tt.err)
+				assert.ErrorContains(err, "couldn't stage fixed files")
 			} else {
 				assert.NoError(err)
 			}

--- a/tests/helpers/cmdtest/ordered.go
+++ b/tests/helpers/cmdtest/ordered.go
@@ -11,6 +11,8 @@ import (
 type Out struct {
 	Command string
 	Output  string
+	// Err is returned instead of running the command, to simulate a failing git call.
+	Err error
 }
 
 // OrderedCmd contains predefined list of commands and makes sure actual calls are the same.
@@ -45,5 +47,5 @@ func (c *OrderedCmd) Run(command []string, root string, in io.Reader, out io.Wri
 	_, _ = out.Write([]byte(checkCmd.Output))
 	c.outs = c.outs[1:]
 
-	return nil
+	return checkCmd.Err
 }

--- a/tests/helpers/cmdtest/ordered_test.go
+++ b/tests/helpers/cmdtest/ordered_test.go
@@ -1,6 +1,7 @@
 package cmdtest
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -12,12 +13,15 @@ import (
 func TestOrderedCmd(t *testing.T) {
 	var _ system.Command = (*OrderedCmd)(nil)
 
+	errFailed := errors.New("failed")
+
 	cmd := NewOrdered(
 		t,
 		[]Out{
-			{"A 1", ""},
-			{"B 2", ""},
-			{"C 3", ""},
+			{Command: "A 1"},
+			{Command: "B 2"},
+			{Command: "C 3"},
+			{Command: "D 4", Err: errFailed},
 		},
 	)
 	_ = cmd.WithoutEnvs("OK")
@@ -25,4 +29,5 @@ func TestOrderedCmd(t *testing.T) {
 	assert.NoError(t, cmd.Run([]string{"A", "1"}, "", system.NullReader, io.Discard, io.Discard))
 	assert.NoError(t, cmd.Run([]string{"B", "2"}, "", system.NullReader, io.Discard, io.Discard))
 	assert.NoError(t, cmd.Run([]string{"C", "3"}, "", system.NullReader, io.Discard, io.Discard))
+	assert.ErrorIs(t, cmd.Run([]string{"D", "4"}, "", system.NullReader, io.Discard, io.Discard), errFailed)
 }


### PR DESCRIPTION
Closes #1471

### Context

With `stage_fixed: true`, `guard.withHiddenUnstagedChanges` calls `git.AddFiles` to stage the files a job has fixed. When that `git add` fails, the error is only logged:

```go
if err := g.git.AddFiles(g.filesToStage.Files()); err != nil {
    g.logger.Warn("Couldn't stage fixed files:", err)
}

return resErr
```

`resErr` is the wrapped result of the jobs, so the staging failure never reaches the caller. `Lefthook.run` sees `err == nil`, prints a green summary and exits 0 — the commit is created with the pre-fix content while nothing in the exit status tells the wrapper or CI that the formatter gate did not actually do its job.

Reproducer from the issue: run the hook without `GIT_INDEX_FILE` during `git commit -a`, so the staging `git add` collides with the `index.lock` git holds:

```
> git add --force -- src/example.tsx
fatal: Unable to create '.../.git/index.lock': File exists.
Couldn't stage fixed files: error in batch 0: exit status 128
summary: (done in 2.75 seconds)
✔️ lint-staged (2.75 seconds)
```

### Changes

`errors.Join` the `AddFiles` error into the returned error at both call sites — the `len(partiallyStagedFiles) == 0` early return and the `CanRestoreUnstagedChanges()` branch. The warning is kept as is, so the immediate output does not change; only the returned error does. `Lefthook.run` then reports `failed to run the hook: ...` and exits non-zero.

`AddFiles` returns `nil` for an empty file list, so hooks that stage nothing are unaffected — the join only happens on a real error.

Added `Test_guard_wrap_stageFixed` to `guard_test.go` covering both call sites, plus the two non-failing paths (nothing to stage, and a successful `git add`) so the change cannot start failing hooks that used to pass. `cmdtest.Out` grew an `Err` field so the ordered command double can simulate a failing git call; it is a new field with a nil zero value, existing expectations behave exactly as before.

### Verification

Before the fix (test only, `guard.go` reverted):

```
--- FAIL: Test_guard_wrap_stageFixed (0.00s)
    --- FAIL: Test_guard_wrap_stageFixed/staging_fixed_files_fails (0.00s)
        	Error:      	Expected error with "exit status 128" in chain but got nil.
    --- FAIL: Test_guard_wrap_stageFixed/staging_fixed_files_fails_with_partially_staged (0.00s)
        	Error:      	Expected error with "exit status 128" in chain but got nil.
    --- PASS: Test_guard_wrap_stageFixed/no_files_to_stage (0.00s)
    --- PASS: Test_guard_wrap_stageFixed/fixed_files_staged (0.00s)
```

After:

```
--- PASS: Test_guard_wrap_stageFixed (0.00s)
    --- PASS: Test_guard_wrap_stageFixed/no_files_to_stage (0.00s)
    --- PASS: Test_guard_wrap_stageFixed/fixed_files_staged (0.00s)
    --- PASS: Test_guard_wrap_stageFixed/staging_fixed_files_fails (0.00s)
    --- PASS: Test_guard_wrap_stageFixed/staging_fixed_files_fails_with_partially_staged (0.00s)
```

`make test` and `make lint` (golangci-lint 2.11.4, 0 issues) pass. `make test-integration` passes 57/57; `tests/integration/run_interrupt.txt` is flaky on my machine but fails the same way on an unmodified `master`, so it is unrelated.

### Not changed

- No new config option. The issue offered "fail the hook, or make it configurable"; failing looks like the right default since the alternative is silently committing unfixed content, and `stage_fixed` already fails the hook for every other error in this path. Happy to put it behind a flag instead if you prefer to keep the old behaviour available.
- The `else` branch (`CanRestoreUnstagedChanges()` false) is untouched: it already overwrites `wrappedErr` with `errRestorationConflict`, so those runs fail regardless.
- No integration test — making `git add` fail deterministically inside testscript needs an index lock dance that would be more fragile than what it verifies.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["fix: add context to the staging error"](https://github.com/evilmartians/lefthook/commit/972ca7e62e84b144dc74ebb76c60c1875eb51409) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51478451)</sub>

<!-- /greptile_comment -->