### PR TITLE
ci: fix npm publishing by bumping Node to 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,11 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@12
 
       - uses: Raku/setup-raku@v1
       - name: Publish to NPM


### PR DESCRIPTION
Closes #1507

### Context

`publish-npm` dies before publishing: the job pins Node 20 but installs `npm@latest`, and npm 12 requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`. The "Update npm" step exits with `EBADENGINE`, so `Publish to NPM` is skipped and v2.1.11 never reached npm.

### Changes

- `publish-npm`: Node `20` → `24` (currently resolves to 24.19.0, satisfying npm 12)
- `npm@latest` → `npm@12`, so a future npm major bump can't break the release unnoticed
