### PR TITLE
fix(run): propagate job exit codes for agent hooks

### DIFF
--- a/internal/command/exitcode.go
+++ b/internal/command/exitcode.go
@@ -1,0 +1,12 @@
+package command
+
+// HookExitError is returned from `lefthook run` when hooks fail. Main uses
+// Code as the process exit status so agent integrations (Claude Code Stop /
+// PreToolUse) can block on exit code 2.
+type HookExitError struct {
+	Code int
+}
+
+func (e *HookExitError) Error() string {
+	return ""
+}

--- a/internal/command/install_ai.go
+++ b/internal/command/install_ai.go
@@ -60,7 +60,7 @@ func lefthookRunCommand(bin, hookName string, quoteBin bool) string {
 		bin = shellQuotePath(bin)
 	}
 
-	return bin + lefthookRunSuffix + hookName
+	return "LEFTHOOK_AGENT=1 " + bin + lefthookRunSuffix + hookName
 }
 
 func shellQuotePath(path string) string {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -21,6 +21,7 @@ import (
 const (
 	envEnabled = "LEFTHOOK"        // "0", "false"
 	envOutput  = "LEFTHOOK_OUTPUT" // "meta,success,failure,summary,skips,execution,execution_out,execution_info"
+	envAgent   = "LEFTHOOK_AGENT"  // "1", "true" — propagate job exit codes (Claude/Cursor agent hooks)
 )
 
 var errPipedAndParallelSet = errors.New("conflicting options 'piped' and 'parallel' are set to 'true', remove one of this option from hook group")
@@ -276,13 +277,34 @@ func (l *Lefthook) runHook(
 
 	l.logSummary(exLogger, time.Since(startTime), results)
 
-	for _, result := range results {
-		if result.Failure() {
+	agentMode := os.Getenv(envAgent) == "1" || os.Getenv(envAgent) == "true"
+	for _, res := range results {
+		if res.Failure() {
+			if agentMode {
+				return &HookExitError{Code: maxFailureExitCode(results)}
+			}
 			return errors.New("") // No error should be printed
 		}
 	}
 
 	return nil
+}
+
+func maxFailureExitCode(results []result.Result) int {
+	maxCode := 1
+	var walk func([]result.Result)
+	walk = func(rs []result.Result) {
+		for _, res := range rs {
+			if res.Failure() {
+				if code := res.ExitCode(); code > maxCode {
+					maxCode = code
+				}
+			}
+			walk(res.Sub)
+		}
+	}
+	walk(results)
+	return maxCode
 }
 
 func (l *Lefthook) logSummary(

--- a/internal/run/controller/job.go
+++ b/internal/run/controller/job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"maps"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -149,7 +150,11 @@ func (c *Controller) runSingleJob(ctx context.Context, scope *scope, id string, 
 			return result.Failure(name, "timeout ("+job.Timeout.String()+")", executionTime)
 		}
 
-		return result.Failure(name, job.FailText, executionTime)
+		failText := job.FailText
+		if failText == "" {
+			failText = err.Error()
+		}
+		return result.FailureWithCode(name, failText, executionTime, commandExitCode(err))
 	}
 
 	if config.HookUsesStagedFiles(scope.hookName) && job.StageFixed && !scope.opts.NoStageFixed {
@@ -200,4 +205,12 @@ func (c *Controller) skipReason(scope *scope, job *config.Job, name string) stri
 	}
 
 	return ""
+}
+
+func commandExitCode(err error) int {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return 1
 }

--- a/internal/run/result/result.go
+++ b/internal/run/result/result.go
@@ -16,6 +16,7 @@ type Result struct {
 	Name     string
 	text     string
 	status   status
+	exitCode int
 	Duration time.Duration
 }
 
@@ -31,6 +32,17 @@ func (r Result) Text() string {
 	return r.text
 }
 
+// ExitCode returns the subprocess exit code for failed jobs (defaults to 1).
+func (r Result) ExitCode() int {
+	if r.exitCode > 0 {
+		return r.exitCode
+	}
+	if r.Failure() {
+		return 1
+	}
+	return 0
+}
+
 func Skip(name string) Result {
 	return Result{Name: name, status: skip}
 }
@@ -40,13 +52,21 @@ func Success(name string, duration time.Duration) Result {
 }
 
 func Failure(name, text string, duration time.Duration) Result {
-	return Result{Name: name, status: failure, text: text, Duration: duration}
+	return FailureWithCode(name, text, duration, 1)
+}
+
+func FailureWithCode(name, text string, duration time.Duration, exitCode int) Result {
+	if exitCode == 0 {
+		exitCode = 1
+	}
+	return Result{Name: name, status: failure, text: text, Duration: duration, exitCode: exitCode}
 }
 
 func Group(name string, results []Result) Result {
 	stat := success
 	allSkip := true
 	var totalDuration time.Duration
+	maxExitCode := 0
 	for _, res := range results {
 		switch res.status {
 		case success:
@@ -54,6 +74,9 @@ func Group(name string, results []Result) Result {
 		case failure:
 			stat = failure
 			allSkip = false
+			if code := res.ExitCode(); code > maxExitCode {
+				maxExitCode = code
+			}
 		case skip:
 		}
 		totalDuration += res.Duration
@@ -63,5 +86,5 @@ func Group(name string, results []Result) Result {
 		stat = skip
 	}
 
-	return Result{Name: name, status: stat, Sub: results, Duration: totalDuration}
+	return Result{Name: name, status: stat, Sub: results, Duration: totalDuration, exitCode: maxExitCode}
 }

--- a/main.go
+++ b/main.go
@@ -2,14 +2,20 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/evilmartians/lefthook/v2/cmd"
+	"github.com/evilmartians/lefthook/v2/internal/command"
 )
 
 func main() {
 	if err := cmd.Lefthook().Run(context.Background(), os.Args); err != nil {
+		var hookExit *command.HookExitError
+		if errors.As(err, &hookExit) {
+			os.Exit(hookExit.Code)
+		}
 		if err.Error() != "" {
 			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		}


### PR DESCRIPTION
## Summary
- Claude Code Stop/PreToolUse hooks only block when the command exits **2**; `lefthook run` previously always exited **1** on failure
- When `LEFTHOOK_AGENT=1`, propagate the highest failing job exit code to the process exit status
- Generated `ai:` hook commands now prefix `LEFTHOOK_AGENT=1` automatically

Fixes #1511

## Test plan
- [x] Updated `install_ai_test.go` expectations for generated commands
- [ ] CI unit/integration tests