### PR TITLE
fix: resolve file_types paths from the repo root

### DIFF
--- a/internal/run/controller/command/build_command.go
+++ b/internal/run/controller/command/build_command.go
@@ -102,6 +102,7 @@ func (b *Builder) buildReplacer(params *JobParams) replacer.Replacer {
 
 func (b *Builder) buildFilter(params *JobParams) *filter.Filter {
 	return filter.New(b.git.Fs, b.logger, filter.Params{
+		RepoRoot:     b.git.RootPath,
 		Glob:         params.Glob,
 		ExcludeFiles: params.ExcludeFiles,
 		Root:         params.Root,

--- a/internal/run/controller/filter/filter.go
+++ b/internal/run/controller/filter/filter.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -33,6 +34,7 @@ const (
 )
 
 type Params struct {
+	RepoRoot     string
 	Root         string
 	Glob         []string
 	FileTypes    []string
@@ -213,13 +215,15 @@ func (f *Filter) byType(fs afero.Fs, vs []string, types []string) []string {
 
 	vsf := make([]string, 0)
 	for _, v := range vs {
+		path := f.resolve(v)
+
 		var err error
 		var fileInfo os.FileInfo
 		lfs, ok := fs.(afero.Lstater)
 		if ok {
-			fileInfo, _, err = lfs.LstatIfPossible(v)
+			fileInfo, _, err = lfs.LstatIfPossible(path)
 		} else {
-			fileInfo, err = fs.Stat(v)
+			fileInfo, err = fs.Stat(path)
 		}
 		if err != nil {
 			f.logger.Errorf("Couldn't check file type of %s: %s", v, err)
@@ -246,7 +250,7 @@ func (f *Filter) byType(fs afero.Fs, vs []string, types []string) []string {
 				continue
 			}
 
-			text := f.checkIsText(v)
+			text := f.checkIsText(path)
 			binary := !text
 
 			if filter.simpleTypes&typeText != 0 && binary {
@@ -263,7 +267,7 @@ func (f *Filter) byType(fs afero.Fs, vs []string, types []string) []string {
 			}
 
 			var found bool
-			fileMimeType, err := mimetype.DetectFile(v)
+			fileMimeType, err := mimetype.DetectFile(path)
 			if err != nil {
 				f.logger.Errorf("Couldn't check mime type of file %s: %s", v, err)
 				continue
@@ -282,6 +286,16 @@ func (f *Filter) byType(fs afero.Fs, vs []string, types []string) []string {
 	}
 
 	return vsf
+}
+
+// resolve returns the absolute path of a file reported by git, which is always
+// relative to the repository root and not to the current working directory.
+func (f *Filter) resolve(path string) string {
+	if f.RepoRoot == "" || filepath.IsAbs(path) {
+		return path
+	}
+
+	return filepath.Join(f.RepoRoot, f.Root, path)
 }
 
 func (f *Filter) parseFileTypeFilter(types []string) fileTypeFilter {

--- a/internal/run/controller/filter/filter_test.go
+++ b/internal/run/controller/filter/filter_test.go
@@ -3,6 +3,10 @@ package filter
 import (
 	"fmt"
 	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/evilmartians/lefthook/v2/tests/helpers/loggertest"
 )
 
 func slicesEqual(a, b []string) bool {
@@ -220,6 +224,42 @@ func TestByRoot(t *testing.T) {
 			result := byRoot(tt.source, tt.path)
 			if !slicesEqual(result, tt.result) {
 				t.Errorf("expected %v to be equal to %v", result, tt.result)
+			}
+		})
+	}
+}
+
+func TestByTypeResolvesPathsFromRepoRoot(t *testing.T) {
+	for i, tt := range [...]struct {
+		repoRoot, root string
+		source, result []string
+	}{
+		{
+			repoRoot: "/repo",
+			source:   []string{"subdir/file.txt", "subdir/missing.txt"},
+			result:   []string{"subdir/file.txt"},
+		},
+		{
+			repoRoot: "/repo",
+			root:     "subdir",
+			source:   []string{"./file.txt"},
+			result:   []string{"./file.txt"},
+		},
+		{
+			source: []string{"subdir/file.txt"},
+			result: []string{},
+		},
+	} {
+		t.Run(fmt.Sprintf("%d:", i), func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			if err := afero.WriteFile(fs, "/repo/subdir/file.txt", []byte("some text"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			f := New(fs, loggertest.NewExecution(), Params{RepoRoot: tt.repoRoot, Root: tt.root})
+			res := f.byType(fs, tt.source, []string{"text"})
+			if !slicesEqual(res, tt.result) {
+				t.Errorf("expected %v to be equal to %v", res, tt.result)
 			}
 		})
 	}

--- a/internal/run/controller/job.go
+++ b/internal/run/controller/job.go
@@ -162,6 +162,7 @@ func (c *Controller) runSingleJob(ctx context.Context, scope *scope, id string, 
 			}
 
 			files = filter.New(c.git.Fs, c.logger, filter.Params{
+				RepoRoot:     c.git.RootPath,
 				Glob:         scope.glob,
 				Root:         scope.root,
 				ExcludeFiles: scope.excludeFiles,

--- a/tests/integration/filter_by_file_type_subdirectory_issue_957.txt
+++ b/tests/integration/filter_by_file_type_subdirectory_issue_957.txt
@@ -1,0 +1,23 @@
+[windows] skip
+
+exec git init
+exec git config user.email "you@example.com"
+exec git config user.name "Your Name"
+exec git add -A
+exec git commit -m 'test'
+cd subdir
+exec lefthook run pre-commit
+stdout '.*echo ❯\s+lefthook.yml subdir/file.txt\s*'
+
+-- lefthook.yml --
+output:
+  - execution
+  - skips
+pre-commit:
+  commands:
+    echo:
+      run: echo {all_files}
+      file_types: text
+
+-- subdir/file.txt --
+some text


### PR DESCRIPTION
Closes #957

### Context

Running `lefthook run <hook>` from a subdirectory of the repo breaks any job that uses `file_types` (or a mime type filter). Every file is reported as `Couldn't check file type of <path>: lstat <path>: no such file or directory` and the job is then skipped with "no files for inspection".

Git reports file paths relative to the repository root, and lefthook runs its git commands with the working directory set to that root. The `file_types` filter, though, passed those paths straight to `Lstat`/`Stat`, `mimetype.DetectFile` and the text-detection reader, all of which resolve against the process working directory. At the repo root the two happen to agree, which is why this only shows up from a subdirectory and never when lefthook is invoked as a git hook.

The rest of the filter chain (`byGlob`, `byExclude`, `byRoot`) is pure string matching, so `file_types` is the only stage that touches the disk and the only one affected.

### Changes

- `filter.Params` gets a `RepoRoot` field, populated from `git.Repo.RootPath` at both `filter.New` call sites. That is the same root the repo already uses in `Repo.isFile`, so no new root resolution is introduced.
- `byType` resolves each path against `RepoRoot` plus the job's `root:` before inspecting it. Only the path used for disk access changes; the filtered list that feeds `{staged_files}` and friends stays root-relative as before.
- Adds a testscript integration test reproducing the issue (`cd subdir` then `lefthook run pre-commit` with `file_types: text`) and a table-driven unit test for the path resolution, including the `root:` case.

Verified with `make test`, the full `-tags=integration` suite (57 fixtures), `go vet ./...` and `golangci-lint run` (0 issues).
