### PR TITLE
fix(run): error when --job/--command matches nothing

### DIFF
--- a/internal/run/controller/controller.go
+++ b/internal/run/controller/controller.go
@@ -4,9 +4,11 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/evilmartians/lefthook/v2/internal/config"
@@ -104,8 +106,29 @@ func (c *Controller) RunHook(ctx context.Context, opts Options, hook *config.Hoo
 			results = c.sequentially(ctx, scope, hook.Jobs, hook.Piped)
 		}
 	})
+	if err != nil {
+		return results, err
+	}
 
-	return results, err
+	// If --job/--command was given but nothing in the hook matched it, every job
+	// (and therefore every top-level result, since a Group's status is `skip` only
+	// when all of its own sub-results are) was skipped rather than actually run.
+	// Without this check, a typo'd job/command name silently "succeeds" having done
+	// nothing at all.
+	if len(opts.RunOnlyJobs) > 0 && len(results) > 0 {
+		matched := false
+		for _, res := range results {
+			if !res.Skip() {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return results, fmt.Errorf("no job matching %s found in hook %q", strings.Join(opts.RunOnlyJobs, ", "), hook.Name)
+		}
+	}
+
+	return results, nil
 }
 
 func (c *Controller) concurrently(ctx context.Context, scope *scope, jobs []*config.Job) []result.Result {

--- a/internal/run/controller/controller_test.go
+++ b/internal/run/controller/controller_test.go
@@ -60,6 +60,8 @@ func TestRunAll(t *testing.T) {
 		gitCommands      []string
 		force            bool
 		skipLFS          bool
+		runOnlyJobs      []string
+		wantErr          bool
 	}{
 		"empty hook": {
 			hookName: "post-commit",
@@ -570,6 +572,28 @@ func TestRunAll(t *testing.T) {
 				"git diff --name-only HEAD @{push}",
 			},
 		},
+		"with --job matching an existing job": {
+			hookName: "post-commit",
+			hook: configtest.ParseHook(`
+        jobs:
+          - name: test
+            run: success
+          - name: lint
+            run: fail
+      `),
+			runOnlyJobs: []string{"test"},
+			success:     []result.Result{succeeded("test")},
+		},
+		"with --job matching nothing": {
+			hookName: "post-commit",
+			hook: configtest.ParseHook(`
+        jobs:
+          - name: test
+            run: success
+      `),
+			runOnlyJobs: []string{"nonexistent"},
+			wantErr:     true,
+		},
 		"with LFS disabled": {
 			hookName: "post-checkout",
 			skipLFS:  true,
@@ -632,13 +656,18 @@ func TestRunAll(t *testing.T) {
 			cmdExecutor.Reset()
 
 			opts := Options{
-				GitArgs:    tt.args,
-				Force:      tt.force,
-				SkipLFS:    tt.skipLFS,
-				SourceDirs: tt.sourceDirs,
+				GitArgs:     tt.args,
+				Force:       tt.force,
+				SkipLFS:     tt.skipLFS,
+				SourceDirs:  tt.sourceDirs,
+				RunOnlyJobs: tt.runOnlyJobs,
 			}
 			tt.hook.Name = tt.hookName
 			results, err := controller.RunHook(t.Context(), opts, tt.hook)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
 			assert.NoError(err)
 
 			var success, fail []result.Result

--- a/internal/run/result/result.go
+++ b/internal/run/result/result.go
@@ -27,6 +27,10 @@ func (r Result) Failure() bool {
 	return r.status == failure
 }
 
+func (r Result) Skip() bool {
+	return r.status == skip
+}
+
 func (r Result) Text() string {
 	return r.text
 }


### PR DESCRIPTION
Closes #1332

### Context

`lefthook run pre-commit --job nonexistent` (or `--command nonexistent`) exits 0 with no error. In `internal/run/controller/job.go`, a job that doesn't match `RunOnlyJobs` is simply skipped — nothing afterward checks whether *any* job in the hook actually matched the requested name, so a typo'd job/command name silently runs nothing and reports success.

### Changes

- Added `Result.Skip()` in `internal/run/result/result.go`, alongside the existing `Success()`/`Failure()` accessors.
- In `Controller.RunHook` (`internal/run/controller/controller.go`), after running the hook's jobs, check whether `RunOnlyJobs` was set and every top-level result came back as `Skip`. Since `result.Group` already reports `skip` only when *all* of its own sub-results are skip, this also correctly handles `--job <group-name>` without needing to touch the recursive job/scope filtering logic at all. If nothing matched, return an error (which the caller in `internal/command/run.go` already turns into a nonzero exit + printed message) instead of succeeding silently.

### Testing

- Added two cases to `TestRunAll` in `controller_test.go`: `--job` matching an existing job (still runs normally, other jobs skipped as before) and `--job` matching nothing (now returns an error).
- Verified the "matching nothing" case fails without the fix (via `git stash` on `controller.go`/`result.go`) and passes with it restored.
- `go test ./...` passes; `gofmt` and `go vet` are clean on the changed files.