### PR TITLE
fix: LEFTHOOK_OUTPUT precedence

### DIFF
--- a/docs/configuration/output.md
+++ b/docs/configuration/output.md
@@ -28,7 +28,7 @@ output:
   - skips          # Print "skip" (i.e. no files matched)
 ```
 
-You can also *extend* this list with an environment variable `LEFTHOOK_OUTPUT`:
+You can also override this list with the environment variable `LEFTHOOK_OUTPUT`:
 
 ```bash
 LEFTHOOK_OUTPUT="meta,success,summary" lefthook run pre-commit

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -82,8 +82,15 @@ func (l *Lefthook) Run(ctx context.Context, args RunArgs) error {
 	}
 
 	enableLogTags := os.Getenv(envOutput)
+	output := cfg.Output
+	if enableLogTags != "" {
+		output = enableLogTags
+		if enableLogTags == "false" {
+			output = false
+		}
+	}
 
-	exLogger := l.logger.NewExecutionLogger(enableLogTags, cfg.Output)
+	exLogger := l.logger.NewExecutionLogger(output)
 
 	if exLogger.Enabled(logger.LogMeta) {
 		exLogger.LogMeta(args.Hook)

--- a/tests/integration/output_env_issue_1496.txt
+++ b/tests/integration/output_env_issue_1496.txt
@@ -1,0 +1,26 @@
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add -A
+
+env NO_COLOR=1
+env LEFTHOOK_OUTPUT=meta
+exec lefthook run pre-commit --no-tty --no-auto-install
+stdout 'lefthook.*hook:.*pre-commit'
+! stdout 'linting'
+! stdout 'summary:'
+! stderr .
+
+env LEFTHOOK_OUTPUT=false
+exec lefthook run pre-commit --no-tty --no-auto-install
+! stdout .
+! stderr .
+
+-- lefthook.yml --
+output:
+  - summary
+
+pre-commit:
+  commands:
+    lint:
+      run: echo linting


### PR DESCRIPTION
Closes #1496

### Context

`LEFTHOOK_OUTPUT` was parsed, but the logger then combined it with the configured output value. This made the default configuration re-enable every output section and also prevented the environment variable from overriding an explicit `output` list.

### Changes

- Use a non-empty `LEFTHOOK_OUTPUT` value as the output setting, restoring its precedence over configuration.
- Honor the documented `LEFTHOOK_OUTPUT=false` behavior.
- Add CLI regression coverage and clarify the override behavior in the output documentation.

### Testing

- `go test -cpu 24 -race -count=1 -timeout=30s ./...`
- `make test-integration`
- `go vet ./...`
- `golangci-lint run`

### AI assistance

OpenAI Codex assisted with codebase analysis, implementation, tests, and validation. The resulting changes were reviewed against the repository history and contribution guidelines.
