### PR TITLE
fix(templates): stop baking install-time path into shared hook shims

### DIFF
--- a/internal/templates/hook.tmpl
+++ b/internal/templates/hook.tmpl
@@ -32,11 +32,6 @@ call_lefthook()
   then
     lefthook.bat "$@"
   {{ end -}}
-  {{ if .LefthookPathCurrent -}}
-  elif {{ .LefthookPathCurrent }} -h >/dev/null 2>&1
-  then
-    {{ .LefthookPathCurrent }} "$@"
-  {{ end -}}
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -27,28 +26,21 @@ type hookTmplData struct {
 	HookName                string
 	Extension               string
 	LefthookPath            string
-	LefthookPathCurrent     string
 	Rc                      string
 	Roots                   []string
 	AssertLefthookInstalled bool
 }
 
 func Hook(hookName string, args Args) []byte {
-	lefthookPathCurrent, err := os.Executable()
-	if err != nil {
-		lefthookPathCurrent = ""
-	}
-
 	buf := &bytes.Buffer{}
 	t := template.Must(template.ParseFS(templatesFS, "hook.tmpl"))
-	if err = t.Execute(buf, hookTmplData{
+	if err := t.Execute(buf, hookTmplData{
 		HookName:                hookName,
 		Extension:               getExtension(),
 		Rc:                      args.Rc,
 		AssertLefthookInstalled: args.AssertLefthookInstalled,
 		Roots:                   args.Roots,
 		LefthookPath:            filepath.ToSlash(strings.ReplaceAll(strings.TrimSpace(args.LefthookPath), "\n", ";")),
-		LefthookPathCurrent:     filepath.ToSlash(lefthookPathCurrent),
 	}); err != nil {
 		panic(err)
 	}

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -1,0 +1,31 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHook_OmitsInstallTimeExecutablePath(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := string(Hook("pre-commit", Args{}))
+	if strings.Contains(out, filepath.ToSlash(exe)) {
+		t.Fatalf("hook shim must not bake install-time executable path %q into shared .git/hooks", exe)
+	}
+}
+
+func TestHook_KeepsWorktreeRelativeNodeModulesFallback(t *testing.T) {
+	out := string(Hook("pre-commit", Args{}))
+
+	if !strings.Contains(out, `dir="$(git rev-parse --show-toplevel)"`) {
+		t.Fatal("expected worktree-relative node_modules fallback")
+	}
+	if !strings.Contains(out, `node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook`) {
+		t.Fatal("expected per-worktree lefthook npm binary fallback")
+	}
+}


### PR DESCRIPTION
## Summary
- Remove the `os.Executable()` branch from generated git hook shims.
- Worktrees share `.git/hooks/`; an install-time absolute path from one worktree breaks hooks in siblings when that path goes away.
- Per-worktree `$dir/node_modules/...` fallbacks already resolve lefthook correctly.

Fixes #1398

## Test plan
- [x] Added `internal/templates/templates_test.go`
- [ ] CI