### PR TITLE
fix(lfs): do not pipe stdin into post-checkout git-lfs hook

### DIFF
--- a/internal/run/controller/lfs.go
+++ b/internal/run/controller/lfs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -54,6 +55,11 @@ func (c *Controller) runLFSHook(ctx context.Context, hookName string, args []str
 	)
 	out := new(bytes.Buffer)
 	errOut := new(bytes.Buffer)
+	var stdin io.Reader
+	if hookName == "pre-push" {
+		// Git LFS reads ref updates from stdin for pre-push only.
+		stdin = c.cachedStdin
+	}
 	err = c.cmd.RunWithContext(
 		ctx,
 		append(
@@ -61,7 +67,7 @@ func (c *Controller) runLFSHook(ctx context.Context, hookName string, args []str
 			args...,
 		),
 		"",
-		c.cachedStdin,
+		stdin,
 		out,
 		errOut,
 	)


### PR DESCRIPTION
## Summary
- Stop forwarding `os.Stdin` to `git lfs post-checkout` (and other non-pre-push LFS hooks). Only `pre-push` reads ref updates from stdin.
- Fixes deadlocks when `lefthook run post-checkout` inherits an open pipe/socket stdin.

Fixes #1493

## Test plan
- [ ] CI
- Manual repro from issue: open-pipe stdin should no longer hang when git-lfs is installed