### PR TITLE
fix: inherit terminal size for PTY commands

### DIFF
--- a/internal/run/controller/exec/exec_unix.go
+++ b/internal/run/controller/exec/exec_unix.go
@@ -92,7 +92,7 @@ func (e CommandExecutor) execute(ctx context.Context, cmdstr string, args *execu
 			return err
 		}
 	case isatty.IsTerminal(os.Stdout.Fd()):
-		p, err := pty.Start(command)
+		p, err := startWithInheritedSize(command, os.Stdout)
 		if err != nil {
 			return err
 		}
@@ -126,4 +126,18 @@ func (e CommandExecutor) execute(ctx context.Context, cmdstr string, args *execu
 	defer func() { _ = command.Process.Kill() }()
 
 	return command.Wait()
+}
+
+func startWithInheritedSize(command *exec.Cmd, terminal *os.File) (*os.File, error) {
+	size, err := pty.GetsizeFull(terminal)
+	if err != nil {
+		return nil, fmt.Errorf("get terminal size: %w", err)
+	}
+
+	p, err := pty.StartWithSize(command, size)
+	if err != nil {
+		return nil, fmt.Errorf("start command with PTY: %w", err)
+	}
+
+	return p, nil
 }

--- a/internal/run/controller/exec/exec_unix_test.go
+++ b/internal/run/controller/exec/exec_unix_test.go
@@ -6,12 +6,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	osexec "os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/creack/pty"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/evilmartians/lefthook/v2/tests/helpers/loggertest"
@@ -123,6 +125,40 @@ func TestExecute_ContextCancellation(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Less(t, elapsed, 5*time.Second, "should return promptly after context cancellation")
+}
+
+func TestStartWithInheritedSize(t *testing.T) {
+	parentPTY, parentTTY, err := pty.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = parentPTY.Close() }()
+	defer func() { _ = parentTTY.Close() }()
+
+	expected := &pty.Winsize{Rows: 40, Cols: 120}
+	err = pty.Setsize(parentPTY, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	command := osexec.CommandContext(t.Context(), "sleep", "10")
+	childPTY, err := startWithInheritedSize(command, parentTTY)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = childPTY.Close() }()
+	defer func() {
+		_ = command.Process.Kill()
+		_ = command.Wait()
+	}()
+
+	actual, err := pty.GetsizeFull(childPTY)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, expected.Rows, actual.Rows)
+	assert.Equal(t, expected.Cols, actual.Cols)
 }
 
 func TestExecute_UseStdin(t *testing.T) {

--- a/internal/run/controller/exec/exec_unix_test.go
+++ b/internal/run/controller/exec/exec_unix_test.go
@@ -128,37 +128,47 @@ func TestExecute_ContextCancellation(t *testing.T) {
 }
 
 func TestStartWithInheritedSize(t *testing.T) {
-	parentPTY, parentTTY, err := pty.Open()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = parentPTY.Close() }()
-	defer func() { _ = parentTTY.Close() }()
+	for name, tt := range map[string]struct {
+		rows uint16
+		cols uint16
+	}{
+		"standard terminal": {rows: 40, cols: 120},
+		"minimal terminal":  {rows: 1, cols: 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			parentPTY, parentTTY, err := pty.Open()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = parentPTY.Close() }()
+			defer func() { _ = parentTTY.Close() }()
 
-	expected := &pty.Winsize{Rows: 40, Cols: 120}
-	err = pty.Setsize(parentPTY, expected)
-	if err != nil {
-		t.Fatal(err)
-	}
+			expected := &pty.Winsize{Rows: tt.rows, Cols: tt.cols}
+			err = pty.Setsize(parentPTY, expected)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	command := osexec.CommandContext(t.Context(), "sleep", "10")
-	childPTY, err := startWithInheritedSize(command, parentTTY)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = childPTY.Close() }()
-	defer func() {
-		_ = command.Process.Kill()
-		_ = command.Wait()
-	}()
+			command := osexec.CommandContext(t.Context(), "sleep", "10")
+			childPTY, err := startWithInheritedSize(command, parentTTY)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = childPTY.Close() }()
+			defer func() {
+				_ = command.Process.Kill()
+				_ = command.Wait()
+			}()
 
-	actual, err := pty.GetsizeFull(childPTY)
-	if err != nil {
-		t.Fatal(err)
-	}
+			actual, err := pty.GetsizeFull(childPTY)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	assert.Equal(t, expected.Rows, actual.Rows)
-	assert.Equal(t, expected.Cols, actual.Cols)
+			assert.Equal(t, expected.Rows, actual.Rows)
+			assert.Equal(t, expected.Cols, actual.Cols)
+		})
+	}
 }
 
 func TestExecute_UseStdin(t *testing.T) {


### PR DESCRIPTION
Closes #1497

### Context

Lefthook-created PTYs report zero rows and columns instead of inheriting the parent terminal size. TTY-aware child processes can consequently hang or fail; nano-staged's renderer loops indefinitely when its terminal width is zero.

### Changes

- Start child PTYs with dimensions read from the parent terminal.
- Add a regression test proving rows and columns are inherited.
- Verify the fix with `make lint`, `make test`, and the 120x40 minimal reproduction.