### PR TITLE
deps: bump Go to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evilmartians/lefthook/v2
 
-go 1.26.4
+go 1.26.6
 
 require (
 	charm.land/lipgloss/v2 v2.0.5


### PR DESCRIPTION
### Context

Fix GO-2026-5026 (CVE-2026-39821) in net/http Punycode handling.

### Changes

Update go 1.26.4 -> 1.26.6

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it makes only the intended Go patch-version update and introduces no identified regressions.

The changed directive selects Go 1.26.6 while leaving dependency versions and application behavior otherwise unchanged; the reported dependency advisories are pre-existing and not newly exposed by this change.

<sub>Reviews (1): Last reviewed commit: ["deps: bump Go to 1.26.6"](https://github.com/evilmartians/lefthook/commit/b7999d8723395ab329a981dac346994e14e4822f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53965273)</sub>

<!-- /greptile_comment -->