### PR TITLE
fix: don't force-install hooks from the npm postinstall

### DIFF
--- a/docs/usage/commands/install.md
+++ b/docs/usage/commands/install.md
@@ -14,6 +14,8 @@ Reinstall is not required when you modify `lefthook.yml`, the configuration file
 
 ::: callout info Note
 NPM package `lefthook` installs the hooks in a postinstall script automatically. For projects not using NPM package run `lefthook install` after cloning the repo.
+
+The postinstall script runs a plain `lefthook install`, so when `core.hooksPath` is set it stops and prints the same message as running the command by hand. Run `lefthook install --force` or `lefthook install --reset-hooks-path` once, deliberately, to resolve it.
 :::
 
 ### Installing specific hooks

--- a/packaging/registries/npm-bundled/postinstall.js
+++ b/packaging/registries/npm-bundled/postinstall.js
@@ -3,8 +3,10 @@ if (!isEnabled(process.env.CI) || isEnabled(process.env.LEFTHOOK)) {
   const { spawnSync } = require('child_process');
   const { getExePath } = require('./get-exe');
 
-  // run install
-  spawnSync(getExePath(), ['install', '-f'], {
+  // run install. No -f: --force also tells `install` to proceed when
+  // core.hooksPath is set, and an unattended postinstall must not make that
+  // call. See packaging/registries/npm/lefthook/postinstall.js.
+  spawnSync(getExePath(), ['install'], {
     cwd: process.env.INIT_CWD || process.cwd(),
     stdio: 'inherit',
   });

--- a/packaging/registries/npm/lefthook/postinstall.js
+++ b/packaging/registries/npm/lefthook/postinstall.js
@@ -7,7 +7,11 @@ function install() {
     return
   }
 
-  spawnSync(getExePath(), ["install", "-f"], {
+  // No -f here. --force also tells `install` to proceed when core.hooksPath is
+  // set, and an unattended postinstall must not make that call: npm runs this
+  // from wherever it happens to be, including a temp clone of a git dependency,
+  // where the user's global hooks directory is what would get overwritten.
+  spawnSync(getExePath(), ["install"], {
     cwd: process.env.INIT_CWD || process.cwd(),
     stdio: "inherit",
   });


### PR DESCRIPTION
Closes #1487

### Context

`--force` means two things at once — `cmd/install.go` spells it out: *"overwrite .old files and proceed even if core.hooksPath is set"*. The npm postinstall runs `lefthook install -f`, so it wants the first half and silently gets the second, and the `core.hooksPath` guard added in #1292 never fires for anyone installing through npm.

It reaches past the project being installed. npm runs `prepare` for git dependencies in a temp clone under the npm cache; that clone is itself a git repo, so the user's **global** `core.hooksPath` applies to it. Installing an unrelated package can rewrite hooks shared by every repository on the machine, without anyone typing `lefthook install`.

Reproduced with a binary built from `master`, in a repo whose `core.hooksPath` holds a hand-written `pre-commit`:

```console
$ lefthook install
core.hooksPath is set locally to '.../hooks-global'
Custom hooks paths are not supported by default.
exit=1                      # hook untouched

$ lefthook install -f       # what the postinstall runs today
exit=0
$ head -1 .../hooks-global/pre-commit
#!/bin/sh                   # the lefthook wrapper; the original moved to pre-commit.old
```

### Changes

Drop `-f` from both postinstall scripts, and note the resulting behavior in the install docs.

Dropping it costs nothing here. `cleanHook` only consults `force` when a *foreign* hook and its `.old` backup both already exist — an existing lefthook hook is matched by `isLefthookFile` and removed without it, which is the case a postinstall actually hits on upgrade. `internal/command/install_test.go` already pins that as `"with existing lefthook hooks"` with `force` unset, and a second plain `lefthook install` against a real repo reports `sync hooks: ✔️(pre-commit)` and creates no `.old`.

The only behavior that changes is foreign-hook-plus-existing-`.old`, which now stops with the existing error instead of overwriting the backup unasked. `--force` is unchanged and still there for whoever means it.

`spawnSync` does not check the exit status, so `npm install` still succeeds; when the guard fires the user sees its message and instructions.

Not addressed here, from the same issue: the generated wrapper embeds the install-time absolute binary path. That's a separate concern and I'd rather it got its own issue than rode along on this one.

### Checklist

- [x] `make lint` passes — `go vet ./...` clean; `golangci-lint` not run locally (Windows), CI will cover it
- [x] `make test` passes — full `go test ./...` green
- [x] Docs updated if behavior changed or new config option added

*Branch note: based on the `2.1.11` commit rather than current `master`, because the token used here lacks the `workflow` scope needed to push newer upstream commits that touch `.github/workflows/`. None of the three files touched differ between the two, so it applies to `master` unchanged — happy to rebase.*

**AI disclosure:** this change was prepared with the assistance of Claude Code. I reviewed the change and the verification before opening, and I stand behind them as my own.
