### PR TITLE
fix(exec): expose lefthook binary on PATH for nested hook commands

### DIFF
--- a/internal/run/controller/exec/env.go
+++ b/internal/run/controller/exec/env.go
@@ -1,0 +1,65 @@
+package exec
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const lefthookBinEnv = "LEFTHOOK_BIN"
+
+// withLefthookEnv prepends the running lefthook binary's directory to PATH and
+// sets LEFTHOOK_BIN so nested hook commands like `run: lefthook validate` work
+// when git invokes hooks with a stripped PATH (see issue #1518).
+func withLefthookEnv(env []string) []string {
+	exe, err := os.Executable()
+	if err != nil || exe == "" {
+		return env
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return env
+	}
+	binDir := filepath.Dir(exe)
+
+	hasBin := false
+	hasPath := false
+	out := make([]string, 0, len(env)+2)
+
+	for _, entry := range env {
+		if strings.HasPrefix(entry, lefthookBinEnv+"=") {
+			hasBin = true
+			out = append(out, entry)
+			continue
+		}
+		if pathVal, ok := strings.CutPrefix(entry, "PATH="); ok {
+			hasPath = true
+			if !pathContainsDir(pathVal, binDir) {
+				out = append(out, "PATH="+binDir+string(os.PathListSeparator)+pathVal)
+			} else {
+				out = append(out, entry)
+			}
+			continue
+		}
+		out = append(out, entry)
+	}
+
+	if !hasBin {
+		out = append(out, fmt.Sprintf("%s=%s", lefthookBinEnv, exe))
+	}
+	if !hasPath {
+		out = append(out, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
+
+	return out
+}
+
+func pathContainsDir(pathEnv, dir string) bool {
+	for _, part := range strings.Split(pathEnv, string(os.PathListSeparator)) {
+		if part == dir {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/run/controller/exec/env.go
+++ b/internal/run/controller/exec/env.go
@@ -5,22 +5,45 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/evilmartians/lefthook/v2/internal/logger"
 )
 
 const lefthookBinEnv = "LEFTHOOK_BIN"
 
+var (
+	executablePath = os.Executable
+	evalSymlinks   = filepath.EvalSymlinks
+)
+
 // withLefthookEnv prepends the running lefthook binary's directory to PATH and
 // sets LEFTHOOK_BIN so nested hook commands like `run: lefthook validate` work
 // when git invokes hooks with a stripped PATH (see issue #1518).
-func withLefthookEnv(env []string) []string {
-	exe, err := os.Executable()
-	if err != nil || exe == "" {
-		return env
-	}
-	exe, err = filepath.EvalSymlinks(exe)
+func withLefthookEnv(env []string, log *logger.ExecutionLogger) []string {
+	exe, err := executablePath()
 	if err != nil {
+		if log != nil {
+			log.Warnf("Could not enrich hook PATH with lefthook binary: %v\n", err)
+		}
 		return env
 	}
+	if exe == "" {
+		if log != nil {
+			log.Warnf("Could not enrich hook PATH: empty executable path\n")
+		}
+		return env
+	}
+	exe, err = evalSymlinks(exe)
+	if err != nil {
+		if log != nil {
+			log.Warnf("Could not resolve lefthook binary path: %v\n", err)
+		}
+		return env
+	}
+	return enrichEnvWithLefthookBinary(env, exe)
+}
+
+func enrichEnvWithLefthookBinary(env []string, exe string) []string {
 	binDir := filepath.Dir(exe)
 
 	hasBin := false

--- a/internal/run/controller/exec/env_test.go
+++ b/internal/run/controller/exec/env_test.go
@@ -1,6 +1,8 @@
 package exec
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,46 +10,122 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/evilmartians/lefthook/v2/internal/logger"
 )
 
-func TestWithLefthookEnv(t *testing.T) {
+func TestEnrichEnvWithLefthookBinary(t *testing.T) {
+	const exe = "/tmp/lefthook-bin/lefthook"
+	binDir := filepath.Dir(exe)
+
+	for name, tt := range map[string]struct {
+		env      []string
+		contains []string
+		excludes []string
+		pathOnce bool
+	}{
+		"sets LEFTHOOK_BIN and prepends PATH": {
+			env: []string{"FOO=bar", "PATH=/usr/bin"},
+			contains: []string{
+				"FOO=bar",
+				lefthookBinEnv + "=" + exe,
+			},
+		},
+		"does not override existing LEFTHOOK_BIN": {
+			env: []string{lefthookBinEnv + "=/custom/lefthook", "PATH=/usr/bin"},
+			contains: []string{
+				lefthookBinEnv + "=/custom/lefthook",
+			},
+			excludes: []string{lefthookBinEnv + "=" + exe},
+		},
+		"does not duplicate bin dir in PATH": {
+			env:      []string{"PATH=" + binDir + ":/usr/bin"},
+			pathOnce: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			env := enrichEnvWithLefthookBinary(tt.env, exe)
+
+			for _, want := range tt.contains {
+				assert.Contains(t, env, want)
+			}
+			for _, omit := range tt.excludes {
+				assert.NotContains(t, env, omit)
+			}
+
+			if name == "sets LEFTHOOK_BIN and prepends PATH" {
+				pathEntry := envEntry(env, "PATH=")
+				require.NotEmpty(t, pathEntry)
+				assert.True(t, strings.HasPrefix(pathEntry, "PATH="+binDir+string(os.PathListSeparator)))
+				assert.Contains(t, pathEntry, "/usr/bin")
+			}
+
+			if tt.pathOnce {
+				assert.Equal(t, 1, strings.Count(strings.Join(env, "\n"), "PATH="))
+			}
+		})
+	}
+}
+
+func TestWithLefthookEnv_resolutionErrors(t *testing.T) {
+	for name, tt := range map[string]struct {
+		executable func() (string, error)
+		eval       func(string) (string, error)
+		wantWarn   string
+	}{
+		"executable discovery error": {
+			executable: func() (string, error) { return "", errors.New("no exe") },
+			eval:       filepath.EvalSymlinks,
+			wantWarn:   "Could not enrich hook PATH with lefthook binary: no exe",
+		},
+		"empty executable path": {
+			executable: func() (string, error) { return "", nil },
+			eval:       filepath.EvalSymlinks,
+			wantWarn:   "Could not enrich hook PATH: empty executable path",
+		},
+		"symlink resolution error": {
+			executable: func() (string, error) { return "/tmp/lefthook", nil },
+			eval:       func(string) (string, error) { return "", errors.New("broken symlink") },
+			wantWarn:   "Could not resolve lefthook binary path: broken symlink",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			oldExecutable := executablePath
+			oldEval := evalSymlinks
+			executablePath = tt.executable
+			evalSymlinks = tt.eval
+			t.Cleanup(func() {
+				executablePath = oldExecutable
+				evalSymlinks = oldEval
+			})
+
+			var buf bytes.Buffer
+			log := logger.New(&buf).NewExecutionLogger()
+			in := []string{"FOO=bar", "PATH=/usr/bin"}
+
+			got := withLefthookEnv(in, log)
+
+			assert.Equal(t, in, got)
+			assert.Contains(t, buf.String(), tt.wantWarn)
+		})
+	}
+}
+
+func TestWithLefthookEnv_usesRunningBinary(t *testing.T) {
 	exe, err := os.Executable()
 	require.NoError(t, err)
 	exe, err = filepath.EvalSymlinks(exe)
 	require.NoError(t, err)
-	binDir := filepath.Dir(exe)
 
-	t.Run("sets LEFTHOOK_BIN and prepends PATH", func(t *testing.T) {
-		env := withLefthookEnv([]string{"FOO=bar", "PATH=/usr/bin"})
-		assert.Contains(t, env, "FOO=bar")
-		assert.Contains(t, env, lefthookBinEnv+"="+exe)
+	env := withLefthookEnv([]string{"FOO=bar", "PATH=/usr/bin"}, nil)
+	assert.Contains(t, env, lefthookBinEnv+"="+exe)
+}
 
-		var pathEntry string
-		for _, e := range env {
-			if strings.HasPrefix(e, "PATH=") {
-				pathEntry = e
-				break
-			}
+func envEntry(env []string, prefix string) string {
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return entry
 		}
-		require.NotEmpty(t, pathEntry)
-		assert.True(t, strings.HasPrefix(pathEntry, "PATH="+binDir+string(os.PathListSeparator)))
-		assert.Contains(t, pathEntry, "/usr/bin")
-	})
-
-	t.Run("does not override existing LEFTHOOK_BIN", func(t *testing.T) {
-		env := withLefthookEnv([]string{lefthookBinEnv + "=/custom/lefthook", "PATH=/usr/bin"})
-		assert.Contains(t, env, lefthookBinEnv+"=/custom/lefthook")
-		assert.NotContains(t, env, lefthookBinEnv+"="+exe)
-	})
-
-	t.Run("does not duplicate bin dir in PATH", func(t *testing.T) {
-		env := withLefthookEnv([]string{"PATH=" + binDir + ":/usr/bin"})
-		pathCount := 0
-		for _, e := range env {
-			if strings.HasPrefix(e, "PATH=") {
-				pathCount++
-			}
-		}
-		assert.Equal(t, 1, pathCount)
-	})
+	}
+	return ""
 }

--- a/internal/run/controller/exec/env_test.go
+++ b/internal/run/controller/exec/env_test.go
@@ -1,0 +1,53 @@
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithLefthookEnv(t *testing.T) {
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	exe, err = filepath.EvalSymlinks(exe)
+	require.NoError(t, err)
+	binDir := filepath.Dir(exe)
+
+	t.Run("sets LEFTHOOK_BIN and prepends PATH", func(t *testing.T) {
+		env := withLefthookEnv([]string{"FOO=bar", "PATH=/usr/bin"})
+		assert.Contains(t, env, "FOO=bar")
+		assert.Contains(t, env, lefthookBinEnv+"="+exe)
+
+		var pathEntry string
+		for _, e := range env {
+			if strings.HasPrefix(e, "PATH=") {
+				pathEntry = e
+				break
+			}
+		}
+		require.NotEmpty(t, pathEntry)
+		assert.True(t, strings.HasPrefix(pathEntry, "PATH="+binDir+string(os.PathListSeparator)))
+		assert.Contains(t, pathEntry, "/usr/bin")
+	})
+
+	t.Run("does not override existing LEFTHOOK_BIN", func(t *testing.T) {
+		env := withLefthookEnv([]string{lefthookBinEnv + "=/custom/lefthook", "PATH=/usr/bin"})
+		assert.Contains(t, env, lefthookBinEnv+"=/custom/lefthook")
+		assert.NotContains(t, env, lefthookBinEnv+"="+exe)
+	})
+
+	t.Run("does not duplicate bin dir in PATH", func(t *testing.T) {
+		env := withLefthookEnv([]string{"PATH=" + binDir + ":/usr/bin"})
+		pathCount := 0
+		for _, e := range env {
+			if strings.HasPrefix(e, "PATH=") {
+				pathCount++
+			}
+		}
+		assert.Equal(t, 1, pathCount)
+	})
+}

--- a/internal/run/controller/exec/exec_unix.go
+++ b/internal/run/controller/exec/exec_unix.go
@@ -80,7 +80,7 @@ func (e CommandExecutor) execute(ctx context.Context, cmdstr string, args *execu
 	e.logger.Debug("[lefthook] run: ", cmdstr)
 	command := exec.CommandContext(ctx, "sh", "-c", cmdstr)
 	command.Dir = args.root
-	command.Env = append(os.Environ(), args.envs...)
+	command.Env = withLefthookEnv(append(os.Environ(), args.envs...))
 
 	switch {
 	case args.interactive || args.useStdin:

--- a/internal/run/controller/exec/exec_unix.go
+++ b/internal/run/controller/exec/exec_unix.go
@@ -80,7 +80,7 @@ func (e CommandExecutor) execute(ctx context.Context, cmdstr string, args *execu
 	e.logger.Debug("[lefthook] run: ", cmdstr)
 	command := exec.CommandContext(ctx, "sh", "-c", cmdstr)
 	command.Dir = args.root
-	command.Env = withLefthookEnv(append(os.Environ(), args.envs...))
+	command.Env = withLefthookEnv(append(os.Environ(), args.envs...), e.logger)
 
 	switch {
 	case args.interactive || args.useStdin:

--- a/internal/run/controller/exec/exec_windows.go
+++ b/internal/run/controller/exec/exec_windows.go
@@ -84,7 +84,7 @@ func (e CommandExecutor) execute(ctx context.Context, cmdstr string, args *execu
 		CmdLine: cmdLine,
 	}
 	command.Dir = args.root
-	command.Env = append(os.Environ(), args.envs...)
+	command.Env = withLefthookEnv(append(os.Environ(), args.envs...))
 
 	command.Stdout = args.out
 	command.Stdin = args.in

--- a/internal/run/controller/exec/exec_windows.go
+++ b/internal/run/controller/exec/exec_windows.go
@@ -84,7 +84,7 @@ func (e CommandExecutor) execute(ctx context.Context, cmdstr string, args *execu
 		CmdLine: cmdLine,
 	}
 	command.Dir = args.root
-	command.Env = withLefthookEnv(append(os.Environ(), args.envs...))
+	command.Env = withLefthookEnv(append(os.Environ(), args.envs...), e.logger)
 
 	command.Stdout = args.out
 	command.Stdin = args.in


### PR DESCRIPTION
## Summary
- When git invokes hooks (especially `pre-push`), the environment often has a stripped `PATH`
- Nested jobs like `run: lefthook validate` then fail with `sh: lefthook: command not found` even though the parent process is lefthook
- Prepend the running binary's directory to `PATH` and set `LEFTHOOK_BIN` for every job command

Fixes #1518

## Test plan
- [x] Unit tests for `withLefthookEnv` (`env_test.go`)
- [ ] CI `go test ./internal/run/controller/exec/...`