### PR TITLE
fix(templates): quote hook shim paths that contain spaces

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -10,7 +10,7 @@ fi
 
 {{- if .Rc}}
 {{/* Load rc file, which may export ENV variables */}}
-[ -f "{{.Rc}}" ] && . "{{.Rc}}"
+[ -f {{.Rc}} ] && . {{.Rc}}
 {{- end}}
 
 call_lefthook()
@@ -18,10 +18,10 @@ call_lefthook()
   if test -n "$LEFTHOOK_BIN"
   then
     "$LEFTHOOK_BIN" "$@"
-  {{ if .LefthookPath -}}
-  elif test -n "{{ .LefthookPath }}"
+  {{ if .LefthookPathInvoke -}}
+  elif test -n {{ .LefthookPathTest }}
   then
-    "{{ .LefthookPath }}" "$@"
+    {{ .LefthookPathInvoke }} "$@"
   {{ end -}}
   elif lefthook{{.Extension}} -h >/dev/null 2>&1
   then
@@ -33,9 +33,9 @@ call_lefthook()
     lefthook.bat "$@"
   {{ end -}}
   {{ if .LefthookPathCurrent -}}
-  elif "{{ .LefthookPathCurrent }}" -h >/dev/null 2>&1
+  elif {{ .LefthookPathCurrentTest }} -h >/dev/null 2>&1
   then
-    "{{ .LefthookPathCurrent }}" "$@"
+    {{ .LefthookPathCurrent }} "$@"
   {{ end -}}
   else
     dir="$(git rev-parse --show-toplevel)"

--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -10,7 +10,7 @@ fi
 
 {{- if .Rc}}
 {{/* Load rc file, which may export ENV variables */}}
-[ -f {{.Rc}} ] && . {{.Rc}}
+[ -f "{{.Rc}}" ] && . "{{.Rc}}"
 {{- end}}
 
 call_lefthook()
@@ -21,7 +21,7 @@ call_lefthook()
   {{ if .LefthookPath -}}
   elif test -n "{{ .LefthookPath }}"
   then
-    {{ .LefthookPath }} "$@"
+    "{{ .LefthookPath }}" "$@"
   {{ end -}}
   elif lefthook{{.Extension}} -h >/dev/null 2>&1
   then
@@ -33,9 +33,9 @@ call_lefthook()
     lefthook.bat "$@"
   {{ end -}}
   {{ if .LefthookPathCurrent -}}
-  elif {{ .LefthookPathCurrent }} -h >/dev/null 2>&1
+  elif "{{ .LefthookPathCurrent }}" -h >/dev/null 2>&1
   then
-    {{ .LefthookPathCurrent }} "$@"
+    "{{ .LefthookPathCurrent }}" "$@"
   {{ end -}}
   else
     dir="$(git rev-parse --show-toplevel)"

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -44,11 +44,11 @@ func Hook(hookName string, args Args) []byte {
 	if err = t.Execute(buf, hookTmplData{
 		HookName:                hookName,
 		Extension:               getExtension(),
-		Rc:                      args.Rc,
+		Rc:                      shellDoubleQuote(filepath.ToSlash(args.Rc)),
 		AssertLefthookInstalled: args.AssertLefthookInstalled,
 		Roots:                   args.Roots,
-		LefthookPath:            filepath.ToSlash(strings.ReplaceAll(strings.TrimSpace(args.LefthookPath), "\n", ";")),
-		LefthookPathCurrent:     filepath.ToSlash(lefthookPathCurrent),
+		LefthookPath:            shellDoubleQuote(filepath.ToSlash(strings.ReplaceAll(strings.TrimSpace(args.LefthookPath), "\n", ";"))),
+		LefthookPathCurrent:     shellDoubleQuote(filepath.ToSlash(lefthookPathCurrent)),
 	}); err != nil {
 		panic(err)
 	}
@@ -74,4 +74,18 @@ func getExtension() string {
 		return ".exe"
 	}
 	return ""
+}
+
+// shellDoubleQuote escapes a path for use inside double quotes in /bin/sh.
+func shellDoubleQuote(s string) string {
+	if s == "" {
+		return ""
+	}
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		`$`, `\$`,
+		"`", "\\`",
+	)
+	return replacer.Replace(s)
 }

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -16,6 +16,9 @@ const checksumFormat = "%s %d %s\n"
 //go:embed *
 var templatesFS embed.FS
 
+// hookExecutable is os.Executable in production; tests may override it.
+var hookExecutable = os.Executable
+
 type Args struct {
 	Rc                      string
 	LefthookPath            string
@@ -36,7 +39,7 @@ type hookTmplData struct {
 }
 
 func Hook(hookName string, args Args) []byte {
-	lefthookPathCurrent, err := os.Executable()
+	lefthookPathCurrent, err := hookExecutable()
 	if err != nil {
 		lefthookPathCurrent = ""
 	}
@@ -117,6 +120,12 @@ func shellInvokeForLefthookPath(value string) string {
 }
 
 func looksLikeFilePath(value string) bool {
+	if value == "" || containsShellCommandSyntax(value) {
+		return false
+	}
+	if strings.Contains(value, " ") {
+		return strings.Contains(value, "/")
+	}
 	if filepath.IsAbs(value) {
 		return true
 	}
@@ -124,9 +133,24 @@ func looksLikeFilePath(value string) bool {
 		return true
 	}
 
-	return strings.Contains(value, "/") &&
-		!strings.Contains(value, " exec ") &&
-		!strings.Contains(value, " run ")
+	return strings.Contains(value, "/")
+}
+
+func containsShellCommandSyntax(value string) bool {
+	lower := " " + strings.ToLower(value) + " "
+	for _, token := range []string{" exec ", " run ", " tool ", " env "} {
+		if strings.Contains(lower, token) {
+			return true
+		}
+	}
+	if strings.Contains(value, " --") {
+		return true
+	}
+	if strings.Contains(value, " ") && !strings.Contains(value, "/") {
+		return true
+	}
+
+	return false
 }
 
 // shellEscapeDoubleQuote escapes characters that break double-quoted /bin/sh words.

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -26,7 +26,9 @@ type Args struct {
 type hookTmplData struct {
 	HookName                string
 	Extension               string
-	LefthookPath            string
+	LefthookPathTest        string
+	LefthookPathInvoke      string
+	LefthookPathCurrentTest string
 	LefthookPathCurrent     string
 	Rc                      string
 	Roots                   []string
@@ -38,17 +40,22 @@ func Hook(hookName string, args Args) []byte {
 	if err != nil {
 		lefthookPathCurrent = ""
 	}
+	lefthookPathCurrent = filepath.ToSlash(lefthookPathCurrent)
+
+	lefthookPath := filepath.ToSlash(strings.ReplaceAll(strings.TrimSpace(args.LefthookPath), "\n", ";"))
 
 	buf := &bytes.Buffer{}
 	t := template.Must(template.ParseFS(templatesFS, "hook.tmpl"))
 	if err = t.Execute(buf, hookTmplData{
 		HookName:                hookName,
 		Extension:               getExtension(),
-		Rc:                      shellDoubleQuote(filepath.ToSlash(args.Rc)),
+		Rc:                      shellWordForPath(filepath.ToSlash(args.Rc)),
 		AssertLefthookInstalled: args.AssertLefthookInstalled,
 		Roots:                   args.Roots,
-		LefthookPath:            shellDoubleQuote(filepath.ToSlash(strings.ReplaceAll(strings.TrimSpace(args.LefthookPath), "\n", ";"))),
-		LefthookPathCurrent:     shellDoubleQuote(filepath.ToSlash(lefthookPathCurrent)),
+		LefthookPathTest:        shellWordForTest(lefthookPath),
+		LefthookPathInvoke:      shellInvokeForLefthookPath(lefthookPath),
+		LefthookPathCurrentTest: shellWordForPath(lefthookPathCurrent),
+		LefthookPathCurrent:     shellWordForPath(lefthookPathCurrent),
 	}); err != nil {
 		panic(err)
 	}
@@ -76,16 +83,57 @@ func getExtension() string {
 	return ""
 }
 
-// shellDoubleQuote escapes a path for use inside double quotes in /bin/sh.
-func shellDoubleQuote(s string) string {
-	if s == "" {
+// shellWordForPath returns a /bin/sh word for a filesystem path, quoting only when needed.
+func shellWordForPath(path string) string {
+	if path == "" {
 		return ""
 	}
+	if !strings.Contains(path, " ") {
+		return path
+	}
+
+	return `"` + shellEscapeDoubleQuote(path) + `"`
+}
+
+// shellWordForTest returns a double-quoted /bin/sh word for test -n / test -f checks.
+func shellWordForTest(value string) string {
+	if value == "" {
+		return `""`
+	}
+
+	return `"` + shellEscapeDoubleQuote(value) + `"`
+}
+
+// shellInvokeForLefthookPath preserves arbitrary shell commands while quoting path-like values.
+func shellInvokeForLefthookPath(value string) string {
+	if value == "" {
+		return ""
+	}
+	if looksLikeFilePath(value) {
+		return shellWordForPath(value)
+	}
+
+	return value
+}
+
+func looksLikeFilePath(value string) bool {
+	if filepath.IsAbs(value) {
+		return true
+	}
+	if strings.HasPrefix(value, "./") || strings.HasPrefix(value, "../") {
+		return true
+	}
+
+	return strings.Contains(value, "/") &&
+		!strings.Contains(value, " exec ") &&
+		!strings.Contains(value, " run ")
+}
+
+// shellEscapeDoubleQuote escapes characters that break double-quoted /bin/sh words.
+func shellEscapeDoubleQuote(value string) string {
 	replacer := strings.NewReplacer(
 		`\`, `\\`,
 		`"`, `\"`,
-		`$`, `\$`,
-		"`", "\\`",
 	)
-	return replacer.Replace(s)
+	return replacer.Replace(value)
 }

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -52,7 +52,7 @@ func Hook(hookName string, args Args) []byte {
 	if err = t.Execute(buf, hookTmplData{
 		HookName:                hookName,
 		Extension:               getExtension(),
-		Rc:                      shellWordForPath(filepath.ToSlash(args.Rc)),
+		Rc:                      shellWordForRc(filepath.ToSlash(args.Rc)),
 		AssertLefthookInstalled: args.AssertLefthookInstalled,
 		Roots:                   args.Roots,
 		LefthookPathTest:        shellWordForTest(lefthookPath),
@@ -84,6 +84,25 @@ func getExtension() string {
 		return ".exe"
 	}
 	return ""
+}
+
+// shellWordForRc returns a /bin/sh word for an rc file path or documented shell expression.
+func shellWordForRc(value string) string {
+	if value == "" {
+		return ""
+	}
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(trimmed, `"`) && strings.HasSuffix(trimmed, `"`) {
+		return trimmed
+	}
+	if strings.Contains(trimmed, "$") {
+		if strings.Contains(trimmed, " ") {
+			return `"` + shellEscapeDoubleQuote(trimmed) + `"`
+		}
+		return trimmed
+	}
+
+	return shellWordForPath(trimmed)
 }
 
 // shellWordForPath returns a /bin/sh word for a filesystem path, quoting only when needed.
@@ -137,17 +156,26 @@ func looksLikeFilePath(value string) bool {
 }
 
 func containsShellCommandSyntax(value string) bool {
+	if strings.Contains(value, ";") {
+		return true
+	}
 	lower := " " + strings.ToLower(value) + " "
 	for _, token := range []string{" exec ", " run ", " tool ", " env "} {
 		if strings.Contains(lower, token) {
 			return true
 		}
 	}
-	if strings.Contains(value, " --") {
+	if strings.Contains(value, " --") || strings.Contains(value, " -") {
 		return true
 	}
-	if strings.Contains(value, " ") && !strings.Contains(value, "/") {
+	if strings.Contains(value, " ") && strings.Contains(value, "=") {
 		return true
+	}
+	if idx := strings.Index(value, " "); idx > 0 {
+		first := value[:idx]
+		if !strings.Contains(first, "/") && !filepath.IsAbs(first) {
+			return true
+		}
 	}
 
 	return false

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -21,10 +21,31 @@ func TestLooksLikeFilePath(t *testing.T) {
 		"env wrapper command":               {value: "/usr/bin/env lefthook", want: false},
 		"relative wrapper with flag":        {value: "./wrapper --flag", want: false},
 		"go tool command":                   {value: "go tool lefthook", want: false},
+		"node relative path command":        {value: "node ./bin/lefthook", want: false},
+		"relative wrapper short flag":       {value: "./wrapper -f", want: false},
 		"plain command without slash":       {value: "lefthook", want: false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tt.want, looksLikeFilePath(tt.value))
+		})
+	}
+}
+
+func TestShellWordForRc(t *testing.T) {
+	for name, tt := range map[string]struct {
+		in   string
+		want string
+	}{
+		"empty":                         {in: "", want: ""},
+		"plain path":                    {in: "/home/user/.lefthookrc", want: "/home/user/.lefthookrc"},
+		"spaced path":                   {in: "/tmp/my project/.lefthookrc", want: `"/tmp/my project/.lefthookrc"`},
+		"already quoted spaced path":    {in: `"/tmp/my project/.lefthookrc"`, want: `"/tmp/my project/.lefthookrc"`},
+		"expansion without spaces":      {in: "${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc", want: "${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc"},
+		"expansion with spaces":         {in: `${XDG_CONFIG_HOME:-$HOME/.config}/my lefthookrc`, want: `"${XDG_CONFIG_HOME:-$HOME/.config}/my lefthookrc"`},
+		"already quoted expansion path": {in: `"${XDG_CONFIG_HOME:-$HOME/.config}/my lefthookrc"`, want: `"${XDG_CONFIG_HOME:-$HOME/.config}/my lefthookrc"`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellWordForRc(tt.in))
 		})
 	}
 }
@@ -54,6 +75,8 @@ func TestShellInvokeForLefthookPath(t *testing.T) {
 		"shell command":   {in: "bundle exec lefthook", want: "bundle exec lefthook"},
 		"env wrapper":     {in: "/usr/bin/env lefthook", want: "/usr/bin/env lefthook"},
 		"wrapper flag":    {in: "./wrapper --flag", want: "./wrapper --flag"},
+		"node wrapper":    {in: "node ./bin/lefthook", want: "node ./bin/lefthook"},
+		"wrapper -f":      {in: "./wrapper -f", want: "./wrapper -f"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tt.want, shellInvokeForLefthookPath(tt.in))
@@ -135,6 +158,34 @@ func TestHook(t *testing.T) {
 			},
 			mustExclude: []string{
 				`"./wrapper --flag" "$@"`,
+			},
+		},
+		"preserves node wrapper command": {
+			args: Args{LefthookPath: "node ./bin/lefthook"},
+			mustContain: []string{
+				`node ./bin/lefthook "$@"`,
+			},
+			mustExclude: []string{
+				`"node ./bin/lefthook" "$@"`,
+			},
+		},
+		"preserves already quoted rc path": {
+			args: Args{Rc: `"/tmp/my project/.lefthookrc"`},
+			mustContain: []string{
+				`[ -f "/tmp/my project/.lefthookrc" ] && . "/tmp/my project/.lefthookrc"`,
+			},
+			mustExclude: []string{
+				`\"`,
+			},
+		},
+		"preserves already quoted rc expansion path": {
+			args: Args{Rc: `"${XDG_CONFIG_HOME:-$HOME/.config}/my lefthookrc"`},
+			mustContain: []string{
+				`[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/my lefthookrc" ]`,
+			},
+			mustExclude: []string{
+				`\"`,
+				`\$HOME`,
 			},
 		},
 	} {

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -3,83 +3,163 @@ package templates
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestHook_QuotesPathsWithSpaces(t *testing.T) {
-	binPath := filepath.Join("/tmp", "my project", "bin", "lefthook")
-	out := string(Hook("pre-commit", Args{LefthookPath: binPath}))
-
-	slashPath := filepath.ToSlash(binPath)
-	if !strings.Contains(out, `"`+slashPath+`" "$@"`) {
-		t.Fatalf("expected quoted LefthookPath invocation, got:\n%s", out)
-	}
-	if strings.Contains(out, "elif "+slashPath+" -h") {
-		t.Fatalf("unquoted path with space still present:\n%s", out)
-	}
-}
-
-func TestHook_QuotesRcPathWithSpaces(t *testing.T) {
-	rc := filepath.Join("/tmp", "my project", ".lefthookrc")
-	out := string(Hook("pre-commit", Args{Rc: rc}))
-
-	slashRc := filepath.ToSlash(rc)
-	want := `[ -f "` + slashRc + `" ] && . "` + slashRc + `"`
-	if !strings.Contains(out, want) {
-		t.Fatalf("expected quoted rc path %q in:\n%s", want, out)
+func TestLooksLikeFilePath(t *testing.T) {
+	for name, tt := range map[string]struct {
+		value string
+		want  bool
+	}{
+		"absolute path":                     {value: "/usr/local/bin/lefthook", want: true},
+		"relative path":                       {value: "./bin/lefthook", want: true},
+		"spaced filesystem path":            {value: "/tmp/my project/bin/lefthook", want: true},
+		"bundle exec command":               {value: "bundle exec lefthook", want: false},
+		"env wrapper command":               {value: "/usr/bin/env lefthook", want: false},
+		"relative wrapper with flag":        {value: "./wrapper --flag", want: false},
+		"go tool command":                   {value: "go tool lefthook", want: false},
+		"plain command without slash":       {value: "lefthook", want: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, looksLikeFilePath(tt.value))
+		})
 	}
 }
 
-func TestHook_PreservesRcShellExpansion(t *testing.T) {
-	rc := `${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc`
-	out := string(Hook("pre-commit", Args{Rc: rc}))
-
-	if strings.Contains(out, `\$HOME`) || strings.Contains(out, `\$XDG_CONFIG_HOME`) {
-		t.Fatalf("rc path should preserve shell expansion tokens:\n%s", out)
-	}
-	if !strings.Contains(out, `[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc ]`) {
-		t.Fatalf("expected unquoted rc path with shell expansion in:\n%s", out)
+func TestShellWordForPath(t *testing.T) {
+	for name, tt := range map[string]struct {
+		in   string
+		want string
+	}{
+		"empty":                {in: "", want: ""},
+		"no spaces":            {in: "/usr/bin/lefthook", want: "/usr/bin/lefthook"},
+		"spaces need quoting":  {in: "/tmp/my project/lefthook", want: `"/tmp/my project/lefthook"`},
+		"preserves expansion":  {in: "${HOME}/my lefthookrc", want: `"${HOME}/my lefthookrc"`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellWordForPath(tt.in))
+		})
 	}
 }
 
-func TestHook_PreservesConfiguredShellCommand(t *testing.T) {
-	out := string(Hook("pre-commit", Args{LefthookPath: "bundle exec lefthook"}))
-
-	if strings.Contains(out, `"bundle exec lefthook" "$@"`) {
-		t.Fatalf("configured shell command must not be quoted as one word:\n%s", out)
-	}
-	if !strings.Contains(out, "bundle exec lefthook \"$@\"") {
-		t.Fatalf("expected unquoted shell command invocation in:\n%s", out)
-	}
-	if !strings.Contains(out, `elif test -n "bundle exec lefthook"`) {
-		t.Fatalf("expected quoted test -n value for shell command in:\n%s", out)
+func TestShellInvokeForLefthookPath(t *testing.T) {
+	for name, tt := range map[string]struct {
+		in   string
+		want string
+	}{
+		"spaced path":     {in: "/tmp/my project/bin/lefthook", want: `"/tmp/my project/bin/lefthook"`},
+		"shell command":   {in: "bundle exec lefthook", want: "bundle exec lefthook"},
+		"env wrapper":     {in: "/usr/bin/env lefthook", want: "/usr/bin/env lefthook"},
+		"wrapper flag":    {in: "./wrapper --flag", want: "./wrapper --flag"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellInvokeForLefthookPath(tt.in))
+		})
 	}
 }
 
 func TestShellEscapeDoubleQuoteEscapesEmbeddedQuotes(t *testing.T) {
-	got := shellEscapeDoubleQuote(`a"b\c$`)
-	if got != `a\"b\\c$` {
-		t.Fatalf("unexpected escape: %q", got)
+	assert.Equal(t, `a\"b\\c$`, shellEscapeDoubleQuote(`a"b\c$`))
+}
+
+func TestHook(t *testing.T) {
+	binPath := filepath.Join("/tmp", "my project", "bin", "lefthook")
+	slashPath := filepath.ToSlash(binPath)
+	rcWithSpaces := filepath.ToSlash(filepath.Join("/tmp", "my project", ".lefthookrc"))
+
+	for name, tt := range map[string]struct {
+		args        Args
+		mustContain []string
+		mustExclude []string
+	}{
+		"quotes configured path with spaces": {
+			args: Args{LefthookPath: binPath},
+			mustContain: []string{
+				`"` + slashPath + `" "$@"`,
+			},
+			mustExclude: []string{
+				"elif " + slashPath + " -h",
+			},
+		},
+		"quotes rc path with spaces": {
+			args: Args{Rc: filepath.Join("/tmp", "my project", ".lefthookrc")},
+			mustContain: []string{
+				`[ -f "` + rcWithSpaces + `" ] && . "` + rcWithSpaces + `"`,
+			},
+		},
+		"preserves rc shell expansion": {
+			args: Args{Rc: `${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc`},
+			mustContain: []string{
+				`[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc ]`,
+			},
+			mustExclude: []string{
+				`\$HOME`,
+				`\$XDG_CONFIG_HOME`,
+			},
+		},
+		"quotes spaced rc path with shell expansion": {
+			args: Args{Rc: `${XDG_CONFIG_HOME:-$HOME/.config}/my lefthookrc`},
+			mustContain: []string{
+				`[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/my lefthookrc" ]`,
+			},
+			mustExclude: []string{
+				`\$HOME`,
+			},
+		},
+		"preserves configured shell command": {
+			args: Args{LefthookPath: "bundle exec lefthook"},
+			mustContain: []string{
+				`bundle exec lefthook "$@"`,
+				`elif test -n "bundle exec lefthook"`,
+			},
+			mustExclude: []string{
+				`"bundle exec lefthook" "$@"`,
+			},
+		},
+		"preserves env wrapper command": {
+			args: Args{LefthookPath: "/usr/bin/env lefthook"},
+			mustContain: []string{
+				`/usr/bin/env lefthook "$@"`,
+			},
+			mustExclude: []string{
+				`"/usr/bin/env lefthook" "$@"`,
+			},
+		},
+		"preserves relative wrapper command": {
+			args: Args{LefthookPath: "./wrapper --flag"},
+			mustContain: []string{
+				`./wrapper --flag "$@"`,
+			},
+			mustExclude: []string{
+				`"./wrapper --flag" "$@"`,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			out := string(Hook("pre-commit", tt.args))
+			for _, want := range tt.mustContain {
+				assert.Contains(t, out, want)
+			}
+			for _, omit := range tt.mustExclude {
+				assert.NotContains(t, out, omit)
+			}
+		})
 	}
 }
 
 func TestHook_QuotesExecutablePathWithSpaces(t *testing.T) {
-	t.Chdir(t.TempDir())
 	binDir := filepath.Join(t.TempDir(), "space dir")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
 	bin := filepath.Join(binDir, "lefthook")
-	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755))
 
-	// Simulate install-time executable path baking.
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	old := hookExecutable
+	hookExecutable = func() (string, error) { return bin, nil }
+	t.Cleanup(func() { hookExecutable = old })
 
 	out := string(Hook("pre-commit", Args{}))
-	if !strings.Contains(out, `"`+filepath.ToSlash(bin)+`" "$@"`) {
-		t.Fatalf("expected quoted executable path in hook:\n%s", out)
-	}
+	assert.Contains(t, out, `"`+filepath.ToSlash(bin)+`" "$@"`)
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -31,9 +31,35 @@ func TestHook_QuotesRcPathWithSpaces(t *testing.T) {
 	}
 }
 
-func TestShellDoubleQuoteEscapesEmbeddedQuotes(t *testing.T) {
-	got := shellDoubleQuote(`a"b\c$`)
-	if got != `a\"b\\c\$` {
+func TestHook_PreservesRcShellExpansion(t *testing.T) {
+	rc := `${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc`
+	out := string(Hook("pre-commit", Args{Rc: rc}))
+
+	if strings.Contains(out, `\$HOME`) || strings.Contains(out, `\$XDG_CONFIG_HOME`) {
+		t.Fatalf("rc path should preserve shell expansion tokens:\n%s", out)
+	}
+	if !strings.Contains(out, `[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/lefthookrc ]`) {
+		t.Fatalf("expected unquoted rc path with shell expansion in:\n%s", out)
+	}
+}
+
+func TestHook_PreservesConfiguredShellCommand(t *testing.T) {
+	out := string(Hook("pre-commit", Args{LefthookPath: "bundle exec lefthook"}))
+
+	if strings.Contains(out, `"bundle exec lefthook" "$@"`) {
+		t.Fatalf("configured shell command must not be quoted as one word:\n%s", out)
+	}
+	if !strings.Contains(out, "bundle exec lefthook \"$@\"") {
+		t.Fatalf("expected unquoted shell command invocation in:\n%s", out)
+	}
+	if !strings.Contains(out, `elif test -n "bundle exec lefthook"`) {
+		t.Fatalf("expected quoted test -n value for shell command in:\n%s", out)
+	}
+}
+
+func TestShellEscapeDoubleQuoteEscapesEmbeddedQuotes(t *testing.T) {
+	got := shellEscapeDoubleQuote(`a"b\c$`)
+	if got != `a\"b\\c$` {
 		t.Fatalf("unexpected escape: %q", got)
 	}
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -1,0 +1,59 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHook_QuotesPathsWithSpaces(t *testing.T) {
+	binPath := filepath.Join("/tmp", "my project", "bin", "lefthook")
+	out := string(Hook("pre-commit", Args{LefthookPath: binPath}))
+
+	slashPath := filepath.ToSlash(binPath)
+	if !strings.Contains(out, `"`+slashPath+`" "$@"`) {
+		t.Fatalf("expected quoted LefthookPath invocation, got:\n%s", out)
+	}
+	if strings.Contains(out, "elif "+slashPath+" -h") {
+		t.Fatalf("unquoted path with space still present:\n%s", out)
+	}
+}
+
+func TestHook_QuotesRcPathWithSpaces(t *testing.T) {
+	rc := filepath.Join("/tmp", "my project", ".lefthookrc")
+	out := string(Hook("pre-commit", Args{Rc: rc}))
+
+	slashRc := filepath.ToSlash(rc)
+	want := `[ -f "` + slashRc + `" ] && . "` + slashRc + `"`
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected quoted rc path %q in:\n%s", want, out)
+	}
+}
+
+func TestShellDoubleQuoteEscapesEmbeddedQuotes(t *testing.T) {
+	got := shellDoubleQuote(`a"b\c$`)
+	if got != `a\"b\\c\$` {
+		t.Fatalf("unexpected escape: %q", got)
+	}
+}
+
+func TestHook_QuotesExecutablePathWithSpaces(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := filepath.Join(t.TempDir(), "space dir")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(binDir, "lefthook")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate install-time executable path baking.
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out := string(Hook("pre-commit", Args{}))
+	if !strings.Contains(out, `"`+filepath.ToSlash(bin)+`" "$@"`) {
+		t.Fatalf("expected quoted executable path in hook:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Quote `Rc`, `LefthookPath`, and `LefthookPathCurrent` in generated git hook shims so paths containing spaces do not word-split and silently skip all hooks.

Fixes #1488

## Test plan
- [x] Added `internal/templates/templates_test.go` covering spaced paths and shell escaping
- [ ] CI