### PR TITLE
docs: correct Lefthook commit message configuration

### DIFF
--- a/docs/examples/commitlint.md
+++ b/docs/examples/commitlint.md
@@ -43,7 +43,7 @@ prepare-commit-msg:
       interactive: true
       run: yarn run cz --hook # Or npx cz --hook
       env:
-        LEFTHOOK: 0
+        LEFTHOOK: "0"
 
 # Validate commit messages
 commit-msg:


### PR DESCRIPTION
Closes # (issue)

### Context

<!-- Brief description of what problem PR is solving -->
Incorrect type. Expected "string".

### Changes

<!-- Summary for changes in the code -->
Updated LEFTHOOK environment variable to be a string.
