### PR TITLE
docs: hide contributors regenerate tip from the site

### DIFF
--- a/docs/misc/contributors.md
+++ b/docs/misc/contributors.md
@@ -33,4 +33,4 @@
 
 If you feel you’re missing from this list, feel free to add yourself in a PR.
 
-[//]: # 'curl https://api.github.com/repos/evilmartians/lefthook/contributors | jq ".[] | \"[\" + .login + \"]\" + \"(\" + .url + \")\""'
+[//]: # 'curl https://api.github.com/repos/evilmartians/lefthook/contributors | jq -r ".[] | \"- [\" + .login + \"](\" + .html_url + \")\""'

--- a/docs/misc/contributors.md
+++ b/docs/misc/contributors.md
@@ -33,6 +33,8 @@
 
 If you feel you’re missing from this list, feel free to add yourself in a PR.
 
-<!---
+To regenerate this list:
+
+```bash
 curl https://api.github.com/repos/evilmartians/lefthook/contributors | jq '.[] | "[" + .login + "]" + "(" + .url + ")"'
--->
+```

--- a/docs/misc/contributors.md
+++ b/docs/misc/contributors.md
@@ -33,8 +33,4 @@
 
 If you feel you’re missing from this list, feel free to add yourself in a PR.
 
-To regenerate this list:
-
-```bash
-curl https://api.github.com/repos/evilmartians/lefthook/contributors | jq '.[] | "[" + .login + "]" + "(" + .url + ")"'
-```
+[//]: # 'curl https://api.github.com/repos/evilmartians/lefthook/contributors | jq ".[] | \"[\" + .login + \"]\" + \"(\" + .url + \")\""'


### PR DESCRIPTION
## Summary
- The contributors page kept a `curl | jq` regenerate tip in an HTML comment (`<!--- ... -->`).
- Lefthook’s docs site is built with [docmd](https://docmd.io/), which defaults to `security.html: 'escape'`, so that comment is escaped and shown as visible text (also mangled by markdown-it’s typographer). Live example: https://lefthook.dev/misc/contributors/
- Enabling `security.html: 'allow'` would fix HTML comments but can also interpret placeholders like `<shell>` as tags, so instead use a markdown link-definition comment (`[//]: # '...'`) that stays in the source and does not render.

## Test plan
- [x] `docmd dev`: https://lefthook.dev/misc/contributors/ equivalent page ends at “feel free to add yourself in a PR.” — no curl / `&lt;!—` leak
- [x] Raw `docs/misc/contributors.md` still contains the regenerate command
- [ ] After merge/deploy, confirm https://lefthook.dev/misc/contributors/ no longer shows the leaked comment