### PR TITLE
fix(install): honor lefthook-local.yml without creating lefthook.yml

### DIFF
--- a/internal/command/install.go
+++ b/internal/command/install.go
@@ -115,8 +115,29 @@ func (l *Lefthook) readOrCreateConfig() (*config.Config, error) {
 }
 
 func (l *Lefthook) configExists(path string) bool {
-	configPath, _ := l.findMainConfig(path)
-	return configPath != ""
+	_, err := l.findConfig(path)
+	return err == nil
+}
+
+func (l *Lefthook) findConfig(path string) (string, error) {
+	if configPath, err := l.findMainConfig(path); err == nil {
+		return configPath, nil
+	}
+
+	return l.findLocalConfig(path)
+}
+
+func (l *Lefthook) findLocalConfig(path string) (string, error) {
+	for _, name := range config.LocalConfigNames {
+		for _, extension := range config.Extensions {
+			configPath := filepath.Join(path, name+extension)
+			if ok, _ := afero.Exists(l.fs, configPath); ok {
+				return configPath, nil
+			}
+		}
+	}
+
+	return "", errNoConfig
 }
 
 func (l *Lefthook) findMainConfig(path string) (string, error) {
@@ -460,7 +481,7 @@ func (l *Lefthook) checkHooksSynchronized(cfg *config.Config) (bool, []string) {
 }
 
 func (l *Lefthook) configLastUpdateTimestamp() (int64, error) {
-	configPath, err := l.findMainConfig(l.repo.RootPath)
+	configPath, err := l.findConfig(l.repo.RootPath)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/command/install_test.go
+++ b/internal/command/install_test.go
@@ -43,8 +43,28 @@ func TestLefthookInstall(t *testing.T) {
 		wantError               bool
 	}{
 		{
-			name:      "without a config file",
+			name: "without a config file",
 			wantExist: []string{configPath},
+		},
+		{
+			name: "with lefthook-local.yml only",
+			existingFiles: map[string]string{
+				projectPath("lefthook-local.yml"): `
+pre-commit:
+  jobs:
+    - name: check
+      run: echo check
+`,
+			},
+			wantExist: []string{
+				projectPath("lefthook-local.yml"),
+				hookPath("pre-commit"),
+				infoPath(config.ChecksumFileName),
+			},
+			wantNotExist: []string{
+				configPath,
+				hookPath(config.GhostHookName),
+			},
 		},
 		{
 			name: "simple default config",


### PR DESCRIPTION
## Summary
- `lefthook install` no longer scaffolds `lefthook.yml` when only `lefthook-local.yml` (or other local config names) exists, matching documented behavior.
- Checksum timestamp resolution uses the same config discovery path.

Fixes #1489

## Test plan
- [x] Added install test for local-only config
- [ ] CI