### PR TITLE
fix: quote paths in the generated hook shim

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -33,9 +33,9 @@ call_lefthook()
     lefthook.bat "$@"
   {{ end -}}
   {{ if .LefthookPathCurrent -}}
-  elif {{ .LefthookPathCurrent }} -h >/dev/null 2>&1
+  elif {{ shellescape .LefthookPathCurrent }} -h >/dev/null 2>&1
   then
-    {{ .LefthookPathCurrent }} "$@"
+    {{ shellescape .LefthookPathCurrent }} "$@"
   {{ end -}}
   else
     dir="$(git rev-parse --show-toplevel)"

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -40,8 +40,10 @@ func Hook(hookName string, args Args) []byte {
 	}
 
 	buf := &bytes.Buffer{}
-	t := template.Must(template.ParseFS(templatesFS, "hook.tmpl"))
-	if err = t.Execute(buf, hookTmplData{
+	t := template.Must(template.New("hook.tmpl").Funcs(template.FuncMap{
+		"shellescape": shellescape,
+	}).ParseFS(templatesFS, "hook.tmpl"))
+	if err = t.ExecuteTemplate(buf, "hook.tmpl", hookTmplData{
 		HookName:                hookName,
 		Extension:               getExtension(),
 		Rc:                      args.Rc,
@@ -74,4 +76,14 @@ func getExtension() string {
 		return ".exe"
 	}
 	return ""
+}
+
+// shellescape wraps a value in POSIX single quotes so it is passed to the
+// generated hook verbatim. It is used for the auto-detected executable path
+// (os.Executable), which the user cannot quote themselves: a path with a
+// space was word-split and silently disabled every hook. The user-supplied
+// `lefthook` and `rc` values are intentionally not escaped, since they are
+// documented as commands and shell-expanded paths.
+func shellescape(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -1,0 +1,85 @@
+package templates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderHook(t *testing.T, data hookTmplData) string {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	tmpl := template.Must(template.New("hook.tmpl").Funcs(template.FuncMap{
+		"shellescape": shellescape,
+	}).ParseFS(templatesFS, "hook.tmpl"))
+	require.NoError(t, tmpl.ExecuteTemplate(buf, "hook.tmpl", data))
+	return buf.String()
+}
+
+func TestShellescape(t *testing.T) {
+	for name, tt := range map[string]struct {
+		value string
+		want  string
+	}{
+		"plain path":            {value: "/usr/bin/lefthook", want: `'/usr/bin/lefthook'`},
+		"path with space":       {value: "/home/my user/bin/lefthook", want: `'/home/my user/bin/lefthook'`},
+		"embedded single quote": {value: "/home/o'brien/lefthook", want: `'/home/o'\''brien/lefthook'`},
+		"metacharacters":        {value: "/tmp/$(touch pwned)", want: `'/tmp/$(touch pwned)'`},
+		"empty":                 {value: "", want: `''`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellescape(tt.value))
+		})
+	}
+}
+
+func TestHookQuotesAutodetectedExecutablePath(t *testing.T) {
+	hook := renderHook(t, hookTmplData{
+		HookName:            "pre-commit",
+		LefthookPathCurrent: "/home/my user/bin/lefthook",
+	})
+
+	assert.Contains(t, hook, `elif '/home/my user/bin/lefthook' -h >/dev/null 2>&1`)
+	assert.Contains(t, hook, `'/home/my user/bin/lefthook' "$@"`)
+	assert.NotContains(t, hook, `/home/my user/bin/lefthook -h`)
+}
+
+// The `lefthook` and `rc` config values are documented as commands and
+// shell-expanded paths, so they must reach the generated hook unquoted.
+func TestHookPreservesConfiguredCommandsAndExpansion(t *testing.T) {
+	for name, tt := range map[string]struct {
+		data hookTmplData
+		want string
+	}{
+		"lefthook path is a command with arguments": {
+			data: hookTmplData{HookName: "pre-commit", LefthookPath: "bundle exec lefthook"},
+			want: `bundle exec lefthook "$@"`,
+		},
+		"lefthook path carries an env prefix": {
+			data: hookTmplData{HookName: "pre-commit", LefthookPath: "LEFTHOOK_VERBOSE=1 lefthook"},
+			want: `LEFTHOOK_VERBOSE=1 lefthook "$@"`,
+		},
+		"rc path keeps tilde for the shell to expand": {
+			data: hookTmplData{HookName: "pre-commit", Rc: "~/.lefthookrc"},
+			want: `[ -f ~/.lefthookrc ] && . ~/.lefthookrc`,
+		},
+		"rc path keeps environment expansion": {
+			data: hookTmplData{HookName: "pre-commit", Rc: `"${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc"`},
+			want: `. "${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc"`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Contains(t, renderHook(t, tt.data), tt.want)
+		})
+	}
+}
+
+func TestHookPreservesUnaffectedContent(t *testing.T) {
+	hook := string(Hook("pre-commit", Args{}))
+	assert.True(t, strings.HasPrefix(hook, "#!/bin/sh"))
+	assert.Contains(t, hook, `call_lefthook run "pre-commit" "$@"`)
+}


### PR DESCRIPTION
Closes #1488

### Context

When `lefthook install` generates a hook, it bakes the path to the running binary (`os.Executable()`, the `.LefthookPathCurrent` template value) into the shim. That path was interpolated unquoted, so a binary living under a directory with a space (common on macOS: iCloud Drive, Google Drive, any folder with a space in its name) is word-split by the generated `sh`, every branch of `call_lefthook()` fails, and the shim prints `Can't find lefthook in PATH`. Because that terminal branch exits `0` (unless `AssertLefthookInstalled` is set), the commit still succeeds, so the hook is silently and permanently skipped with no signal. Unlike the config values, this path is detected at install time, so the user cannot quote it themselves.

Reproduced with the issue's steps (a lefthook binary living under `/tmp/my project/bin`):

- Before: the shim contains `elif /tmp/my project/bin/lefthook -h ...`; committing prints `Can't find lefthook in PATH` and succeeds with the hook never running.
- After: the shim contains `elif '/tmp/my project/bin/lefthook' -h ...`; committing runs the hook.

### Changes

- Added a `shellescape` template function (POSIX single quotes, `'\''` escaping) and applied it to the two `.LefthookPathCurrent` interpolations in `hook.tmpl`.
- Left the `lefthook` and `rc` config values unquoted on purpose: `lefthook` is documented as an executable path or command (e.g. `bundle exec lefthook`, `LEFTHOOK_VERBOSE=1 lefthook`), and `rc` is documented with tilde and environment-variable expansion (e.g. `~/.lefthookrc`, `"${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc"`). Those rely on the shell interpreting them, and the docs make quoting a spaced path there the user's responsibility. Escaping them would turn commands into nonexistent filenames and stop documented expansions from resolving.
- Added `internal/templates/templates_test.go`: table-driven tests that the auto-detected path is single-quoted, and that a configured command, an env-prefixed command, and tilde/env-expansion rc paths are passed through unquoted.

Verified locally: `go test ./internal/...` and `golangci-lint run` (pinned v2.11.4) pass. No config structs changed, so `schema.json` is untouched.
