### PR TITLE
fix: keep the unstaged-changes backup per worktree

### DIFF
--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -284,7 +284,7 @@ func (r *Repo) SaveUnstagedChanges(files []string) error {
 	// A linked worktree's git dir has no `info` folder until something
 	// creates it.
 	if err = r.Fs.MkdirAll(r.unstagedPatchDir(), infoDirMode); err != nil {
-		return err
+		return fmt.Errorf("failed to create the unstaged patch directory %s: %w", r.unstagedPatchDir(), err)
 	}
 
 	if err = r.saveUnstaged(files); err != nil {

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -20,17 +21,20 @@ import (
 )
 
 const (
-	minGitVersion     = "2.31.0"
-	stashMessage      = "lefthook auto backup"
-	unstagedPatchName = "lefthook-unstaged.patch"
-	infoDirMode       = 0o775
+	minGitVersion       = "2.31.0"
+	stashMessagePrefix  = "lefthook auto backup"
+	unstagedPatchName   = "lefthook-unstaged.patch"
+	unstagedPatchFolder = "info"
+	infoDirMode         = 0o775
 )
 
 var (
-	reHeadBranch              = regexp.MustCompile(`HEAD -> (?P<name>.*)$`)
-	reOriginHeadBranch        = regexp.MustCompile(`ref: refs/remotes/origin/(?P<name>.*)$`)
-	reVersion                 = regexp.MustCompile(`\d+\.\d+\.(\d+|\w+)`)
-	reStashMessage            = regexp.MustCompile(`^(?P<stash>[^ ]+):\s*` + stashMessage)
+	reHeadBranch       = regexp.MustCompile(`HEAD -> (?P<name>.*)$`)
+	reOriginHeadBranch = regexp.MustCompile(`ref: refs/remotes/origin/(?P<name>.*)$`)
+	reVersion          = regexp.MustCompile(`\d+\.\d+\.(\d+|\w+)`)
+	// The tag is optional: entries stored by older lefthook versions carry no
+	// tag and must still be recognized (and cleaned up) after an upgrade.
+	reStashMessage            = regexp.MustCompile(`^(?P<stash>[^ ]+):\s*` + stashMessagePrefix + `(?: (?P<tag>[0-9a-f]+))?$`)
 	cmdPushFilesBase          = []string{"git", "diff", "--name-only", "HEAD", "@{push}"}
 	cmdPushFilesHead          = []string{"git", "diff", "--name-only", "HEAD"}
 	cmdLsTreeFilesHead        = []string{"git", "ls-tree", "-r", "--name-only", "HEAD"}
@@ -59,6 +63,7 @@ type Repo struct {
 	InfoPath  string
 
 	unstagedPatchPath string
+	stashTag          string
 	headBranch        string
 
 	stagedFilesOnce            func() ([]string, error)
@@ -167,7 +172,32 @@ func (r *Repo) ResetCache() {
 		return r.state()
 	})
 
-	r.unstagedPatchPath = filepath.Join(r.InfoPath, unstagedPatchName)
+	r.unstagedPatchPath = filepath.Join(r.unstagedPatchDir(), unstagedPatchName)
+	r.stashTag = stashTagFor(r.GitPath)
+}
+
+// unstagedPatchDir is where the backup of unstaged changes lives: inside the
+// worktree's own git dir (`.git` for a plain checkout, `.git/worktrees/<name>`
+// for a linked worktree), never the common one shared by every worktree.
+// Otherwise concurrent commits from two linked worktrees overwrite each
+// other's backup and silently lose unstaged changes.
+func (r *Repo) unstagedPatchDir() string {
+	return filepath.Join(r.GitPath, unstagedPatchFolder)
+}
+
+// StashMessageFor returns the message used for the unstaged-changes backup
+// stash of the worktree owning `gitPath`. The stash list is shared by every
+// worktree of a repository, so the message carries a per-worktree tag and
+// cleanup only drops the entries of the worktree that created them.
+func StashMessageFor(gitPath string) string {
+	return stashMessagePrefix + " " + stashTagFor(gitPath)
+}
+
+func stashTagFor(gitPath string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(filepath.Clean(gitPath)))
+
+	return fmt.Sprintf("%016x", h.Sum64())
 }
 
 // StagedFiles returns a list of staged files which exist on file system.
@@ -251,6 +281,12 @@ func (r *Repo) SaveUnstagedChanges(files []string) error {
 		return err
 	}
 
+	// A linked worktree's git dir has no `info` folder until something
+	// creates it.
+	if err = r.Fs.MkdirAll(r.unstagedPatchDir(), infoDirMode); err != nil {
+		return err
+	}
+
 	if err = r.saveUnstaged(files); err != nil {
 		return err
 	}
@@ -261,7 +297,7 @@ func (r *Repo) SaveUnstagedChanges(files []string) error {
 		"store",
 		"--quiet",
 		"--message",
-		stashMessage,
+		StashMessageFor(r.GitPath),
 		stashHash,
 	})
 	if err != nil {
@@ -391,6 +427,12 @@ func (r *Repo) dropUnstagedStash() error {
 		line := lines[len(lines)-i-1]
 		matches := reStashMessage.FindStringSubmatch(line)
 		if matches == nil {
+			continue
+		}
+
+		// Another worktree's backup: leave it alone. An entry without a tag
+		// was left by an older lefthook and is dropped like our own.
+		if tag := matches[reStashMessage.SubexpIndex("tag")]; tag != "" && tag != r.stashTag {
 			continue
 		}
 

--- a/internal/run/controller/guard_test.go
+++ b/internal/run/controller/guard_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/evilmartians/lefthook/v2/internal/git"
 	"github.com/evilmartians/lefthook/v2/tests/helpers/cmdtest"
 	"github.com/evilmartians/lefthook/v2/tests/helpers/gittest"
 	"github.com/evilmartians/lefthook/v2/tests/helpers/loggertest"
@@ -90,9 +91,17 @@ func Test_guard_wrap(t *testing.T) {
 				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", Output: ""},
-				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
+				{Command: "git stash store --quiet --message " + git.StashMessageFor(filepath.Join("root", ".git")) + " <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
-				{Command: "git stash list", Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n"},
+				// Entry 1 was left by an older lefthook (no tag), entry 3 belongs to another
+				// worktree (foreign tag), entry 4 is ours: only 1 and 4 get dropped.
+				{
+					Command: "git stash list",
+					Output: "0: my stash\n1: lefthook auto backup\n2: my second stash\n" +
+						"3: lefthook auto backup 0123456789abcdef\n" +
+						"4: " + git.StashMessageFor(filepath.Join("root", ".git")) + "\n",
+				},
+				{Command: "git stash drop --quiet -- 4", Output: ""},
 				{Command: "git stash drop --quiet -- 1", Output: ""},
 			},
 		},
@@ -105,7 +114,7 @@ func Test_guard_wrap(t *testing.T) {
 				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", Output: ""},
-				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
+				{Command: "git stash store --quiet --message " + git.StashMessageFor(filepath.Join("root", ".git")) + " <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git status --short --porcelain -z", Output: "A file1\x00"},
 				// job run
@@ -124,7 +133,7 @@ func Test_guard_wrap(t *testing.T) {
 				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", Output: ""},
-				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
+				{Command: "git stash store --quiet --message " + git.StashMessageFor(filepath.Join("root", ".git")) + " <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git status --short --porcelain -z", Output: "A  file1\x00"},
 				{Command: "git hash-object -- file1", Output: "hash1\n"},
@@ -256,7 +265,7 @@ func Test_guard_wrap_stageFixed(t *testing.T) {
 				{Command: "git diff --binary --unified=0 --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --patch --submodule=short --output " +
 					filepath.Join("root", ".git", "info", "lefthook-unstaged.patch") +
 					" -- file1", Output: ""},
-				{Command: "git stash store --quiet --message lefthook auto backup <stash-hash>", Output: ""},
+				{Command: "git stash store --quiet --message " + git.StashMessageFor(filepath.Join("root", ".git")) + " <stash-hash>", Output: ""},
 				{Command: "git checkout --force -- file1", Output: ""},
 				{Command: "git add --force -- file2", Err: errStaging},
 			},

--- a/tests/integration/worktree_concurrent_commits.txt
+++ b/tests/integration/worktree_concurrent_commits.txt
@@ -1,0 +1,81 @@
+[windows] skip
+
+# Two linked worktrees committing at the same time must not destroy each
+# other's unstaged changes. The backup of partially staged files used to live
+# in the common git dir (shared by every worktree) under one fixed stash
+# message, so the second commit overwrote the first one's backup and both
+# reported success. See https://github.com/evilmartians/lefthook/issues/1529.
+
+chmod 0700 main/hook.sh
+chmod 0700 main/concurrent-commits.sh
+cd main
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add -A
+exec git commit -m 'init'
+exec lefthook install
+exec git worktree add -q ../linked -b linked
+
+exec ./concurrent-commits.sh
+stderr 'script-done'
+
+# Both commits landed ...
+exec git log --oneline
+stdout 'commit-main'
+exec git -C ../linked log --oneline
+stdout 'commit-linked'
+
+# ... each worktree kept its own unstaged line ...
+grep 'unstaged-main' file.txt
+! grep 'unstaged-linked' file.txt
+grep 'unstaged-linked' ../linked/file.txt
+! grep 'unstaged-main' ../linked/file.txt
+
+# ... and both backups were cleaned up.
+exec git stash list
+! stdout 'lefthook auto backup'
+
+-- main/lefthook.yml --
+pre-commit:
+  commands:
+    slow_job:
+      run: ./hook.sh
+
+-- main/hook.sh --
+#!/usr/bin/env bash
+
+sleep 2
+
+-- main/file.txt --
+base
+
+-- main/concurrent-commits.sh --
+#!/usr/bin/env bash
+
+set -e
+
+main="$PWD"
+linked="$PWD/../linked"
+
+# Partially stage file.txt in both worktrees: one staged line and one
+# unstaged line in the same file, which is what makes lefthook back up
+# the unstaged part before running the hook.
+for wt in "$main" "$linked"; do
+  name=$(basename "$wt")
+  (
+    cd "$wt"
+    echo "staged-$name" >> file.txt
+    git add file.txt
+    echo "unstaged-$name" >> file.txt
+  )
+done
+
+# The main worktree's hook sleeps for 2s, so the linked worktree's commit
+# starts while the main one still holds its backup.
+( cd "$main" && git commit -q -m commit-main ) &
+sleep 1
+( cd "$linked" && git commit -q -m commit-linked ) &
+wait
+
+>&2 echo 'script-done'


### PR DESCRIPTION
Fixes #1529.

## Problem

When `pre-commit` hides partially staged files, the backup goes to two places that are shared by every linked worktree of a repository:

- the patch at `<common git dir>/info/lefthook-unstaged.patch` — `git rev-parse --git-path info` resolves to the common dir, not the worktree's own;
- a stash entry under the one fixed message `lefthook auto backup`.

Two worktrees committing at the same time overwrite each other's patch, and `dropUnstagedStash` drops every entry carrying that message. One worktree silently loses its unstaged changes while both commits report success.

## Fix

- The patch now lives in the worktree's own git dir, which `Paths` already fetches (`--git-dir`): `.git/info/` for a plain checkout, exactly as before, and `.git/worktrees/<name>/info/` for a linked worktree (created on first use).
- The stash message carries a per-worktree tag (an fnv hash of the git dir). Cleanup drops only the entries with our own tag, plus untagged entries left by older lefthook versions, so an upgrade mid-flight leaves nothing behind.

No configuration change. Repositories without linked worktrees keep the same path and the same cleanup as today.

## Tests

- `tests/integration/worktree_concurrent_commits.txt` commits from two linked worktrees at once, each with a partially staged file. On `master` it fails: the main worktree ends up with the linked worktree's unstaged line. With this change it passes (ran 3× locally, plus the full integration suite).
- `guard_test.go` updated for the tagged message and extended with a stash list holding an untagged entry, another worktree's entry and our own: only the untagged one and ours are dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
