### PR TITLE
docs: document files inheritance for grouped jobs

### DIFF
--- a/docs/configuration/group.md
+++ b/docs/configuration/group.md
@@ -25,7 +25,7 @@ pre-commit:
           - run: echo 3
 ```
 
-If you specify `env`, `root`, `glob`, or `exclude` on a group, they will be inherited to the underlying jobs.
+If you specify `env`, `root`, `glob`, `exclude`, or `files` on a group, they will be inherited to the underlying jobs. The `files` command is executed for every nested job that uses the `{files}` template; a nested job can define its own `files` to override it.
 
 ```yml
 # lefthook.yml
@@ -39,13 +39,15 @@ pre-commit:
       exclude:
         - "README.md"
       root: "subdir/"
+      files: git diff --name-only master
       group:
         parallel: true
         jobs:
-          - run: echo $E1
-          - run: echo $E1
+          - run: echo $E1 {files}
+          - run: echo $E1 {files}
             env:
               E1: bonjour
+            files: git ls-files
 ```
 
 ::: callout info Note

--- a/docs/configuration/group.md
+++ b/docs/configuration/group.md
@@ -25,7 +25,7 @@ pre-commit:
           - run: echo 3
 ```
 
-If you specify `env`, `root`, `glob`, `exclude`, or `files` on a group, they will be inherited to the underlying jobs. The `files` command is executed for every nested job that uses the `{files}` template; a nested job can define its own `files` to override it.
+If you specify `env`, `root`, `glob`, `exclude`, or `files` on a group, they will be inherited to the underlying jobs.
 
 ```yml
 # lefthook.yml
@@ -39,14 +39,29 @@ pre-commit:
       exclude:
         - "README.md"
       root: "subdir/"
-      files: git diff --name-only master
       group:
         parallel: true
         jobs:
-          - run: echo $E1 {files}
-          - run: echo $E1 {files}
+          - run: echo $E1
+          - run: echo $E1
             env:
               E1: bonjour
+```
+
+A `files` command set on a group is executed for every nested job that uses the `{files}` template. A nested job can define its own `files` to override it.
+
+```yml
+# lefthook.yml
+
+pre-commit:
+  jobs:
+    - glob:
+        - "*.py"
+      files: git diff --name-only master
+      group:
+        jobs:
+          - run: ruff check {files}
+          - run: ruff format --check {files}
             files: git ls-files
 ```
 

--- a/docs/configuration/jobs.md
+++ b/docs/configuration/jobs.md
@@ -10,12 +10,12 @@ Added in lefthook `1.10.0`
 
 Jobs provide a flexible way to define tasks, supporting both commands and scripts. Jobs can be grouped for advanced flow control.
 
-Named jobs are merged across [`extends`](./extends.md) and local config; unnamed jobs are appended in definition order. Groups can include other jobs with their own parallel or piped flow — `glob`, `root`, and `exclude` on a group apply to all nested jobs.
+Named jobs are merged across [`extends`](./extends.md) and local config; unnamed jobs are appended in definition order. Groups can include other jobs with their own parallel or piped flow — `glob`, `root`, `exclude`, `env`, and `files` on a group apply to all nested jobs.
 
 #### Example
 
 ::: callout info Note
-Currently, only `root`, `glob`, and `exclude` options are applied to group jobs. Other options must be set for each job individually. Submit a [feature request](https://github.com/evilmartians/lefthook/issues/new?assignees=&labels=feature+request&projects=&template=feature_request.md) if this limits your workflow.
+Currently, only `root`, `glob`, `exclude`, `env`, and `files` options are applied to group jobs. Other options must be set for each job individually. Submit a [feature request](https://github.com/evilmartians/lefthook/issues/new?assignees=&labels=feature+request&projects=&template=feature_request.md) if this limits your workflow.
 :::
 
 A configuration demonstrating a piped group running in parallel with other jobs:


### PR DESCRIPTION
Closes #1528

### Context

The `group` docs list `env`, `root`, `glob` and `exclude` as options inherited by nested jobs, but not `files`. In practice a `files` command set on a group is inherited too (`scope.extend` carries `filesCmd` down), so `{files}` in each nested job resolves to the parent command's output, and a nested job can set its own `files` to override it.

### Changes

- Add `files` to the list of inherited group options and note that it is evaluated for each nested job that uses `{files}` and can be overridden per job.
- Extend the existing example with `files` on the group and an override on the second nested job.

Docs only, no code changes.

Checked against a local build of `master` (Go 1.26.6): a `files` command on the group is executed for each nested job and `{files}` resolves to its output; a nested job with its own `files` uses that instead. The updated example passes `lefthook validate` / `lefthook dump`.

Happy to adjust the wording.
