### PR TITLE
fix: force colors when colors are explicitly enabled

### DIFF
--- a/docs/configuration/colors.md
+++ b/docs/configuration/colors.md
@@ -8,6 +8,8 @@ title: "colors"
 
 Whether enable or disable colorful output of Lefthook. This option can be overwritten with `--colors` option. You can also provide your own color codes.
 
+With the default `auto` value colors are enabled only when Lefthook detects a color capable terminal. Setting the option (or `--colors`) to `on` forces colors even when the output is not a terminal, e.g. in CI.
+
 #### Example
 
 Disable colors.

--- a/internal/logger/colors.go
+++ b/internal/logger/colors.go
@@ -36,21 +36,27 @@ func (c ColorsSetting) get(color Color) color.Color {
 	return c.colors[color]
 }
 
+var profile = colorprofile.Detect(os.Stdout, os.Environ())
+
 var (
-	profile  = colorprofile.Detect(os.Stdout, os.Environ())
-	complete = lipgloss.Complete(profile)
+	DefaultColors ColorsSetting = colorsForProfile(profile)
+	forcedColors  ColorsSetting = colorsForProfile(max(profile, colorprofile.ANSI))
 )
 
-var DefaultColors ColorsSetting = ColorsSetting{
-	kind: colorsEnabled,
-	colors: map[Color]color.Color{
-		ColorCyan:   complete(lipgloss.Color("14"), lipgloss.Color("73"), lipgloss.Color("#5FAFAF")),
-		ColorGray:   complete(lipgloss.Color("8"), lipgloss.Color("102"), lipgloss.Color("#878787")),
-		ColorGreen:  complete(lipgloss.Color("2"), lipgloss.Color("34"), lipgloss.Color("#00AF00")),
-		ColorRed:    complete(lipgloss.Color("9"), lipgloss.Color("203"), lipgloss.Color("#FF5F5F")),
-		ColorYellow: complete(lipgloss.Color("3"), lipgloss.Color("3"), lipgloss.Color("#808000")),
-		ColorWhite:  complete(lipgloss.Color("15"), lipgloss.Color("15"), lipgloss.Color("#FFFFFF")),
-	},
+func colorsForProfile(profile colorprofile.Profile) ColorsSetting {
+	complete := lipgloss.Complete(profile)
+
+	return ColorsSetting{
+		kind: colorsEnabled,
+		colors: map[Color]color.Color{
+			ColorCyan:   complete(lipgloss.Color("14"), lipgloss.Color("73"), lipgloss.Color("#5FAFAF")),
+			ColorGray:   complete(lipgloss.Color("8"), lipgloss.Color("102"), lipgloss.Color("#878787")),
+			ColorGreen:  complete(lipgloss.Color("2"), lipgloss.Color("34"), lipgloss.Color("#00AF00")),
+			ColorRed:    complete(lipgloss.Color("9"), lipgloss.Color("203"), lipgloss.Color("#FF5F5F")),
+			ColorYellow: complete(lipgloss.Color("3"), lipgloss.Color("3"), lipgloss.Color("#808000")),
+			ColorWhite:  complete(lipgloss.Color("15"), lipgloss.Color("15"), lipgloss.Color("#FFFFFF")),
+		},
+	}
 }
 
 var NoColors ColorsSetting = ColorsSetting{
@@ -88,7 +94,7 @@ func (l *Logger) EnableColors() {
 		return
 	}
 
-	l.colors = DefaultColors
+	l.colors = forcedColors
 	l.colorsForced = true
 }
 

--- a/internal/logger/colors_test.go
+++ b/internal/logger/colors_test.go
@@ -1,0 +1,37 @@
+package logger
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestColorsSetting(t *testing.T) {
+	for name, tt := range map[string]struct {
+		enable   bool
+		colorful bool
+	}{
+		"enabled colors are rendered on non-tty output": {
+			enable:   true,
+			colorful: true,
+		},
+		"disabled colors are not rendered": {
+			enable:   false,
+			colorful: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			l := New(io.Discard)
+			if tt.enable {
+				l.EnableColors()
+			} else {
+				l.DisableColors()
+			}
+
+			painted := l.Paint(ColorRed, "text")
+			if colorful := strings.Contains(painted, "\x1b["); colorful != tt.colorful {
+				t.Errorf("expected colorful output to be %v, got: %q", tt.colorful, painted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1322

### Context

`--colors on` (and `colors: true` in lefthook.yml) has no effect when lefthook's output is not a terminal, which is the normal case in CI. Only `CLICOLOR_FORCE` works.

The colour palette is built once at package init in `internal/logger/colors.go`: `profile = colorprofile.Detect(os.Stdout, os.Environ())` and `complete = lipgloss.Complete(profile)`. On a non-TTY the detected profile is `NoTTY`, so `lipgloss.Complete` downsamples every entry of `DefaultColors` to `NoColor`. `EnableColors()` then assigns that already-empty palette, and nothing is painted. `CLICOLOR_FORCE` escapes this because `colorprofile.Detect` reads the variable itself and returns `ANSI` before the palette is built.

In the issue the suspicion was that this is termenv or lipgloss behaviour to wait on. Detection is what turns the colours off, but an explicit flag is meant to override detection, and lefthook never gives it the chance: the flag only flips `kind`, not the colour values. No upstream change is needed.

### Changes

- Extracted the palette into `colorsForProfile(profile)`.
- Added `forcedColors`, built with `max(profile, colorprofile.ANSI)`, and used it in `EnableColors()`. `ANSI` is what `colorprofile.Detect` resolves to for `CLICOLOR_FORCE=1` on a non-TTY, so the flag and the env var now behave the same, and a richer detected profile is still preserved.
- `auto`, `off`, and custom colours from config are unchanged.
- Added a test that paints with colours enabled and disabled. `go test` output is not a terminal, so it covers the reported condition directly. It fails on the current code and passes with the fix.
- Documented that `auto` needs a colour capable terminal while `on` forces colours even when the output is not a terminal.

Verified by building the binary and running `lefthook run pre-commit --colors on` under `CI=true TERM=dumb` with output piped: before the change the header prints bare, after it prints `\e[96m lefthook \e[m \e[90mv2.1.12\e[m`. `--colors off` still prints no escape codes. `go test -race ./...` and `go vet ./...` pass.

One related gap I left alone to keep this small: `--colors on` still does not export `CLICOLOR_FORCE` to the commands lefthook runs (only `NO_COLOR` is propagated, in the off direction), so a linter invoked by a hook still decides colours on its own. If you want that too, I will open a follow-up.
