### PR TITLE
fix: resolve push-files fallback against the remote-tracking ref

### DIFF
--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -600,5 +600,12 @@ func (r *Repo) readOriginHead() string {
 		return ""
 	}
 
-	return match[reHeadBranch.SubexpIndex("name")]
+	// Return the remote-tracking ref (e.g. "origin/main"), not the bare
+	// branch name: the bare name may not exist as a local branch (a clone
+	// that never checked out the default branch has no local "main"), which
+	// makes the diff in PushFiles fail and the whole hook error out. The
+	// remote-tracking ref always exists once origin/HEAD does, and reflects
+	// what was actually fetched rather than a possibly stale/absent local
+	// branch of the same name.
+	return "origin/" + match[reOriginHeadBranch.SubexpIndex("name")]
 }

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -285,11 +285,11 @@ func TestPushFiles(t *testing.T) {
 			switch command {
 			case "git diff --name-only HEAD @{push}":
 				return errors.New("no upstream configured")
-			case "git diff --name-only HEAD dev --":
+			case "git diff --name-only HEAD origin/dev --":
 				_, err := out.Write([]byte("other.txt\n"))
 				return err
-			case "git diff --name-only HEAD dev":
-				return errors.New("fatal: ambiguous argument 'dev': both revision and filename")
+			case "git diff --name-only HEAD origin/dev":
+				return errors.New("fatal: ambiguous argument 'origin/dev': both revision and filename")
 			default:
 				t.Fatalf("unexpected command: %s", command)
 				return nil
@@ -312,6 +312,64 @@ func TestPushFiles(t *testing.T) {
 		}
 
 		if want := []string{"other.txt"}; len(files) != len(want) || files[0] != want[0] {
+			t.Fatalf("expected %v, got %v", want, files)
+		}
+	})
+
+	t.Run("falls back to the remote-tracking ref when no local branch of that name exists", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		root := "/repo"
+		gitPath := filepath.Join(root, ".git")
+		originHead := filepath.Join(gitPath, "refs", "remotes", "origin", "HEAD")
+
+		if err := fs.MkdirAll(root, 0o755); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := fs.MkdirAll(filepath.Dir(originHead), 0o755); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := afero.WriteFile(fs, filepath.Join(root, "file.txt"), []byte("changed"), 0o644); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := afero.WriteFile(fs, originHead, []byte("ref: refs/remotes/origin/main\n"), 0o644); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		cmd := cmdtest.NewTracking(func(command string, _ string, out io.Writer) error {
+			switch command {
+			case "git diff --name-only HEAD @{push}":
+				// A branch pushed for the first time has no upstream yet.
+				return errors.New("fatal: no upstream configured for branch 'feature'")
+			case "git diff --name-only HEAD main --":
+				// There is no local branch named "main" in this clone (e.g.
+				// someone who always branches straight off origin/main), so
+				// this must never be run.
+				return errors.New("fatal: bad revision 'main'")
+			case "git diff --name-only HEAD origin/main --":
+				_, err := out.Write([]byte("file.txt\n"))
+				return err
+			default:
+				t.Fatalf("unexpected command: %s", command)
+				return nil
+			}
+		})
+
+		logger := loggertest.New()
+		repository := &Repo{
+			Fs:       fs,
+			RootPath: root,
+			GitPath:  gitPath,
+			Git:      NewCommander(cmd, logger),
+			logger:   logger,
+		}
+		repository.ResetCache()
+
+		files, err := repository.PushFiles()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if want := []string{"file.txt"}; len(files) != len(want) || files[0] != want[0] {
 			t.Fatalf("expected %v, got %v", want, files)
 		}
 	})


### PR DESCRIPTION
resolveHeadBranch() read origin/HEAD and returned the bare branch name (e.g. "main"), which PushFiles() then diffed against directly. In a clone that never checked out a local branch of that name (e.g. someone who always branches straight off origin/main), that local ref doesn't exist, so the diff fails with "fatal: bad revision 'main'" and the error propagates instead of falling through to the existing ls-tree fallback. Since pre-push always computes push-files internally to gate the {push_files}/{files} templates, this hard-fails the whole hook even for jobs that never reference either template.

Return the remote-tracking ref ("origin/main") instead, matching what the git-branch--remotes fallback path already produced. The remote-tracking ref always exists once origin/HEAD does, and reflects what was actually fetched rather than a possibly stale or entirely absent local branch of the same name.

Fixes #1474

### Context

Pre-push hooks that gate {push_files}/{files} templates were hard-failing entirely in clones without a local branch matching the remote's default branch name.

### Changes

internal/git/repo.go: resolveHeadBranch() now returns the remote-tracking ref instead of the bare branch name, consistent with the existing git-branch--remotes fallback path. Added a regression test in internal/git/repo_test.go.