### PR TITLE
docs: clarify signed-off commit example

### DIFF
--- a/docs/configuration/run.md
+++ b/docs/configuration/run.md
@@ -131,7 +131,7 @@ pre-commit:
 
 #### Git arguments
 
-Make sure commits are signed.
+Prevent commits from containing multiple sign-offs.
 
 ```yml
 # lefthook.yml


### PR DESCRIPTION
Closes #1490

### Context

The commit-msg example counts Signed-off-by trailers, but its heading says it checks whether commits are signed. This conflates DCO sign-off with cryptographic commit signatures.

### Changes

- Describe the example as rejecting multiple sign-offs, matching its less-than-two check.
- Verified with make lint, make test, and git diff --check.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The documentation-only clarification appears safe to merge.

The new wording accurately describes the unchanged example and introduces no behavioral, security, or documentation-contract issue.

<sub>Reviews (1): Last reviewed commit: ["docs: clarify signed-off commit example"](https://github.com/evilmartians/lefthook/commit/5d0eba3972a4ce43cce8af3a17285d1213831a98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53369261)</sub>

<!-- /greptile_comment -->